### PR TITLE
Add instructions for how to add Dashboard to drop down to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ configuration, like this:
 
 `install packages api key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 
+If you want the ALDashboard to be a dropdown option for admins and developers, add the following to the configuration before your `install packages api key`: 
+
+    administrative interviews:
+      - interview: docassemble.ALDashboard:data/questions/menu.yml
+        title: Dashboard
+        required privileges:
+          - admin
+          - developer
+
 ## Some screenshots
 
 ### Main page


### PR DESCRIPTION
Not sure if this is desired here or the right place for it, but it's what I was looking for in this location. 

Perhaps also an explanation for how to run the Dashboard without adding it to the menu / how to format the link could be helpful here.