### PR TITLE
Better Bootstrap theme default

### DIFF
--- a/docassemble/ALDashboard/data/questions/compile_bootstrap.yml
+++ b/docassemble/ALDashboard/data/questions/compile_bootstrap.yml
@@ -119,17 +119,17 @@ fields:
       is: type_out
     default: |
         $white: #ffffff;
-        $blue: #25dec6;
-        
+        $blue: #0d6efd;
+
         $theme-colors: (
-            "light":      #d8e2a5,
-            "dark":       #1b1b1b,
-            "primary":    #25dec6,
-            "secondary":  #375b5a,
-            "info":       #d74d72,
-            "success":    #0cb545,
-            "warning":    #f4ca0b,
-            "danger":     #fa043c,
+            "light":      #f8f9fa,
+            "dark":       #212529,
+            "primary":    #0d6fed,
+            "secondary":  #6c757,
+            "info":       #0dcaf0,
+            "success":    #198754,
+            "warning":    #ffc107,
+            "danger":     #dc3545,
         );
         @import "bootstrap";
 validation code: |

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -55,5 +55,5 @@ buttons:
     image: paperclip
   - PDF tools:  ${ interview_url(i=user_info().package + ":pdf_wrangling.yml", reset=1) }
     image: file-pdf
-  - Compile custom Bootstrap: ${ interview_url(i=user_info().package + ":compile_bootstrap.yml", reset=1) }
+  - Compile Bootstrap theme: ${ interview_url(i=user_info().package + ":compile_bootstrap.yml", reset=1) }
     image: bootstrap

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -55,5 +55,5 @@ buttons:
     image: paperclip
   - PDF tools:  ${ interview_url(i=user_info().package + ":pdf_wrangling.yml", reset=1) }
     image: file-pdf
-  - Compile a custom Bootstrap theme: ${ interview_url(i=user_info().package + ":compile_bootstrap.yml", reset=1) }
+  - Compile custom Bootstrap: ${ interview_url(i=user_info().package + ":compile_bootstrap.yml", reset=1) }
     image: bootstrap


### PR DESCRIPTION
Correcting a mistake I made a while back; the default colors are horrible. I probably made them for testing and never changed them back. It is a problem because it's impossible to tell what the colors will be before generating the theme, and it's not clear what those values are by default in docassemble.

Now, the default colors when you are typing the theme are the same ones from docassemble's base theme. So you'll get what you expect.

Also shortened a the bootstrap interview label from the menu, which was too long.
