### PR TITLE
Don't show all emails to non-devs + non-admins

### DIFF
--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -54,7 +54,7 @@ fields:
     datatype: integer
     input type: combobox
     code: |
-      speedy_get_users()
+      speedy_get_users() if user_has_privilege(['admin', 'developer']) else [{user_info().id: user_info().email}]
   - Filter out interviews that are on the first page: filter_step1
     required: False
     datatype: yesno


### PR DESCRIPTION
Only show the user's email for selection, and not everyone's.