### PR TITLE
Show a preview of the PDF labels when Renaming

### DIFF
--- a/docassemble/ALDashboard/data/questions/pdf_wrangling.yml
+++ b/docassemble/ALDashboard/data/questions/pdf_wrangling.yml
@@ -128,7 +128,7 @@ right: |
   
   <iframe src="${ field_preview_pdf.url_for() }" height="400"></iframe>
 
-  _note_: This preview will not update with live changes.
+  _note_: This preview will update on the next screen.
   
 continue button field: display_rename_field_choices
 ---

--- a/docassemble/ALDashboard/data/questions/pdf_wrangling.yml
+++ b/docassemble/ALDashboard/data/questions/pdf_wrangling.yml
@@ -109,6 +109,10 @@ question: |
   Here is the new PDF
 subquestion: |
   [:file-pdf: ${ new_pdf.filename }](${ new_pdf.url_for() })
+right: |
+  #### Preview of the new PDF labels
+
+  <iframe src="${ new_field_preview_pdf.url_for() }" height="400"></iframe>
 ---
 code: |
   rename_fields = {}
@@ -138,7 +142,19 @@ attachment:
     [
       {field[0]: "Yes" if field[4] == "/Btn" else field[0]} 
       for field in source_pdf[0].get_pdf_fields()
-    ]   
+    ]
+---
+attachment:
+  variable name: new_field_preview_pdf
+  editable: False
+  pdf template file:
+    code: |
+      new_pdf
+  code: |
+    [
+      {field[0]: "Yes" if field[4] == "/Btn" else field[0]} 
+      for field in new_pdf.get_pdf_fields()
+    ]
 ---
 code: |
   new_pdf.initialize(filename=base_name)


### PR DESCRIPTION
To confirm that you renamed the correct fields, which can be difficult for longer PDFs.

I stuck with the same placement of the PDF, with a new title to show it's the new field names.

![Screenshot from 2023-10-17 17-26-00](https://github.com/SuffolkLITLab/docassemble-ALDashboard/assets/6252212/1648ea2b-0c80-4277-a202-9d91d0690a3a)

(Another quick proof of concept, feel free to reject if we think we should improve the problem in a different way.)