### PR TITLE
Added link to Github Feedback interview

### DIFF
--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -59,3 +59,5 @@ buttons:
     image: bootstrap
   - Install fonts: ${ interview_url(i=user_info().package + ":install_fonts.yml", reset=1)}
     image: font
+  - Feedback on server: ${ interview_url(i="docassemble.GithubFeedbackForm:browse_feedback_sessions.yml", reset=1)}
+    image: comments


### PR DESCRIPTION
`browse_feedback_sessions.yml` is now a button on the menu.

Fix #114.

![Screenshot from 2023-10-30 16-49-01](https://github.com/SuffolkLITLab/docassemble-ALDashboard/assets/6252212/a5fd2be9-d392-4217-bb96-7a56f4c76bb3)
