### PR TITLE
Fix typos

### DIFF
--- a/docassemble/ALDashboard/data/questions/docx_wrangling.yml
+++ b/docassemble/ALDashboard/data/questions/docx_wrangling.yml
@@ -145,7 +145,7 @@ code: |
 continue button field: ask_about_labels
 question: |
   Review the labels
-subuestion: |
+subquestion: |
   On the left is the original text. On the right, you will see the modified
   text with Jinja2 added. Make any changes you need.
 fields:

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -128,7 +128,7 @@ subquestion: |
   </tr>
   % endfor
   </table>
-question back button: True
+back button: True
 ---
 event: view_session_variables
 code: |


### PR DESCRIPTION
* `subuestion` to `subquestion`
* `question back button` to `back button`

Were found when I was testing [DAYamlChecker](https://github.com/BryceStevenWilley/DAYamlChecker), a quick, docassemble-independent YAML checker for simple errors that I made a while back, just forgot to make the PR for them.

That package still needs a lot of work to be really useful, but was pretty nice to immediately catch some issues.