### PR TITLE
Dashboard panel to fix file upload index issues

### DIFF
--- a/docassemble/ALDashboard/data/questions/file_index.yml
+++ b/docassemble/ALDashboard/data/questions/file_index.yml
@@ -1,0 +1,43 @@
+---
+include:
+  - nav.yml
+---
+modules:
+  - .aldashboard
+---
+id: interview order
+mandatory: True
+code: |
+  increment_amount
+  do_increase_index
+  show_results
+---
+code: |
+  increment_index_value(increment_amount, "uploads_indexno_seq")
+  do_increase_index = True
+---
+code: |
+  latest_s3_folder = get_latest_s3_folder("files/")
+---
+question: |
+  View status of S3 /files vs latest index values
+subquestion: |
+  The current index value is: **${ get_current_index_value() }**
+
+  The latest S3 folder is: **${ latest_s3_folder }**
+
+  % if latest_s3_folder > get_current_index_value():
+  <div class="alert alert-warning" role="alert">
+    <strong>Warning:</strong> The latest S3 folder is larger than the current index value.
+  </div>
+  % endif  
+fields:
+  - Increment index by: increment_amount
+    datatype: integer
+    default: 5000
+---
+event: show_results
+question: |
+  New value is ${ get_current_index_value() }
+subquestion: |
+  ${ action_button_html(url_of("restart"), label="Restart", icon="arrow-rotate-right") }

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -103,3 +103,8 @@ data:
     privilege:
       - admin
       - developer
+  - name: Manage S3 file index
+    url: ${ interview_url(i=user_info().package + ":file_index.yml", reset=1) }
+    image: folder-tree
+    privilege:
+      - admin


### PR DESCRIPTION
On botched DA upgrades, docassemble very often will use a lower file number index than it should. When it does, there's a risk of leaking user information to other unsuspecting users.

From @nonprofittechy:

> This adds a new dashboard icon that lets you view the current next file ID that will be assigned, compare it to the most recent file ID that is in use on S3, warn you if the database ID is too low relative to the most recent file, and choose a number to increment the most recent file ID by.

Split off of #158.

Tested just this branch on apps-dev, works well for me.