### PR TITLE
Skip over ALPeople in review generator

### DIFF
--- a/docassemble/ALDashboard/data/questions/review_screen_generator.yml
+++ b/docassemble/ALDashboard/data/questions/review_screen_generator.yml
@@ -150,8 +150,10 @@ code: |
     for obj in objects:
       obj_name = next(iter(obj.keys()), [""])
       obj_type = next(iter(obj.values()), [""])
-      is_skippable_type = any(map(lambda val: obj_type.startswith(val), ["ALDocument.", "ALDocumentBundle.", "DAStaticFile."]))
-      if is_skippable_type:
+      # We skip types that don't need revisit screens, and types that have default revisit screens
+      # defined in AssemblyLine
+      skippable_types = ["ALDocument.", "ALDocumentBundle.", "DAStaticFile.", "ALPeopleList."]
+      if any(map(lambda val: obj_type.startswith(val), skippable_types)):
         continue
       review = {}
       review["Edit"] = f"{ obj_name }.revisit"


### PR DESCRIPTION
Some spare code that was on my machine, that skips making tables for ALPeopleLists. I had intended on waiting until https://github.com/SuffolkLITLab/docassemble-AssemblyLine/commit/3d0181df9f2c78a87db86e018825cffaf8ce27c4 (the commit in Assembly Line with default people tables) was released (that was merged Dec 16th, last release was the 4th, so it hasn't been yet), before adding this to the Dashboard. Tested a little bit with MLH interviews, but not thoroughly.