### PR TITLE
Fix mypy

### DIFF
--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -9,7 +9,7 @@ from docx.oxml import OxmlElement
 import re
 from docassemble.base.util import get_config
 
-os.environ["OPENAI_API_KEY"] = get_config("openai api key")
+os.environ["OPENAI_API_KEY"] = get_config("openai api key") or ""
 
 from typing import List, Tuple, Optional, Union
 

--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -33,8 +33,8 @@ def add_paragraph_before(paragraph, text):
 
 
 def update_docx(
-    document: Union[docx.Document, str], modified_runs: List[Tuple[int, int, str, int]]
-) -> docx.Document:
+    document: Union[docx.document.Document, str], modified_runs: List[Tuple[int, int, str, int]]
+) -> docx.document.Document:
     """Update the document with modified runs.
 
     Args:
@@ -263,7 +263,7 @@ def get_labeled_docx_runs(
     return guesses
 
 
-def modify_docx_with_openai_guesses(docx_path: str) -> docx.Document:
+def modify_docx_with_openai_guesses(docx_path: str) -> docx.document.Document:
     """Uses OpenAI to guess the variable names for a document and then modifies the document with the guesses.
 
     Args:

--- a/docassemble/ALDashboard/requirements.txt
+++ b/docassemble/ALDashboard/requirements.txt
@@ -3,7 +3,6 @@ docassemble.webapp
 types-setuptools
 types-pycurl
 types-requests
-types-setuptools
 mypy
 openai
 tiktoken

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.ALDashboard',
       url='https://github.com/SuffolkLITLab/docassemble-ALDashboard',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyGithub>=2.1.1', 'docassemble.ALToolbox>=0.9.2', 'openai>=1.0', 'tiktoken', 'pyaml'],
+      install_requires=['PyGithub>=2.1.1', 'docassemble.ALToolbox>=0.9.2', 'python-docx>=1.1.1', 'openai>=1.0', 'tiktoken', 'pyaml'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALDashboard/', package='docassemble.ALDashboard'),
      )


### PR DESCRIPTION
With python-docx v1.1.1, the type of `docx.Document` has been changed. To fix `Document`s, we change the type to `docx.document.Document`.

Tested that no functionality was affected locally best I can.