### PR TITLE
Fix font listing

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -349,11 +349,10 @@ def list_installed_fonts():
     """
     List the fonts installed on the server.
     """
-    fc_list = subprocess.run(["fc-list"], stdout=subprocess.PIPE)
+    fc_list = subprocess.run(["fc-list"], stdout=subprocess.PIPE, text=True)
     output = subprocess.run(
-        ["sort"], stdin=fc_list.stdout, capture_output=True, text=True
+        ["sort"], input=fc_list.stdout, capture_output=True, text=True
     ).stdout
-    fc_list.stdout.close()
     return output
 
 


### PR DESCRIPTION
Previously had the error:

```
Error in assembly: AttributeError: 'bytes' object has no attribute 'fileno'
...
File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/ALDashboard/aldashboard.py", line 353, in list_installed_fonts\n    output = subprocess.run(\n', '
File "/usr/lib/python3.10/subprocess.py", line 1606, in _get_handles\n    p2cread = stdin.fileno()\n
```

Not sure what really changed between versions, but we can make the first call to `fc-list` act the same as the call to text (i.e. pass `text=True`) to make it a string and not bytes.

The subprocess docs
(https://docs.python.org/3/library/subprocess.html#subprocess.run) say that you should use the `input` argument for strings, which also fixes the internal error in subprocess, which seems to be expecting a file.

Is currently happening in PROD. Tested locally to confirm the fix.