### PR TITLE
Sort sessions and fix users dropdown

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -122,13 +122,13 @@ def da_write_config(data: Dict):
     restart_all()
 
 
-def speedy_get_users() -> List[Tuple[int, str]]:
+def speedy_get_users() -> List[Dict[int, str]]:
     """
     Return a list of all users in the database. Possibly faster than get_user_list().
     """
     the_users = UserModel.query.with_entities(UserModel.id, UserModel.email).all()
 
-    return [user for user in the_users]
+    return [{user[0]: user[1]} for user in the_users]
 
 
 def get_users_and_name() -> List[Tuple[int, str, str, str]]:

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -19,7 +19,7 @@ fields:
   - Filename: filename
     required: False
     code: |
-      [{interview: interviews[interview].get('title')} for interview in interviews]
+      sorted([{interview: interviews[interview].get('title')} for interview in interviews], key=lambda y: next(iter(y.values()), ''))
   - User (leave blank to view all sessions): chosen_user
     required: False
     datatype: integer


### PR DESCRIPTION
Made a few small fixes to the `list_sessions.yml` interview after using it this morning:

* The interviews were listed all out of order, which made it hard to know where to start looking: they are now sorted alphabetically
* `speedy_get_users` returned Tuples, which didn't seem to be working in the user selection on the first screen of `list_sessions`, and I don't think DA handles very well in general. I changed it to return a List of key-value maps, which is what the `code` section of a combobox expects.

Tested both of these changes in apps-dev, and it works great. Might merge these soon, since I've trying to use it to pinpoint more production errors with the ALAffidavitOfIndigency that are appearing.