### PR TITLE
Only allow one concurrent deployment to Dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,20 @@
-
-name: Deploy the ALDashboard to PyPI and the Dev server
+name: Deploy package to the Dev server
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "dev-server"
+  cancel-in-progress: false
 
 jobs:
   deploy-to-dev:
     name: Deploy to the Development server
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
     - uses: SuffolkLITLab/ALActions/da_package@main
       with:
         SERVER_URL: ${{ vars.DEV_SERVER_URL }}


### PR DESCRIPTION
Grabbed this bit from the GitHub templates for pages sites, i.e. https://github.com/SuffolkLITLab/EfileProxyServer/blob/main/.github/workflows/docs_site.yml