### PR TITLE
Update and install packages without requiring an API key

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -38,6 +38,7 @@ __all__ = [
     "da_write_config",
     "ALPackageInstaller",
     "get_package_info",
+    "install_from_pypi",
 ]
 
 

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -1,120 +1,155 @@
 from docassemble.webapp.users.models import UserModel
 from docassemble.webapp.db_object import init_sqlalchemy
 from github import Github  # PyGithub
+
 # db is a SQLAlchemy Engine
 from sqlalchemy.sql import text
 from typing import List, Tuple, Dict
 import docassemble.webapp.worker
-from docassemble.webapp.server import user_can_edit_package, get_master_branch, install_git_package, redirect, should_run_create, flash, url_for, restart_all
+from docassemble.webapp.server import (
+    user_can_edit_package,
+    get_master_branch,
+    install_git_package,
+    redirect,
+    should_run_create,
+    flash,
+    url_for,
+    restart_all,
+    install_pip_package,
+    get_package_info,
+)
 from docassemble.base.config import daconfig
 from docassemble.webapp.backend import cloud
-from docassemble.base.util import log, DAFile, DAObject, DAList
+from docassemble.base.util import log, DAFile, DAObject, DAList, word
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 import re
 
 db = init_sqlalchemy()
 
-__all__ = ['install_from_github_url',
-           'reset',
-           'speedy_get_users',
-           'speedy_get_sessions', 
-           'get_users_and_name',
-           'da_get_config',
-           'da_get_config_as_file',
-           'da_write_config',
-           'ALPackageInstaller'
-          ]
+__all__ = [
+    "install_from_github_url",
+    "reset",
+    "speedy_get_users",
+    "speedy_get_sessions",
+    "get_users_and_name",
+    "da_get_config",
+    "da_get_config_as_file",
+    "da_write_config",
+    "ALPackageInstaller",
+    "get_package_info",
+]
 
-def install_from_github_url(url:str, branch=""):
-  giturl = url.strip().rstrip('/')
-  if isinstance(branch, str):
-    branch = branch.strip()
-  if not branch:
-    branch = get_master_branch(giturl)
-  packagename = re.sub(r'/*$', '', giturl)
-  packagename = re.sub(r'^git+', '', packagename)
-  packagename = re.sub(r'#.*', '', packagename)
-  packagename = re.sub(r'\.git$', '', packagename)
-  packagename = re.sub(r'.*/', '', packagename)
-  packagename = re.sub(r'^docassemble-', 'docassemble.', packagename)
-  if user_can_edit_package(giturl=giturl) and user_can_edit_package(pkgname=packagename):
-      install_git_package(packagename, giturl, branch)
-  else:
-      flash(word("You do not have permission to install this package."), 'error')
-  return packagename
-  
+
+def install_from_github_url(url: str, branch: str = ""):
+    giturl = url.strip().rstrip("/")
+    if isinstance(branch, str):
+        branch = branch.strip()
+    if not branch:
+        branch = get_master_branch(giturl)
+    packagename = re.sub(r"/*$", "", giturl)
+    packagename = re.sub(r"^git+", "", packagename)
+    packagename = re.sub(r"#.*", "", packagename)
+    packagename = re.sub(r"\.git$", "", packagename)
+    packagename = re.sub(r".*/", "", packagename)
+    packagename = re.sub(r"^docassemble-", "docassemble.", packagename)
+    if user_can_edit_package(giturl=giturl) and user_can_edit_package(
+        pkgname=packagename
+    ):
+        install_git_package(packagename, giturl, branch)
+    else:
+        flash(word("You do not have permission to install this package."), "error")
+    return packagename
+
+
+def install_from_pypi(packagename: str):
+    return install_pip_package(packagename)
+
+
 def reset(packagename=""):
-  result = docassemble.webapp.worker.update_packages.apply_async(link=docassemble.webapp.worker.reset_server.s(run_create=should_run_create(packagename)))
-  return redirect(url_for('update_package_wait'))
+    result = docassemble.webapp.worker.update_packages.apply_async(
+        link=docassemble.webapp.worker.reset_server.s(
+            run_create=should_run_create(packagename)
+        )
+    )
+    return redirect(url_for("update_package_wait"))
+
 
 def da_get_config_as_file():
-  yaml = YAML()
-  yaml.allow_duplicate_keys = True  
-  #try:
-  with open(daconfig['config file'], 'r', encoding='utf-8') as fp:
-    content = fp.read()
-  
-  the_file = DAFile()
-  the_file.initialize(filename="config.yml")
-  the_file.write(content)
-  return the_file
+    yaml = YAML()
+    yaml.allow_duplicate_keys = True
+    # try:
+    with open(daconfig["config file"], "r", encoding="utf-8") as fp:
+        content = fp.read()
+
+    the_file = DAFile()
+    the_file.initialize(filename="config.yml")
+    the_file.write(content)
+    return the_file
+
 
 def da_get_config():
-  yaml = YAML()
-  yaml.allow_duplicate_keys = True  
-  #try:
-  with open(daconfig['config file'], 'r', encoding='utf-8') as fp:
-    content = fp.read()
-  data = yaml.load(content)
-  return data
-  #except:
-  #  return None
-      
-def da_write_config(data:Dict):
-  yaml = YAML()
-  yaml.allow_duplicate_keys = True  
-  try:
-    # ruamel.yaml has a big rant about why we shouldn't save the YAML output to a string,
-    # but it's done upstream here so we will use the provided workaround 
-    # see https://yaml.readthedocs.io/en/latest/example.html?highlight=StringIO#output-of-dump-as-a-string
-    stream = StringIO()
-    yaml.dump(data, stream)
-    yaml_data = stream.getvalue()
-  except:
-    log("Invalid configuration provided to da_write_config, skipping.")
-    return None
-  if cloud is not None:
-      key = cloud.get_key('config.yml')
-      key.set_contents_from_string(yaml_data)
-  with open(daconfig['config file'], 'w', encoding='utf-8') as fp:
-      fp.write(yaml_data)
-  restart_all()  
+    yaml = YAML()
+    yaml.allow_duplicate_keys = True
+    # try:
+    with open(daconfig["config file"], "r", encoding="utf-8") as fp:
+        content = fp.read()
+    data = yaml.load(content)
+    return data
+    # except:
+    #  return None
 
-def speedy_get_users()->List[Tuple[int, str]]:
-  """
-  Return a list of all users in the database. Possibly faster than get_user_list().
-  """
-  the_users = UserModel.query.with_entities(UserModel.id, UserModel.email).all()
-  
-  return [tuple(user) for user in the_users]
 
-def get_users_and_name()->List[Tuple[int, str, str]]:
-  users = UserModel.query.with_entities(UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name)
-  
-  return users
+def da_write_config(data: Dict):
+    yaml = YAML()
+    yaml.allow_duplicate_keys = True
+    try:
+        # ruamel.yaml has a big rant about why we shouldn't save the YAML output to a string,
+        # but it's done upstream here so we will use the provided workaround
+        # see https://yaml.readthedocs.io/en/latest/example.html?highlight=StringIO#output-of-dump-as-a-string
+        stream = StringIO()
+        yaml.dump(data, stream)
+        yaml_data = stream.getvalue()
+    except:
+        log("Invalid configuration provided to da_write_config, skipping.")
+        return None
+    if cloud is not None:
+        key = cloud.get_key("config.yml")
+        key.set_contents_from_string(yaml_data)
+    with open(daconfig["config file"], "w", encoding="utf-8") as fp:
+        fp.write(yaml_data)
+    restart_all()
 
-def speedy_get_sessions(user_id:int=None, filename:str=None)->List[Tuple]:
-  """
-  Return a lsit of the most recent 500 sessions, optionally tied to a specific user ID.
-  
-  Each session is a tuple with named columns:
-  filename,
-  user_id,
-  modtime,
-  key
-  """
-  get_sessions_query = text("""
+
+def speedy_get_users() -> List[Tuple[int, str]]:
+    """
+    Return a list of all users in the database. Possibly faster than get_user_list().
+    """
+    the_users = UserModel.query.with_entities(UserModel.id, UserModel.email).all()
+
+    return [tuple(user) for user in the_users]
+
+
+def get_users_and_name() -> List[Tuple[int, str, str]]:
+    users = UserModel.query.with_entities(
+        UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name
+    )
+
+    return users
+
+
+def speedy_get_sessions(user_id: int = None, filename: str = None) -> List[Tuple]:
+    """
+    Return a lsit of the most recent 500 sessions, optionally tied to a specific user ID.
+
+    Each session is a tuple with named columns:
+    filename,
+    user_id,
+    modtime,
+    key
+    """
+    get_sessions_query = text(
+        """
   SELECT  userdict.filename as filename
          ,num_keys
          ,userdictkeys.user_id as user_id
@@ -136,28 +171,30 @@ def speedy_get_sessions(user_id:int=None, filename:str=None)->List[Tuple]:
   (userdict.filename = :filename OR :filename is null)
   ORDER BY modtime desc 
   LIMIT 500;
-  """)
-  if not filename:
-    filename = None # Explicitly treat empty string as equivalent to None
-  if not user_id: # TODO: verify that 0 is not a valid value for user ID
-    user_id = None
-  
-  with db.connect() as con:
-    rs = con.execute(get_sessions_query, user_id=user_id, filename=filename)
-  sessions = []
-  for session in rs:
-    sessions.append(session)
-  
-  return sessions
+  """
+    )
+    if not filename:
+        filename = None  # Explicitly treat empty string as equivalent to None
+    if not user_id:  # TODO: verify that 0 is not a valid value for user ID
+        user_id = None
+
+    with db.connect() as con:
+        rs = con.execute(get_sessions_query, user_id=user_id, filename=filename)
+    sessions = []
+    for session in rs:
+        sessions.append(session)
+
+    return sessions
 
 
 class ALPackageInstaller(DAObject):
     """Methods and state for installing AssemblyLine."""
-    def init( self, *pargs, **kwargs ):
-        super().init(*pargs, **kwargs)
-        self.initializeAttribute('errors', ErrorList)
 
-    def get_validated_github_username(self, access_token: str ):
+    def init(self, *pargs, **kwargs):
+        super().init(*pargs, **kwargs)
+        self.initializeAttribute("errors", ErrorList)
+
+    def get_validated_github_username(self, access_token: str):
         """
         Given a valid GitHub `access_token`, returns the username associated with it.
         Otherwise, adds one or more errors to the installer.
@@ -167,21 +204,24 @@ class ALPackageInstaller(DAObject):
         github_user = github.get_user()
         try:
             # Ensure the token has the right permissions
-            scopes = github_user.raw_headers['x-oauth-scopes'].split(', ')
-            if not 'repo' in scopes and not 'public_repo' in scopes:
-                self.errors.appendObject(template_name='github_permissions_error', scopes=scopes)
+            scopes = github_user.raw_headers["x-oauth-scopes"].split(", ")
+            if not "repo" in scopes and not "public_repo" in scopes:
+                self.errors.appendObject(
+                    template_name="github_permissions_error", scopes=scopes
+                )
                 return None
             else:
                 return github_user.login
         except Exception as error:
             # GitHub doesn't recognize the token
             # github.GithubException.BadCredentialsException (401, 403) (specific exception not working)
-            self.errors.appendObject(template_name='github_credentials_error')
+            self.errors.appendObject(template_name="github_credentials_error")
 
 
 class ErrorList(DAList):
     """Contains `ErrorLikeObject`s so they can be recognized by docassemble."""
-    def init( self, *pargs, **kwargs ):
+
+    def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.object_type = ErrorLikeObject
         self.gathered = True
@@ -193,10 +233,11 @@ class ErrorLikeObject(DAObject):
     show its error. It can contain any other attributes so its template can access them
     as needed. DAObject doesn't seem to be enough to allow template definition.
     """
-    def init( self, *pargs, **kwargs ):
+
+    def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         # `unknown_error` can be a default template for unexpected errors to use
-        self.template_name = kwargs.get('template_name', 'unknown_error')
+        self.template_name = kwargs.get("template_name", "unknown_error")
 
 
 #  select userdict.filename, num_keys, userdictkeys.user_id, modtime, userdict.key from userdict natural join (select key, max(modtime) as modtime, count(key) as num_keys from userdict group by key) mostrecent left join userdictkeys on userdictkeys.key = userdict.key order by modtime desc;
@@ -204,4 +245,4 @@ class ErrorLikeObject(DAObject):
 
 # From server.py
 #  subq = db.session.query(db.func.max(UserDict.indexno).label('indexno'), UserDict.filename, UserDict.key).group_by(UserDict.filename, UserDict.key).subquery()
-#  interview_query = db.session.query(UserDictKeys.user_id, UserDictKeys.temp_user_id, UserDictKeys.filename, UserDictKeys.key, UserDict.dictionary, UserDict.encrypted, UserModel.email).join(subq, and_(subq.c.filename == UserDictKeys.filename, subq.c.key == UserDictKeys.key)).join(UserDict, and_(UserDict.indexno == subq.c.indexno, UserDict.key == UserDictKeys.key, UserDict.filename == UserDictKeys.filename)).join(UserModel, UserModel.id == UserDictKeys.user_id).filter(UserDictKeys.user_id == user_id, UserDictKeys.filename == filename, UserDictKeys.key == session).group_by(UserModel.email, UserDictKeys.user_id, UserDictKeys.temp_user_id, UserDictKeys.filename, UserDictKeys.key, UserDict.dictionary, UserDict.encrypted, UserDictKeys.indexno).order_by(UserDictKeys.indexno) 
+#  interview_query = db.session.query(UserDictKeys.user_id, UserDictKeys.temp_user_id, UserDictKeys.filename, UserDictKeys.key, UserDict.dictionary, UserDict.encrypted, UserModel.email).join(subq, and_(subq.c.filename == UserDictKeys.filename, subq.c.key == UserDictKeys.key)).join(UserDict, and_(UserDict.indexno == subq.c.indexno, UserDict.key == UserDictKeys.key, UserDict.filename == UserDictKeys.filename)).join(UserModel, UserModel.id == UserDictKeys.user_id).filter(UserDictKeys.user_id == user_id, UserDictKeys.filename == filename, UserDictKeys.key == session).group_by(UserModel.email, UserDictKeys.user_id, UserDictKeys.temp_user_id, UserDictKeys.filename, UserDictKeys.key, UserDict.dictionary, UserDict.encrypted, UserDictKeys.indexno).order_by(UserDictKeys.indexno)

--- a/docassemble/ALDashboard/data/questions/install_packages.yml
+++ b/docassemble/ALDashboard/data/questions/install_packages.yml
@@ -6,6 +6,9 @@ metadata:
     - developer
   temporary session: True
 ---
+modules:
+  - .aldashboard
+---
 objects:
   - packages: DAList.using(object_type=DAObject, there_are_any=True, complete_attribute="github_url")
 ---
@@ -33,17 +36,11 @@ code: |
 ---
 event: install_packages_event
 code: |
+  background_error_action("bg_failure")
   for package in packages:
     pkgname = install_from_github_url(package.github_url)
-    reset(pkgname)  
-  background_response()
----  
-event: waiting_screen
-question: |
-  Wait here while we start the installation process
-reload: True  
----
-code: |
+    reset(pkgname)
+
   the_config = da_get_config()
   if not the_config.get("dispatch"):
     the_config["dispatch"] = {}
@@ -52,14 +49,31 @@ code: |
       match = re.search(package_regex, package.github_url)
       if match:
         package_path = f"docassemble.{ match.groups()[0] }:data/questions/{ package.yaml_name }"
-        the_config[package.alias] = package_path
+        the_config["dispatch"][package.alias] = package_path
   results = da_write_config(the_config)
-  update_config = True
+
+  background_response_action("bg_success")
+---
+event: bg_success
+code: |
+  it_worked = True
+  background_response()
+---  
+event: waiting_screen
+question: |
+  Wait here while we start the installation process
+reload: True
+---
+event: bg_failure
+code: |
+  it_worked = False
+  background_response()
 ---
 event: ending_screen
 question: |
   All done
 subquestion: |
+  % if it_worked:
   It may take a few minutes for the installation process to complete.
 
   You can now use these links to reach your interviews:
@@ -67,5 +81,8 @@ subquestion: |
   % for package in packages:
   * [${package.alias}](/start/${package.alias})
   % endfor
+  % else:
+  Something went wrong. Check the [worker.log](/logs?file=worker.log) to learn what.
+  % endif
 buttons:
   - Restart: restart

--- a/docassemble/ALDashboard/data/questions/install_packages.yml
+++ b/docassemble/ALDashboard/data/questions/install_packages.yml
@@ -7,37 +7,16 @@ metadata:
   temporary session: True
 ---
 objects:
-  - daREST: DAWeb.using(base_url=get_config('url root',"https://" + get_config('external hostname',"")) + "/api" )
   - packages: DAList.using(object_type=DAObject, there_are_any=True, complete_attribute="github_url")
----
-code: |
-  install_packages_api_key = get_config('install packages api key')
 ---
 mandatory: True
 id: interview order
 code: |
-  if not install_packages_api_key:
-    exit_no_api_key
   packages.gather()
   if install_packages_task.ready():
     ending_screen
   else:
     waiting_screen
----
-event: exit_no_api_key
-question: |
-  Please add an API key!
-subquestion: |
-  This interview requires an API key to work.
-  
-  You can create an API key by going to your profile. Please
-  create an API key with either IP restrictions or no restrictions.
-  
-  Then add it to the [configuration file](${ url_of('config') }) like this:
-  
-  ```
-  install packages api key: x7123aG...
-  ```
 ---
 question: |
   What packages do you want to install?
@@ -46,6 +25,8 @@ fields:
   - Github URL: packages[i].github_url
   - YAML filename: packages[i].yaml_name
   - Short name or alias (no spaces): packages[i].alias
+    validate: |
+      lambda y: y.isidentifier()
 ---
 code: |
   install_packages_task = background_action('install_packages_event')
@@ -53,50 +34,38 @@ code: |
 event: install_packages_event
 code: |
   for package in packages:
-    data = {"key": install_packages_api_key,
-            "github_url": package.github_url
-            }
-    # This won't persist after backround task completes
-    package.status = daREST.post("package",data=data)
+    pkgname = install_from_github_url(package.github_url)
+    reset(pkgname)  
   background_response()
 ---  
 event: waiting_screen
 question: |
-  Wait here
+  Wait here while we start the installation process
 reload: True  
 ---
 code: |
-  dispatch_temp = ""
+  the_config = da_get_config()
+  if not the_config.get("dispatch"):
+    the_config["dispatch"] = {}
   for package in packages:
-    package_regex = r"https:\/\/github\.com\/.*\/docassemble-([\w]*)"
-    match = re.search(package_regex, package.github_url)
-    if match:
-      dispatch_temp += '  "' + package.alias + '": '  
-      package_name = "docassemble." + match.groups()[0]
-      dispatch_temp += '"' + package_name + ':data/questions/' + package.yaml_name + '"'
-      dispatch_temp += "\n"
-  dispatch_directive = dispatch_temp
-  del dispatch_temp
-  del match
+      package_regex = r"https:\/\/github\.com\/.*\/docassemble-([\w]*)"
+      match = re.search(package_regex, package.github_url)
+      if match:
+        package_path = f"docassemble.{ match.groups()[0] }:data/questions/{ package.yaml_name }"
+        the_config[package.alias] = package_path
+  results = da_write_config(the_config)
+  update_config = True
 ---
 event: ending_screen
 question: |
   All done
 subquestion: |
-  Copy the dispatch directive below into the right place in the 
-  configuration file.
+  It may take a few minutes for the installation process to complete.
+
+  You can now use these links to reach your interviews:
   
-  
-  ${ indent(dispatch_directive) }
-  
-  
-  IOnce you install the dispatch directive, you can use these
-  links to reach your interviews:
-  
-  Alias | Link
-  ------|--------
   % for package in packages:
-  ${ package.alias } | [${package.alias}](/start/${package.alias})
+  * [${package.alias}](/start/${package.alias})
   % endfor
 buttons:
   - Restart: restart

--- a/docassemble/ALDashboard/data/questions/update_packages.yml
+++ b/docassemble/ALDashboard/data/questions/update_packages.yml
@@ -17,7 +17,7 @@ objects:
   - packages: DAList.using(object_type=DAObject, there_are_any=True, complete_attribute="package_name")
 ---
 code: |
-  installed_packages = get_package_info(exclude_core=True)
+  installed_packages = get_package_info()
 ---
 mandatory: True
 id: interview order
@@ -50,7 +50,7 @@ code: |
 ---
 event: install_packages_event
 code: |
-  for package in installed_packages:
+  for package in installed_packages[0]:
     if package.package.name in packages.true_values():
       if package.package.type and package.package.type == "git":
         install_from_github_url(package.package.giturl)

--- a/docassemble/ALDashboard/data/questions/update_packages.yml
+++ b/docassemble/ALDashboard/data/questions/update_packages.yml
@@ -2,6 +2,9 @@
 include:
   - nav.yml
 ---
+modules:
+  - .aldashboard  
+---
 metadata:
   title: Bulk Package Update
   sessions are unique: True
@@ -11,40 +14,19 @@ metadata:
   temporary session: True
 ---
 objects:
-  - daREST: DAWeb.using(base_url=get_config('url root',"https://" + get_config('external hostname',"")) + "/api" )
   - packages: DAList.using(object_type=DAObject, there_are_any=True, complete_attribute="package_name")
 ---
 code: |
-  installed_packages = daREST.get('package',{"key": install_packages_api_key })
----
-code: |
-  install_packages_api_key = get_config('install packages api key')
+  installed_packages = get_package_info(exclude_core=True)
 ---
 mandatory: True
 id: interview order
 code: |
-  if not install_packages_api_key:
-    exit_no_api_key
   packages.gather()
   if install_packages_task.ready():
     ending_screen
   else:
     waiting_screen
----
-event: exit_no_api_key
-question: |
-  Please add an API key!
-subquestion: |
-  This interview requires an API key to work.
-  
-  You can create an API key by going to your profile. Please
-  create an API key with either IP restrictions or no restrictions.
-  
-  Then add it to the [configuration file](${ url_of('config') }) like this:
-  
-  ```
-  install packages api key: x7123aG...
-  ```
 ---
 question: |
   What packages do you want to update?
@@ -53,19 +35,27 @@ fields:
     required: False
     datatype: checkboxes
     code: |
-      [[package.get('name'),f"{package.get('name','')} ({package.get('version')})",True] for package in installed_packages if 'docassemble.' in package.get('name') and package.get('name') not in ['docassemble.demo','docassemble.webapp','docassemble.base']]
+      [
+        package.package.name
+        for package in installed_packages[0]
+        if (
+          package.package.name.startswith("docassemble")
+          and package.can_update
+          and package.package.name not in ["docassemble", "docassemble-backports", "docassemble.webapp", "docassemble-textstat", "docassemblekvsession"]
+        )
+      ]
 ---
 code: |
   install_packages_task = background_action('install_packages_event')
 ---
 event: install_packages_event
 code: |
-  for package in packages:
-    data = {"key": install_packages_api_key,
-            "update": package
-            }
-    # This won't persist after backround task completes
-    package.status = daREST.post("package",data=data)
+  for package in installed_packages:
+    if package.package.name in packages.true_values():
+      if package.package.type and package.package.type == "git":
+        install_from_github_url(package.package.giturl)
+      elif package.package.type and package.package.type == "pip":
+        install_from_pypi(package.package.name)
   background_response()
 ---  
 event: waiting_screen

--- a/docassemble/ALDashboard/data/questions/update_packages.yml
+++ b/docassemble/ALDashboard/data/questions/update_packages.yml
@@ -53,18 +53,22 @@ code: |
   for package in installed_packages[0]:
     if package.package.name in packages.true_values():
       if package.package.type and package.package.type == "git":
-        install_from_github_url(package.package.giturl)
+        pkgname = install_from_github_url(package.package.giturl)
+        reset(pkgname)
       elif package.package.type and package.package.type == "pip":
         install_from_pypi(package.package.name)
   background_response()
 ---  
 event: waiting_screen
 question: |
-  Wait here
+  Wait here while we start installing packages
 reload: True
 ---
 event: ending_screen
 question: |
-  All done
+  Your packages are installing
+subquestion: |
+  Check the log file to monitor progress. It may still take a few more minutes
+  for the installation process to complete.
 buttons:
   - Restart: restart

--- a/docassemble/ALDashboard/data/questions/update_packages.yml
+++ b/docassemble/ALDashboard/data/questions/update_packages.yml
@@ -50,6 +50,7 @@ code: |
 ---
 event: install_packages_event
 code: |
+  background_error_action("bg_failure")
   for package in installed_packages[0]:
     if package.package.name in packages.true_values():
       if package.package.type and package.package.type == "git":
@@ -57,18 +58,32 @@ code: |
         reset(pkgname)
       elif package.package.type and package.package.type == "pip":
         install_from_pypi(package.package.name)
+  background_response_action("bg_success")
+---
+event: bg_success
+code: |
+  it_worked = True
   background_response()
 ---  
 event: waiting_screen
 question: |
-  Wait here while we start installing packages
+  Wait here while we start the installation process
 reload: True
+---
+event: bg_failure
+code: |
+  it_worked = False
+  background_response()
 ---
 event: ending_screen
 question: |
   Your packages are installing
 subquestion: |
+  % if it_worked:
   Check the log file to monitor progress. It may still take a few more minutes
   for the installation process to complete.
+  % else:
+  Something went wrong. Check the [worker.log](/logs?file=worker.log) to learn what.
+  % endif
 buttons:
   - Restart: restart


### PR DESCRIPTION
Remove dependency on API key for package install and update dashboards.
Also--add the dispatch directives to the config instead of making author copy and paste.

Fix #58 
Fix #34 