### PR TITLE
Address Yaml Checker warning

### DIFF
--- a/docassemble/ALDashboard/data/questions/package_scanner.yml
+++ b/docassemble/ALDashboard/data/questions/package_scanner.yml
@@ -177,7 +177,7 @@ mandatory: True
 code: |
   intro
   search_type
-  if github_select_type == "created":
+  if showifdef("github_select_type") == "created":
     end_date  # Github input with the end_date question
   else:
     github_user  # Github input w/t the end_date question


### PR DESCRIPTION
`github_select_type` should be wrapped in a `showifdef`, since it's not always defined. Technically worked before, but was precarious.

Tested locally and made sure that the interview still works.