### PR TITLE
Handle more unusual fields | code usage

### DIFF
--- a/docassemble/ALDashboard/data/questions/review_screen_generator.yml
+++ b/docassemble/ALDashboard/data/questions/review_screen_generator.yml
@@ -52,8 +52,11 @@ code: |
       if 'fields' in doc:
         for field in doc["fields"]:
           if field and "code" in field:
-            object_name = name_match.match(field["code"])[1]
-            if object_name == "x" or "[i]" in field["code"]:
+            try:
+              object_name = name_match.match(field["code"])[1]
+              if object_name == "x" or "[i]" in field["code"]:
+                continue
+            except:
               continue
             else:
               if ".name_fields(" in field["code"]:


### PR DESCRIPTION
Existing code runs into an error if the usage of fields | code doesn't match a pattern like x..._fields()