### PR TITLE
Add REST/MCP interface to DAYamlChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ When installed on a docassemble server, ALDashboard exposes a Flask API at:
 - `POST /al/api/v1/dashboard/translation/validate`
 - `POST /al/api/v1/dashboard/review-screen/draft`
 - `POST /al/api/v1/dashboard/docx/validate`
+- `POST /al/api/v1/dashboard/yaml/check`
+- `POST /al/api/v1/dashboard/yaml/reformat`
 - `POST /al/api/v1/dashboard/pdf/label-fields`
 - `POST /al/api/v1/dashboard/pdf/fields/detect`
 - `POST /al/api/v1/dashboard/pdf/fields/relabel`
@@ -107,6 +109,12 @@ celery modules:
 - `POST /al/api/v1/dashboard/docx/validate`
   - Input: one or more DOCX templates.
   - Output: per-file Jinja rendering errors.
+- `POST /al/api/v1/dashboard/yaml/check`
+  - Input: `yaml_text` (or `yaml_content`) and optional `filename`.
+  - Output: structured DAYamlChecker issues with `errors`, `warnings`, and `valid`.
+- `POST /al/api/v1/dashboard/yaml/reformat`
+  - Input: `yaml_text` (or `yaml_content`), optional `line_length` and `convert_indent_4_to_2`.
+  - Output: reformatted YAML in `formatted_yaml` and `changed` boolean.
 - `POST /al/api/v1/dashboard/pdf/label-fields`
   - Input: PDF upload.
   - Output: PDF with fields detected and optionally relabeled (backward-compatible alias of `/pdf/fields/detect`).

--- a/docassemble/ALDashboard/api_dashboard.py
+++ b/docassemble/ALDashboard/api_dashboard.py
@@ -41,6 +41,8 @@ from .api_dashboard_utils import (
     translation_payload_from_request,
     validate_docx_payload_from_request,
     validate_translation_payload_from_request,
+    yaml_check_payload_from_request,
+    yaml_reformat_payload_from_request,
 )
 from . import api_mcp  # noqa: F401
 
@@ -63,6 +65,8 @@ if not in_celery:
         dashboard_review_screen_task,
         dashboard_validate_docx_task,
         dashboard_validate_translation_task,
+        dashboard_yaml_check_task,
+        dashboard_yaml_reformat_task,
     )
 
 
@@ -489,6 +493,22 @@ def dashboard_docx_validate():
 def dashboard_interview_lint():
     return _run_endpoint(
         interview_lint_payload_from_request, dashboard_interview_lint_task
+    )
+
+
+@app.route(f"{DASHBOARD_API_BASE_PATH}/yaml/check", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def dashboard_yaml_check():
+    return _run_endpoint(yaml_check_payload_from_request, dashboard_yaml_check_task)
+
+
+@app.route(f"{DASHBOARD_API_BASE_PATH}/yaml/reformat", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def dashboard_yaml_reformat():
+    return _run_endpoint(
+        yaml_reformat_payload_from_request, dashboard_yaml_reformat_task
     )
 
 

--- a/docassemble/ALDashboard/api_dashboard_worker.py
+++ b/docassemble/ALDashboard/api_dashboard_worker.py
@@ -17,6 +17,8 @@ from .api_dashboard_utils import (
     translation_payload_from_options,
     validate_docx_payload_from_options,
     validate_translation_payload_from_options,
+    yaml_check_payload_from_options,
+    yaml_reformat_payload_from_options,
 )
 
 
@@ -90,3 +92,15 @@ def dashboard_pdf_fields_detect_task(payload: Dict[str, Any]) -> Dict[str, Any]:
 def dashboard_pdf_fields_relabel_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     with bg_context():
         return pdf_fields_relabel_payload_from_options(payload)
+
+
+@workerapp.task
+def dashboard_yaml_check_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    with bg_context():
+        return yaml_check_payload_from_options(payload)
+
+
+@workerapp.task
+def dashboard_yaml_reformat_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    with bg_context():
+        return yaml_reformat_payload_from_options(payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     'openai>=1.0',
     'tiktoken',
     'pyaml',
-    'formfyxer>=1.0.1'
+    'formfyxer>=1.0.1',
+    'dayamlchecker>=0.2.0'
 ]
 license="MIT"
 license-files = [

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALDashboard',
       license='The MIT License (MIT)',
       url='https://github.com/SuffolkLITLab/docassemble-ALDashboard',
       packages=find_namespace_packages(),
-      install_requires=['PyGithub>=2.1.1', 'docassemble.ALToolbox>=0.9.2', 'python-docx>=1.1.1', 'openai>=1.0', 'tiktoken', 'pyaml', 'formfyxer>=1.0.1', 'Mako>=1.1.4', 'pyspellchecker>=0.6.3', 'ruamel.yaml>=0.17.4', 'textstat>=0.7.0'],
+      install_requires=['PyGithub>=2.1.1', 'docassemble.ALToolbox>=0.9.2', 'python-docx>=1.1.1', 'openai>=1.0', 'tiktoken', 'pyaml', 'formfyxer>=1.0.1', 'dayamlchecker>=0.2.0', 'Mako>=1.1.4', 'pyspellchecker>=0.6.3', 'ruamel.yaml>=0.17.4', 'textstat>=0.7.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALDashboard/', package='docassemble.ALDashboard'),
      )


### PR DESCRIPTION
We do have an MCP layer for the `dayamlchecker` CLI, but just started standardizing MCP to this repo. And this is easier to run and use remotely.