### PR TITLE
Correct description-file to description_file

### DIFF
--- a/docassemble/ALDashboard/create_package.py
+++ b/docassemble/ALDashboard/create_package.py
@@ -145,7 +145,7 @@ include README.md
 """
   setupcfg = """\
 [metadata]
-description-file = README.md
+description_file = README.md
 """
   setuppy = """\
 import os


### PR DESCRIPTION
The deprecation warning from pip:

```
UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```

Side note: I believe that "future version" date is now 2023-09-26, a month from now. So I'll likely do a few smaller changes in all of the repos that need this change soon.  

Similar change to https://github.com/jhpyle/docassemble/pull/640.