### PR TITLE
Fix sqlalchemy bug

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -131,7 +131,7 @@ def speedy_get_users() -> List[Tuple[int, str]]:
     return [tuple(user) for user in the_users]
 
 
-def get_users_and_name() -> List[Tuple[int, str, str]]:
+def get_users_and_name() -> List[Tuple[int, str, str, str]]:
     users = UserModel.query.with_entities(
         UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name
     )

--- a/docassemble/ALDashboard/data/questions/manage_users.yml
+++ b/docassemble/ALDashboard/data/questions/manage_users.yml
@@ -28,7 +28,7 @@ code: |
 code: |
   user_lookup = {}
   for user in get_users_and_name():
-    user_lookup[user[0]] = user['email']
+    user_lookup[user[0]] = user[3]
 ---
 id: select user
 question: |
@@ -38,7 +38,7 @@ fields:
     datatype: integer
     input type: combobox
     code: |
-      [{user[0]: f"{user['first_name']} {user['last_name']} {user['email']}"} for user in get_users_and_name()]
+      [{user[0]: f"{user[1]} {user[2]} {user[3]}"} for user in get_users_and_name()]
     exclude:
       - "2"
     # User ID 2 is the "cron" user and should not be managed here        


### PR DESCRIPTION
sqlalchemy sometimes returns tuples where it would default return dicts. Decided to change the frontend to use tuples instead of dicts, since ALDashboard isn't built for people to overwrite.

Fix #77.