### PR TITLE
Improvements to package install and browsing

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -70,7 +70,7 @@ __all__ = [
 def install_from_github_url(url: str, branch: str = "", pat: Optional[str] = None):
     giturl = url.strip().rstrip("/")
     if pat:
-        # modify so it looks like https://e8cc02bec7061de98ba4851263638d7483f63d41:x-oauth-basic@github.com/johnsmith/docassemble-missouri-familylaw
+        # modify so it looks like https://ghp_...:x-oauth-basic@github.com/johnsmith/docassemble-missouri-familylaw
         giturl = re.sub(r"^https://", f"https://{pat}:x-oauth-basic@", giturl)
     if isinstance(branch, str):
         branch = branch.strip()

--- a/docassemble/ALDashboard/data/questions/browse_interviews.yml
+++ b/docassemble/ALDashboard/data/questions/browse_interviews.yml
@@ -1,0 +1,34 @@
+---
+modules:
+  - .aldashboard
+  - docassemble.demo.accordion
+---
+default screen parts:
+  right: |
+    ${ action_button_html(interview_url(i=f"{user_info().package}:menu.yml"), label="Back to Dashboard") }
+---
+mandatory: True
+id: browse packages
+question: |
+  Interviews on this server
+subquestion: |
+  Below is a list of every interview YAML file in every Docassemble package on this server.
+  Not all YAMLs are intended to be run directly as interviews.
+
+  % for package_name, question_files in sorted(list_question_files_in_docassemble_packages().items()):
+  % if loop.index == 0:
+  ${ start_accordion(package_name.replace("docassemble.", "")) }
+  % else:
+  ${ next_accordion(package_name.replace("docassemble.", "")) }
+  % endif
+  % if question_files:
+  <ul>
+  % for question_file in question_files:
+  <li> 
+    <a href="${ interview_url(i=package_name + ":" + question_file, reset=1) }">${ question_file }</a>
+  </li>
+  % endfor
+  </ul>
+  % endif
+  % endfor
+  ${ end_accordion() }

--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -206,7 +206,7 @@ fields:
   - Server short title: the_config['default short title']
     default: ${ the_config.get('default short title') }
   - App name: the_config['appname']
-    default: ${ the_config.get('appname', '') }
+    default: ${ the_config.get('appname', the_config.get('default short title')) }
   - note: |
       ---
       Some features require background processing, which means you need
@@ -371,6 +371,9 @@ subquestion: |
   
   1. Let users give feedback about an interview.
   2. Display a "last updated" date on the "About" page of an interview.
+  1. Install and update packages from GitHub.
+
+  We recommend using **2 separate GitHub accounts** for these tasks.
 
   First, in order to use GitHub you should create a dedicated GitHub account. You can use an account that already exists, but we recommend having an account that only handles Assembly Line functionality.
   
@@ -383,9 +386,21 @@ subquestion: |
       1. Tap the checkbox for "repo" permissions.
   1. Finish creating the personal access token.
   1. Copy the token and paste it below
+
+  If you have a private repository, you will need a second token with "repo" permissions.
+
+  This token is only used to install and update packages, and should not be the same
+  as the account used for feedback. It is OK for this token to be associated with your
+  personal GitHub account.
 fields:
-  - Personal access token: the_config['github issues']['token']
+  - Personal access token for authoring issues: the_config['github issues']['token']
     default: ${ the_config['github issues'].get('token', '') }
+  - Personal access token for installing private repositories: the_config['assembly line']['github install token']
+    default: ${ the_config['assembly line'].get('github install token', '') }
+    required: False
+    help: |
+      If you have private repositories, you will need a second token with "repo" permissions.
+      This token is only used to install and update packages.
 ---
 id: github owners list
 continue button field: github_owners_list

--- a/docassemble/ALDashboard/data/questions/install_packages.yml
+++ b/docassemble/ALDashboard/data/questions/install_packages.yml
@@ -26,10 +26,20 @@ question: |
 list collect: True
 fields:
   - Github URL: packages[i].github_url
+  - This is a private GitHub repo: packages[i].is_private
+    datatype: yesno
+  - Github [Personal Access Token](https://docassemble.org/docs/packages.html#github_install): packages[i].github_token
+    show if: packages[i].is_private
+    default: |
+      ${ get_config('assembly line',{}).get("github install token", "") }
+  - Also add an alias: packages[i].add_alias
+    datatype: yesno
   - YAML filename: packages[i].yaml_name
+    show if: packages[i].add_alias
   - Short name or alias (no spaces): packages[i].alias
     validate: |
       lambda y: y.isidentifier()
+    show if: packages[i].add_alias
 ---
 code: |
   install_packages_task = background_action('install_packages_event')
@@ -38,19 +48,21 @@ event: install_packages_event
 code: |
   background_error_action("bg_failure")
   for package in packages:
-    pkgname = install_from_github_url(package.github_url)
+    pkgname = install_from_github_url(package.github_url, pat=package.github_token if package.is_private else None)
     reset(pkgname)
 
-  the_config = da_get_config()
-  if not the_config.get("dispatch"):
-    the_config["dispatch"] = {}
-  for package in packages:
-      package_regex = r"https:\/\/github\.com\/.*\/docassemble-([\w]*)"
-      match = re.search(package_regex, package.github_url)
-      if match:
-        package_path = f"docassemble.{ match.groups()[0] }:data/questions/{ package.yaml_name }"
-        the_config["dispatch"][package.alias] = package_path
-  results = da_write_config(the_config)
+  if any((package.add_alias for package in packages)):
+    the_config = da_get_config()
+    if not the_config.get("dispatch"):
+      the_config["dispatch"] = {}
+    for package in packages:
+      if package.add_alias:
+        package_regex = r"https:\/\/github\.com\/.*\/docassemble-([\w]*)"
+        match = re.search(package_regex, package.github_url)
+        if match:
+          package_path = f"docassemble.{ match.groups()[0] }:data/questions/{ package.yaml_name }"
+          the_config["dispatch"][package.alias] = package_path
+    results = da_write_config(the_config)
 
   background_response_action("bg_success")
 ---
@@ -76,13 +88,18 @@ subquestion: |
   % if it_worked:
   It may take a few minutes for the installation process to complete.
 
+  % if any((package.add_alias for package in packages)):
   You can now use these links to reach your interviews:
   
   % for package in packages:
+  % if package.add_alias:
   * [${package.alias}](/start/${package.alias})
+  % endif
   % endfor
+  % endif
   % else:
   Something went wrong. Check the [worker.log](/logs?file=worker.log) to learn what.
   % endif
+
 buttons:
   - Restart: restart

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -56,6 +56,9 @@ data:
   - name: Package scanner
     url: ${ interview_url(i=user_info().package + ":package_scanner.yml", reset=1) }
     image: search
+  - name: View installed interviews
+    url: ${ interview_url(i=user_info().package + ":browse_interviews.yml", reset=1) }
+    image: list
   - name: View answer files
     url: ${ interview_url(i=user_info().package + ":list_sessions.yml", reset=1) }
     image: file-alt

--- a/docassemble/ALDashboard/package_scanner.py
+++ b/docassemble/ALDashboard/package_scanner.py
@@ -163,9 +163,9 @@ def fetch_github_repo_version(repo_list, key_pkgs, github_user) -> dict:
                     version_num = decoded_line[str_start:str_end][9:].replace(
                         "',\n", ""
                     )
-                    v[
-                        "version"
-                    ] = version_num  # Add version number to the original repo_list.
+                    v["version"] = (
+                        version_num  # Add version number to the original repo_list.
+                    )
                     has_version_num = True
                     break
 

--- a/docassemble/ALDashboard/requirements.txt
+++ b/docassemble/ALDashboard/requirements.txt
@@ -3,6 +3,7 @@ docassemble.webapp
 types-setuptools
 types-pycurl
 types-requests
+types-setuptools
 mypy
 openai
 tiktoken

--- a/docassemble/ALDashboard/translation.py
+++ b/docassemble/ALDashboard/translation.py
@@ -54,7 +54,9 @@ __all__ = [
 
 class Translation(NamedTuple):
     file: DAFile  # an XLSX or XLIFF file
-    untranslated_words: int  # Word count for all untranslated segments that are not Mako or HTML
+    untranslated_words: (
+        int  # Word count for all untranslated segments that are not Mako or HTML
+    )
     untranslated_segments: int  # Number of rows in the output that have untranslated text - one for each question, subquestion, field, etc.
     total_rows: int
 
@@ -69,7 +71,9 @@ def translation_file(yaml_filename: str, tr_lang: str) -> Translation:
     This code was adjusted from the Flask endpoint-only version in server.py. XLIFF support was removed
     for now but can be added later.
     """
-    filetype: str = "XLSX"  # Look in server.py for support of XLIFF format, but we won't implement it here
+    filetype: str = (
+        "XLSX"  # Look in server.py for support of XLIFF format, but we won't implement it here
+    )
     output_file = DAFile()
     setup_translation()
     if yaml_filename is None or not re.search(r"\S", yaml_filename):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,4 +63,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module="mako.*"
 ignore_missing_imports = true
-


### PR DESCRIPTION
Fix #119 
Fix #64 

Adds a simple dashboard to let you view installed packages and the YAML files in them, and then run those packages. Makes it unnecessary to create a link to run the package.

Also adds the ability to add a private access token to the global configuration and to use a private access token when installing a package from GitHub using the Dashboard.