### PR TITLE
Remove `id` from initial comment block

### DIFF
--- a/docassemble/ALDashboard/data/questions/api_test.yml
+++ b/docassemble/ALDashboard/data/questions/api_test.yml
@@ -1,5 +1,4 @@
 ---
-id: interview documentation
 comment: |
   # API Tester
 


### PR DESCRIPTION
A similar fix to https://github.com/SuffolkLITLab/docassemble-ALDashboard/pull/199, should have fixed it there.