### PR TITLE
Fix field default mako split across lines

### DIFF
--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -665,8 +665,8 @@ fields:
       - medium
       - high
     default: |
-      ${ the_config.get("open ai", {}).get("reasoning effort")
-         if the_config.get("open ai", {}).get("reasoning effort") in ["low", "medium", "high"]
+      ${ the_config.get("open ai", {}).get("reasoning effort") \
+         if the_config.get("open ai", {}).get("reasoning effort") in ["low", "medium", "high"] \
          else "low" }
     show if: configure_api_llm
   - Configure [e-filing](https://assemblyline.suffolklitlab.org/docs/components/EFSPIntegration/overview): configure_api_efile


### PR DESCRIPTION
Wasn't able to run in the plaground with a hard error:

```
Syntax Error: unexpected indent (<unknown>, line 2)

In file docassemble.ALDashboard:data/questions/install_assembly_line.yml in the block on line 500 from package docassemble.ALDashboard:
```

Wasn't caught by DAYamlChecker, but that fix is incoming as well.