### PR TITLE
Pdf editor bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist/
 .env.*
 .env2
 *Zone.Identifier*
+
+.codex

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -32,6 +32,8 @@ def _format_pdf_fields_for_ui_payload(
     formatted_fields: List[Dict[str, Any]] = []
     for page_idx, page_fields in enumerate(fields_per_page):
         for field in page_fields:
+            raw_font_size = getattr(field, "font_size", None)
+            auto_size = raw_font_size == 0
             formatted_fields.append(
                 {
                     "id": str(uuid.uuid4()),
@@ -42,7 +44,8 @@ def _format_pdf_fields_for_ui_payload(
                     "y": field.y,
                     "width": field.configs.get("width", 100),
                     "height": field.configs.get("height", 20),
-                    "fontSize": field.font_size or 12,
+                    "fontSize": 12 if auto_size else (raw_font_size or 12),
+                    "autoSize": auto_size,
                 }
             )
     return formatted_fields

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -99,6 +99,17 @@ def _sanitize_checkbox_export_value(raw_value: Any) -> str:
     return token or "Yes"
 
 
+def _looks_like_name_email_address_phone_field(field_name: Any) -> bool:
+    """Return True when a field name should keep auto-size enabled."""
+    return bool(
+        re.search(
+            r"(name|address|street|city|state|zip|postal|phone|phone_number|email|cell)",
+            str(field_name or ""),
+            flags=re.IGNORECASE,
+        )
+    )
+
+
 def _get_named_pdf_parent(field_obj: Any) -> Optional[Any]:
     """Walk up a PDF widget tree until a named field container is found.
 
@@ -3430,6 +3441,10 @@ def pdf_labeler_bulk_normalize():
             options.get("uniformCheckboxSize"), default=True
         )
         checkbox_size_pt = int(options.get("checkboxSizePt") or 12)
+        auto_size_name_address = parse_bool(
+            options.get("autoSizeNameAddress"), default=True
+        )
+        fixed_text_height_pt = int(options.get("fixedTextHeightPt") or 14)
         remove_embedded_fonts_flag = parse_bool(
             options.get("removeEmbeddedFonts"), default=False
         )
@@ -3504,7 +3519,7 @@ def pdf_labeler_bulk_normalize():
                                     if norm_font_size
                                     else int(f.get("fontSize", 12) or 12)
                                 ),
-                                "autoSize": True,
+                                "autoSize": False,
                             }
 
                             if field_type_str == "checkbox" and norm_checkbox_style:
@@ -3513,6 +3528,15 @@ def pdf_labeler_bulk_normalize():
                             if field_type_str == "checkbox" and uniform_checkbox_size:
                                 nf["width"] = checkbox_size_pt
                                 nf["height"] = checkbox_size_pt
+                            if (
+                                auto_size_name_address
+                                and field_type_str == "text"
+                                and _looks_like_name_email_address_phone_field(
+                                    field_name
+                                )
+                            ):
+                                nf["autoSize"] = True
+                                nf["height"] = fixed_text_height_pt
 
                             normalized_fields.append(nf)
 

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -3447,6 +3447,10 @@
                 nextField.allowScroll = false;
             }
 
+            if (nextField.type === 'text' || nextField.type === 'multiline') {
+                nextField.autoSize = false;
+            }
+
             if (settings.autoSizeNameAddress && nextField.type === 'text' && looksLikeNameOrAddressField(nextField.name)) {
                 nextField.autoSize = true;
                 nextField.height = ptToNormalizedLength(settings.fixedTextHeightPt, nextField.pageIndex, 'y');

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -128,7 +128,7 @@
                         <label class="btn btn-outline-secondary" for="fields-mode-rename">Rename</label>
                     </div>
                     <div id="fields-filter-controls" class="fields-toolbar">
-                        <input id="field-search" type="search" class="form-control form-control-sm" placeholder="Filter by field name">
+                        <input id="field-search" type="search" class="form-control form-control-sm" placeholder="Filter by field name" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" data-lpignore="true" data-1p-ignore="true">
                         <div class="fields-toolbar-row">
                             <select id="field-type-filter" class="form-select form-select-sm" aria-label="Filter fields by type">
                                 <option value="">All types</option>

--- a/docassemble/ALDashboard/test/test_api_dashboard_utils.py
+++ b/docassemble/ALDashboard/test/test_api_dashboard_utils.py
@@ -1,6 +1,7 @@
 import unittest
 import base64
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import docx
@@ -9,6 +10,7 @@ from docassemble.ALDashboard.api_dashboard_utils import (
     DEFAULT_MAX_UPLOAD_BYTES,
     DashboardAPIValidationError,
     _validate_upload_size,
+    _format_pdf_fields_for_ui_payload,
     autolabel_payload_from_options,
     build_openapi_spec,
     coerce_async_flag,
@@ -25,6 +27,34 @@ from docassemble.ALDashboard.api_dashboard_utils import (
 
 
 class TestDashboardAPIUtils(unittest.TestCase):
+    def test_format_pdf_fields_sets_auto_size_true_for_zero_font_size(self):
+        field = SimpleNamespace(
+            name="users[0].name.first",
+            type="text",
+            x=10,
+            y=20,
+            font_size=0,
+            configs={"width": 120, "height": 16},
+        )
+        payload = _format_pdf_fields_for_ui_payload([[field]])
+        self.assertEqual(len(payload), 1)
+        self.assertTrue(payload[0]["autoSize"])
+        self.assertEqual(payload[0]["fontSize"], 12)
+
+    def test_format_pdf_fields_sets_auto_size_false_for_fixed_font_size(self):
+        field = SimpleNamespace(
+            name="users[0].other",
+            type="text",
+            x=10,
+            y=20,
+            font_size=11,
+            configs={"width": 120, "height": 16},
+        )
+        payload = _format_pdf_fields_for_ui_payload([[field]])
+        self.assertEqual(len(payload), 1)
+        self.assertFalse(payload[0]["autoSize"])
+        self.assertEqual(payload[0]["fontSize"], 11)
+
     def test_parse_bool_accepts_common_values(self):
         self.assertTrue(parse_bool("true"))
         self.assertTrue(parse_bool("YES"))

--- a/docassemble/ALDashboard/test/test_api_labelers_query_params.py
+++ b/docassemble/ALDashboard/test/test_api_labelers_query_params.py
@@ -4,9 +4,7 @@ import sys
 import textwrap
 import unittest
 
-
-_STUBBED_IMPORT_PREFIX = textwrap.dedent(
-    """
+_STUBBED_IMPORT_PREFIX = textwrap.dedent("""
     import importlib
     import json
     import sys
@@ -65,8 +63,7 @@ _STUBBED_IMPORT_PREFIX = textwrap.dedent(
 
     module = importlib.import_module("docassemble.ALDashboard.api_labelers")
     app = app_object_module.app
-    """
-)
+    """)
 
 
 class TestLabelerQueryParams(unittest.TestCase):
@@ -88,15 +85,13 @@ class TestLabelerQueryParams(unittest.TestCase):
         return json.loads(stdout)
 
     def test_parse_initial_playground_source_accepts_filename_spaces(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             print(json.dumps(module._parse_initial_playground_source(
                 \"demo-project\",
                 \"Template With Spaces.docx\",
                 allowed_extensions=(\".docx\",),
             )))
-            """
-        )
+            """)
         self.assertEqual(
             result,
             {
@@ -106,15 +101,13 @@ class TestLabelerQueryParams(unittest.TestCase):
         )
 
     def test_parse_initial_playground_source_defaults_project(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             print(json.dumps(module._parse_initial_playground_source(
                 \"\",
                 \"intake form.pdf\",
                 allowed_extensions=(\".pdf\",),
             )))
-            """
-        )
+            """)
         self.assertEqual(
             result,
             {
@@ -124,8 +117,7 @@ class TestLabelerQueryParams(unittest.TestCase):
         )
 
     def test_parse_initial_playground_source_rejects_wrong_extension(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             try:
                 module._parse_initial_playground_source(
                     \"demo-project\",
@@ -139,13 +131,11 @@ class TestLabelerQueryParams(unittest.TestCase):
                 }))
             else:
                 raise AssertionError(\"Expected validation error\")
-            """
-        )
+            """)
         self.assertEqual(result["type"], "DashboardAPIValidationError")
 
     def test_parse_initial_playground_source_rejects_invalid_project(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             try:
                 module._parse_initial_playground_source(
                     \"../bad-project\",
@@ -159,25 +149,21 @@ class TestLabelerQueryParams(unittest.TestCase):
                 }))
             else:
                 raise AssertionError(\"Expected validation error\")
-            """
-        )
+            """)
         self.assertEqual(result["type"], "DashboardAPIValidationError")
 
     def test_parse_initial_playground_source_keeps_project_without_filename(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             print(json.dumps(module._parse_initial_playground_source(
                 \"demo-project\",
                 \"\",
                 allowed_extensions=(\".docx\",),
             )))
-            """
-        )
+            """)
         self.assertEqual(result, {"project": "demo-project"})
 
     def test_request_query_params_are_url_decoded_for_pdf(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             with app.test_request_context(
                 \"/al/pdf-labeler?project=demo-project&filename=My%20Form%20v2.pdf\"
             ):
@@ -185,8 +171,7 @@ class TestLabelerQueryParams(unittest.TestCase):
                     allowed_extensions=(\".pdf\",)
                 )
             print(json.dumps(payload))
-            """
-        )
+            """)
         self.assertEqual(
             result,
             {
@@ -196,15 +181,13 @@ class TestLabelerQueryParams(unittest.TestCase):
         )
 
     def test_docx_bootstrap_includes_initial_playground_source(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             with app.test_request_context(
                 \"/al/docx-labeler?project=demo-project&filename=Family+Intake.docx\"
             ):
                 payload = module._build_docx_labeler_bootstrap()
             print(json.dumps(payload))
-            """
-        )
+            """)
         self.assertEqual(
             result["initialPlaygroundSource"],
             {
@@ -214,20 +197,17 @@ class TestLabelerQueryParams(unittest.TestCase):
         )
 
     def test_pdf_bootstrap_ignores_invalid_filename_extension(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             with app.test_request_context(
                 \"/al/pdf-labeler?project=demo-project&filename=not-a-pdf.docx\"
             ):
                 payload = module._build_pdf_labeler_bootstrap()
             print(json.dumps(payload))
-            """
-        )
+            """)
         self.assertEqual(result["initialPlaygroundSource"], {})
 
     def test_render_template_content_escapes_script_breakout_sequences(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             module._get_template_content = lambda _filename: '<script type=\"application/json\">__LABELER_BOOTSTRAP_JSON__</script>'
             rendered = module._render_template_content(
                 \"ignored.html\",
@@ -239,14 +219,12 @@ class TestLabelerQueryParams(unittest.TestCase):
                 },
             )
             print(json.dumps({\"rendered\": rendered}))
-            """
-        )
+            """)
         self.assertIn("\\u003c/script\\u003e", result["rendered"])
         self.assertNotIn("</script><script>", result["rendered"])
 
     def test_name_address_phone_email_heuristic_matches_expected_names(self):
-        result = self._run_probe(
-            """
+        result = self._run_probe("""
             print(json.dumps({
                 "name": module._looks_like_name_email_address_phone_field("users[0].name.first"),
                 "email": module._looks_like_name_email_address_phone_field("users[0].email"),
@@ -254,8 +232,7 @@ class TestLabelerQueryParams(unittest.TestCase):
                 "address": module._looks_like_name_email_address_phone_field("users[0].address.city"),
                 "other": module._looks_like_name_email_address_phone_field("users[0].income.monthly"),
             }))
-            """
-        )
+            """)
         self.assertEqual(
             result,
             {

--- a/docassemble/ALDashboard/test/test_api_labelers_query_params.py
+++ b/docassemble/ALDashboard/test/test_api_labelers_query_params.py
@@ -244,6 +244,29 @@ class TestLabelerQueryParams(unittest.TestCase):
         self.assertIn("\\u003c/script\\u003e", result["rendered"])
         self.assertNotIn("</script><script>", result["rendered"])
 
+    def test_name_address_phone_email_heuristic_matches_expected_names(self):
+        result = self._run_probe(
+            """
+            print(json.dumps({
+                "name": module._looks_like_name_email_address_phone_field("users[0].name.first"),
+                "email": module._looks_like_name_email_address_phone_field("users[0].email"),
+                "phone": module._looks_like_name_email_address_phone_field("users[0].phone_number"),
+                "address": module._looks_like_name_email_address_phone_field("users[0].address.city"),
+                "other": module._looks_like_name_email_address_phone_field("users[0].income.monthly"),
+            }))
+            """
+        )
+        self.assertEqual(
+            result,
+            {
+                "name": True,
+                "email": True,
+                "phone": True,
+                "address": True,
+                "other": False,
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* Auto size was turned on by default for all fields; default to off except for heuristically detected name/address/phone number fields
* Add hints to the filter input so eager browser plugins don't fill it in with a username