### PR TITLE
Clarify GitHub auth setup instructions for feedback and "last updated"

### DIFF
--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -13,19 +13,19 @@ code: |
   recommended_api_config
   
   # GitHub
-  if not skip_github:
-    feedback_form_config
-    github_owners_list
-    save_repo_owners
-    if len(the_config['github issues']['allowed repository owners']) == 1:
-      set_default_owner_from_list
-    else:
-      github_owners_default
-    cofirm_github_info
+  feedback_form_config
+  github_owners_list
+  save_repo_owners
+  if len(the_config['github issues']['allowed repository owners']) == 1:
+    set_default_owner_from_list
+  else:
+    github_owners_default
+  auto_fill_leftover_github_values
+  cofirm_github_info
   
   menu_shortcut_config
   save_config
-  selected_mandatory_packages    
+  selected_mandatory_packages
   al_install_done
   end_screen
 ---
@@ -218,28 +218,18 @@ fields:
     hide if: skip_efile
     required: False
 ---
-id: github intro
-# TODO: Allow user to pick which of the two functionalities they want
-question: |
-  Feedback and "About" page information with GitHub
-subquestion: |
-  Assembly Line can use GitHub to let you:
-  
-  1. Get user feedback about each interview.
-  2. Display a "last updated" date on the "About" page of an interview.
-  
-  You can skip this setup step.
-fields:
-  - Skip setting up GitHub: skip_github
-    datatype: yesno
----
 # This must be tested with a private repository
 #  If your GitHub organization's repositories are private, the account must have permission to see it and file issues.
 id: github PAT
 continue button field: feedback_form_config
 question: |
-  GitHub authentication
+  Feedback and "About" page information with GitHub
 subquestion: |
+  Assembly Line uses GitHub to let you:
+  
+  1. Get user feedback about each interview.
+  2. Display a "last updated" date on the "About" page of an interview.
+
   First, in order to use GitHub you should create a dedicated GitHub account. You can use an account that already exists, but we recommend having an account that only handles Assembly Line functionality.
   
   The account must have permission make pull requests on your GitHub organization's repositories. You can read [GitHub's documentation about setting an account's permissions](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization).
@@ -298,42 +288,41 @@ fields:
       the_config['github issues'].get('allowed repository owners', [])
 ---
 code: |
+  # Password seems to be required by al_general.py
+  the_config['github issues']['password'] = the_config['github issues']['token']
   the_config['github readonly']['username'] = the_config['github issues']['username']
   the_config['github readonly']['token'] = the_config['github issues']['token']
+  the_config['github readonly']['password'] = the_config['github issues']['token']
+  auto_fill_leftover_github_values = True
 ---
 id: confirm github info
 continue button field: cofirm_github_info
 question: |
   Is this GitHub information correct?
 review:
-  - Edit: the_config['github issues']['username']
+  - Edit:
+      - the_config['github issues']['username']
+      - allowed_github_repo_owners
+      - the_config['github issues']['default repository owner']
     button: |
-      ##### Authentication
+      The personal access token values have been hidden here for better security.
       
-      Config setting | Value
-      :- | :-
-      `config['github issues']['username']` | ${ the_config['github issues']['username'] }
-      `config['github issues']['token']` | **\*\*\*${ the_config['github issues']['token'][-4:] }
-      `config['github readonly']['username']` | ${ the_config['github issues']['username'] }
-      `config['github readonly']['token']` | **\*\*\*${ the_config['github issues']['token'][-4:] }
-      
-      ---
-  - Edit: allowed_github_repo_owners
-    button: |
-      ##### List of allowed repository owners
-      
-      Config setting | Value
-      :- | :-
-      `config['github issues']['allowed repository owners']` | ${ the_config['github issues'].get('allowed repository owners', []) }
-      
-      ---
-  - Edit: the_config['github issues']['default repository owner']
-    button: |
-      ##### Default repository owner
-      
-      Config setting | Value
-      :- | :-
-      `config['github issues']['default repository owner']` | ${ the_config['github issues']['default repository owner'] }
+      <pre>
+      <code>
+      github issues:[BR]
+          username: ${ the_config['github issues']['username'] }[BR]
+          token: **\*\*\*${ the_config['github issues']['token'][-4:] }[BR]
+          allowed repository owners:[BR]
+          % for owner in the_config['github issues']['allowed repository owners']:
+          - ${ owner }[BR]
+          % endfor
+          default repository owner: ${ the_config['github issues']['default repository owner'] }[BR]
+      github readonly:[BR]
+          username: ${ the_config['github issues']['username'] }[BR]
+          token: **\*\*\*${ the_config['github issues']['token'][-4:] }
+      </code>
+      </pre>
+      [BR]
 ---
 id: shortcuts
 continue button field: menu_shortcut_config
@@ -370,7 +359,7 @@ data:
     help: |
       Feedback form used in the footer by default. This is a dependency of
       the "Core" package above that will always be installed, but you can
-      force an independent update here.      
+      force an independent update here. 
 ---
 variable name: optional_packages
 data:
@@ -423,7 +412,8 @@ code: |
   al_install_done = True
 ---
 question: |
-  What packages do you want to install or update?  
+  What packages do you want to install or update?
+continue button label: Install Assembly Line
 fields:
   - Core packages: selected_mandatory_packages
     datatype: checkboxes

--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -11,7 +11,18 @@ code: |
   welcome
   basic_server_config
   recommended_api_config
-  feedback_form_config
+  
+  # GitHub
+  if not skip_github:
+    feedback_form_config
+    github_owners_list
+    save_repo_owners
+    if len(the_config['github issues']['allowed repository owners']) == 1:
+      set_default_owner_from_list
+    else:
+      github_owners_default
+    cofirm_github_info
+  
   menu_shortcut_config
   save_config
   selected_mandatory_packages    
@@ -21,8 +32,17 @@ code: |
 code: |
   backup_file = da_get_config_as_file()
 ---
+depends on:
+  - allowed_github_repo_owners
 code: |
   the_config['github issues']['allowed repository owners'] = allowed_github_repo_owners.splitlines()
+  save_repo_owners = True
+---
+code: |
+  the_config['github issues']['default repository owner'] = the_config['github issues']['allowed repository owners'][0]
+  set_default_owner_from_list = True
+---
+code: |
   if add_weaver_shortcut and not 'docassemble.ALWeaver:data/questions/assembly_line.yml' in the_config.get('administrative interviews',[]):
     if not isinstance(the_config.get('administrative interviews'), list):
       the_config['administrative interviews'] = []
@@ -198,31 +218,122 @@ fields:
     hide if: skip_efile
     required: False
 ---
-id: feedback form config
+id: github intro
+# TODO: Allow user to pick which of the two functionalities they want
+question: |
+  Feedback and "About" page information with GitHub
+subquestion: |
+  Assembly Line can use GitHub to let you:
+  
+  1. Get user feedback about each interview.
+  2. Display a "last updated" date on the "About" page of an interview.
+  
+  You can skip this setup step.
+fields:
+  - Skip setting up GitHub: skip_github
+    datatype: yesno
+---
+# This must be tested with a private repository
+#  If your GitHub organization's repositories are private, the account must have permission to see it and file issues.
+id: github PAT
 continue button field: feedback_form_config
 question: |
-  GitHub feedback and about information
+  GitHub authentication
 subquestion: |
-  You should configure a dedicated GitHub account with permission to make
-  pull requests on public repositories and generate a private access token
-  for it.
+  First, in order to use GitHub you should create a dedicated GitHub account. You can use an account that already exists, but we recommend having an account that only handles Assembly Line functionality.
   
-  This feature is used to add feedback to production interviews as well
-  as to display a "last updated" date on the about page.
+  The account must have permission make pull requests on your GitHub organization's repositories. You can read [GitHub's documentation about setting an account's permissions](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization).
+  
+  Give us the information about that account and set up its permissions.
 fields:
+  - What is the username of the account: the_config['github issues']['username']
+    default: ${ the_config['github issues'].get('username', '') }
+    help: |
+      This will set the `config['github issues']['username']` and the `config['github readonly']['username']` values.
   - note: |
-      #### GitHub Feedback form
-  - Username: the_config['github issues']['username']
-  - Private token: the_config['github issues']['token']
-  - Default Github organization: the_config['github issues']['default repository owner']
-  - Allowed repository owners (one per line): allowed_github_repo_owners
+      Now you need to authorize your docassemble server to use that account to make issues. You can do that by creating a personal access token (PAT):
+
+      1. Follow directions to start making a personal access token (PAT) for the account on GitHub. You can find the directions in a section at [this GitHub documentation page](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+      1. Set the expiration date to "No expiration".
+      1. Tap the checkbox for “repo” permissions.
+      1. Finish creating the personal access token.
+      1. Copy the token and paste it below
+  - Personal access token: the_config['github issues']['token']
+    default: ${ the_config['github issues'].get('token', '') }
+    help: |
+      This will set the `config['github issues']['token']` and the `config['github readonly']['token']` values.
+---
+id: github owners list
+continue button field: github_owners_list
+question: |
+  Avoid GitHub issue spamming
+subquestion: |
+  To make sure that no one can use the feedback forms to spam just any GitHub repository with issues, you must limit which repositories your feedback forms can access. You can do this by limiting your issues to repositories owned by specific users or organizations.
+      
+  An interview can name its own repository's owner, but you must make sure that the owner is an owner that you have approved.
+      
+  Here, list the usernames of all the GitHub users or organizations who own repositories where you will allow users make issues.
+  
+  This will set the `config['github issues']['allowed repository owners']` value.
+  
+  You can just list one if you want.
+fields:
+  - Usernames[BR](one per line): allowed_github_repo_owners
     datatype: area
     default: |
       ${ "\n".join(the_config['github issues'].get('allowed repository owners',[])) }
-  - note: |
-      #### GitHub account for reading last updated time
-  - Username: the_config['github readonly']['username']
-  - Private token: the_config['github readonly']['username']
+---
+id: github owners default
+continue button field: github_owners_default
+question: |
+  Default GitHub repository owner
+subquestion: |
+  Finally, you can also choose a default repository owner so that interviews don't have to each list their own. Pick one of the usernames to be the default repository owner.
+  
+  This will set the `config['github issues']['default repository owner']` value.
+fields:
+  - Default account name: the_config['github issues']['default repository owner']
+    input type: radio
+    code: |
+      the_config['github issues'].get('allowed repository owners', [])
+---
+code: |
+  the_config['github readonly']['username'] = the_config['github issues']['username']
+  the_config['github readonly']['token'] = the_config['github issues']['token']
+---
+id: confirm github info
+continue button field: cofirm_github_info
+question: |
+  Is this GitHub information correct?
+review:
+  - Edit: the_config['github issues']['username']
+    button: |
+      ##### Authentication
+      
+      Config setting | Value
+      :- | :-
+      `config['github issues']['username']` | ${ the_config['github issues']['username'] }
+      `config['github issues']['token']` | **\*\*\*${ the_config['github issues']['token'][-4:] }
+      `config['github readonly']['username']` | ${ the_config['github issues']['username'] }
+      `config['github readonly']['token']` | **\*\*\*${ the_config['github issues']['token'][-4:] }
+      
+      ---
+  - Edit: allowed_github_repo_owners
+    button: |
+      ##### List of allowed repository owners
+      
+      Config setting | Value
+      :- | :-
+      `config['github issues']['allowed repository owners']` | ${ the_config['github issues'].get('allowed repository owners', []) }
+      
+      ---
+  - Edit: the_config['github issues']['default repository owner']
+    button: |
+      ##### Default repository owner
+      
+      Config setting | Value
+      :- | :-
+      `config['github issues']['default repository owner']` | ${ the_config['github issues']['default repository owner'] }
 ---
 id: shortcuts
 continue button field: menu_shortcut_config

--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -20,7 +20,6 @@ code: |
     set_default_owner_from_list
   else:
     github_owners_default
-  auto_fill_leftover_github_values
   
   menu_shortcut_config
   save_config
@@ -98,9 +97,7 @@ code: |
     the_config['voicerss'] = {}
   if not the_config.get('github issues'):
     the_config['github issues'] = {}
-  if not the_config.get('github readonly'):
-    the_config['github readonly'] = {}   
-    the_config['github readonly']['type'] = 'basic' # This just is for DA compatibility and should always be left this way    
+    the_config['github issues']['type'] = 'basic' # This just is for DA compatibility and should always be left this way    
 ---
 id: configuration questions
 continue button field: basic_server_config
@@ -275,14 +272,6 @@ fields:
     input type: radio
     code: |
       the_config['github issues'].get('allowed repository owners', [])
----
-code: |
-  # Password seems to be required by al_general.py
-  the_config['github issues']['password'] = the_config['github issues']['token']
-  the_config['github readonly']['username'] = the_config['github issues']['username']
-  the_config['github readonly']['token'] = the_config['github issues']['token']
-  the_config['github readonly']['password'] = the_config['github issues']['token']
-  auto_fill_leftover_github_values = True
 ---
 id: shortcuts
 continue button field: menu_shortcut_config

--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -21,7 +21,6 @@ code: |
   else:
     github_owners_default
   auto_fill_leftover_github_values
-  cofirm_github_info
   
   menu_shortcut_config
   save_config
@@ -227,46 +226,38 @@ question: |
 subquestion: |
   Assembly Line uses GitHub to let you:
   
-  1. Get user feedback about each interview.
+  1. Let users give feedback about an interview.
   2. Display a "last updated" date on the "About" page of an interview.
 
   First, in order to use GitHub you should create a dedicated GitHub account. You can use an account that already exists, but we recommend having an account that only handles Assembly Line functionality.
   
-  The account must have permission make pull requests on your GitHub organization's repositories. You can read [GitHub's documentation about setting an account's permissions](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization).
+  The account must have permission to edit your GitHub organization's repositories. You can read [GitHub's documentation about setting an account's permissions](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization).
   
   Give us the information about that account and set up its permissions.
 fields:
   - What is the username of the account: the_config['github issues']['username']
     default: ${ the_config['github issues'].get('username', '') }
-    help: |
-      This will set the `config['github issues']['username']` and the `config['github readonly']['username']` values.
   - note: |
       Now you need to authorize your docassemble server to use that account to make issues. You can do that by creating a personal access token (PAT):
-
-      1. Follow directions to start making a personal access token (PAT) for the account on GitHub. You can find the directions in a section at [this GitHub documentation page](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
-      1. Set the expiration date to "No expiration".
-      1. Tap the checkbox for “repo” permissions.
+      
+      1. Follow [these directions to make a personal access token (PAT) for the account](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token) on GitHub, stopping at the "expiration" section.
+          1. Set the expiration date to "No expiration".
+          1. Tap the checkbox for "repo" permissions.
       1. Finish creating the personal access token.
       1. Copy the token and paste it below
   - Personal access token: the_config['github issues']['token']
     default: ${ the_config['github issues'].get('token', '') }
-    help: |
-      This will set the `config['github issues']['token']` and the `config['github readonly']['token']` values.
 ---
 id: github owners list
 continue button field: github_owners_list
 question: |
   Avoid GitHub issue spamming
 subquestion: |
-  To make sure that no one can use the feedback forms to spam just any GitHub repository with issues, you must limit which repositories your feedback forms can access. You can do this by limiting your issues to repositories owned by specific users or organizations.
-      
-  An interview can name its own repository's owner, but you must make sure that the owner is an owner that you have approved.
+  To make sure that no one uses the feedback forms to spam just any GitHub repository with issues, you can limit your feedback forms to only make issues to repositories owned by specific users or organizations.
       
   Here, list the usernames of all the GitHub users or organizations who own repositories where you will allow users make issues.
   
-  This will set the `config['github issues']['allowed repository owners']` value.
-  
-  You can just list one if you want.
+  You can list just one if you want.
 fields:
   - Usernames[BR](one per line): allowed_github_repo_owners
     datatype: area
@@ -279,8 +270,6 @@ question: |
   Default GitHub repository owner
 subquestion: |
   Finally, you can also choose a default repository owner so that interviews don't have to each list their own. Pick one of the usernames to be the default repository owner.
-  
-  This will set the `config['github issues']['default repository owner']` value.
 fields:
   - Default account name: the_config['github issues']['default repository owner']
     input type: radio
@@ -294,35 +283,6 @@ code: |
   the_config['github readonly']['token'] = the_config['github issues']['token']
   the_config['github readonly']['password'] = the_config['github issues']['token']
   auto_fill_leftover_github_values = True
----
-id: confirm github info
-continue button field: cofirm_github_info
-question: |
-  Is this GitHub information correct?
-review:
-  - Edit:
-      - the_config['github issues']['username']
-      - allowed_github_repo_owners
-      - the_config['github issues']['default repository owner']
-    button: |
-      The personal access token values have been hidden here for better security.
-      
-      <pre>
-      <code>
-      github issues:[BR]
-          username: ${ the_config['github issues']['username'] }[BR]
-          token: **\*\*\*${ the_config['github issues']['token'][-4:] }[BR]
-          allowed repository owners:[BR]
-          % for owner in the_config['github issues']['allowed repository owners']:
-          - ${ owner }[BR]
-          % endfor
-          default repository owner: ${ the_config['github issues']['default repository owner'] }[BR]
-      github readonly:[BR]
-          username: ${ the_config['github issues']['username'] }[BR]
-          token: **\*\*\*${ the_config['github issues']['token'][-4:] }
-      </code>
-      </pre>
-      [BR]
 ---
 id: shortcuts
 continue button field: menu_shortcut_config
@@ -435,5 +395,4 @@ question: |
   Installation complete
 subquestion: |
   Check the status in the [Package management page](/updatepackage)
-  
   

--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -96,8 +96,7 @@ code: |
   if not the_config.get('voicerss'):
     the_config['voicerss'] = {}
   if not the_config.get('github issues'):
-    the_config['github issues'] = {}
-    the_config['github issues']['type'] = 'basic' # This just is for DA compatibility and should always be left this way    
+    the_config['github issues'] = {} 
 ---
 id: configuration questions
 continue button field: basic_server_config


### PR DESCRIPTION
This is just a rough first experiment. There are some fairly big changes.

First of all, I should note that the installation interview sets github "token" not "password" and al_general.py asks for "password". Regardless of merging this in, that needs to be fixed either in here, similar to what I've done, or in al_general.py. I kept "token" around because I'm not sure if something else uses "token".

1. This is a fairly big UX departure from the previous version. Let me know if you want to try to revert a bit - keep it all on the same page or other such constraints. This change makes it a departure from the flow of the rest of the interview. The biggest departure being an in-flow review screen for just the GitHub details.

2. I also changed how token input is being taken and used, but I can change it back if needed. I couldn't figure out why the "issues" username and token were separate from the "readonly" username and token. Do we want the installer to create a separate github account for each of those? What are the permission levels for each of those tokens?

I _think_ the read-only permissions are the "repo:status" permissions, but I'm not sure. I'm also not sure what permission level would allow only issue filing. Either way, it looks like [a private repo might require full "repo" level permissions](https://stackoverflow.com/a/58721249/14144258). If so, that would require at least one more question for the installer to answer, so for now I've combined them and instructed installers to set "repo" permission levels. I don't quite have bandwidth to test the permutations.

Separately, I tried to make the github tools optional, but I don't think it'll work with the styled package without some changes to AssemblyLine, so I gave up on that. In the GitHubFeedback package, the values currently default to Suffolk LIT Lab and we probably want to override those no matter what. Once we've worked on AL to allow it to only offer the feedback form under certain circumstances, we can make it optional in here too pretty easily.

Closes #41.

<!-- 
1. I made the GitHub info optional. This seems to work for the unstyled package. The styled package is more complicated. It ends up using suffolk's info In al_general.py there's no fallback for `get_config("github readonly")`, even though the function description says it'll fallback to anonymous authentication. 
 

4. For the styled package, we'd need to change AL al_general.py to not require `username` and such, but I _think_ not much else would have to be done. From the way variables were set in this package and from the code I looked at in other packages, allowed owners could be an empty list, default owners could be non-existent, and the "last updated" fetch could fail without a problem. I'm not exactly clear on how I can go back and forth testing that with these different packages.
-->