### PR TITLE
Add preload guard to test modules

### DIFF
--- a/docassemble/ALDashboard/test/test_api_dashboard_utils.py
+++ b/docassemble/ALDashboard/test/test_api_dashboard_utils.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 import base64
 import tempfile

--- a/docassemble/ALDashboard/test/test_api_labelers_query_params.py
+++ b/docassemble/ALDashboard/test/test_api_labelers_query_params.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import json
 import subprocess
 import sys

--- a/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
+++ b/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
@@ -1,3 +1,4 @@
+# do not pre-load
 """Tests for _apply_pdf_field_visual_defaults preserve_button_appearances behavior.
 
 These tests verify that:

--- a/docassemble/ALDashboard/test/test_docx_repair.py
+++ b/docassemble/ALDashboard/test/test_docx_repair.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import os
 import tempfile
 import unittest

--- a/docassemble/ALDashboard/test/test_docx_wrangling.py
+++ b/docassemble/ALDashboard/test/test_docx_wrangling.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 from pathlib import Path
 import tempfile

--- a/docassemble/ALDashboard/test/test_docx_wrangling_scopes.py
+++ b/docassemble/ALDashboard/test/test_docx_wrangling_scopes.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 
 import docx

--- a/docassemble/ALDashboard/test/test_interview_linter.py
+++ b/docassemble/ALDashboard/test/test_interview_linter.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 from unittest.mock import patch
 import tempfile

--- a/docassemble/ALDashboard/test/test_labeler_config.py
+++ b/docassemble/ALDashboard/test/test_labeler_config.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import tempfile
 import unittest
 from pathlib import Path

--- a/docassemble/ALDashboard/test/test_labeler_js_extraction.py
+++ b/docassemble/ALDashboard/test/test_labeler_js_extraction.py
@@ -1,3 +1,4 @@
+# do not pre-load
 """Tests to verify JS extraction from labeler HTML templates to static files.
 
 Ensures no regression from moving inline JavaScript out of the DOCX and PDF

--- a/docassemble/ALDashboard/test/test_mcp_registry.py
+++ b/docassemble/ALDashboard/test/test_mcp_registry.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 import os
 from unittest.mock import patch

--- a/docassemble/ALDashboard/test/test_pdf_accessibility.py
+++ b/docassemble/ALDashboard/test/test_pdf_accessibility.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import os
 import tempfile
 import unittest

--- a/docassemble/ALDashboard/test/test_pdf_export_utils.py
+++ b/docassemble/ALDashboard/test/test_pdf_export_utils.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 
 from docassemble.ALDashboard.pdf_export_utils import build_pdf_export_fields_per_page

--- a/docassemble/ALDashboard/test/test_pdf_field_labeler.py
+++ b/docassemble/ALDashboard/test/test_pdf_field_labeler.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import tempfile
 import unittest
 from pathlib import Path

--- a/docassemble/ALDashboard/test/test_pdf_field_labeler_import.py
+++ b/docassemble/ALDashboard/test/test_pdf_field_labeler_import.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import subprocess
 import sys
 import unittest

--- a/docassemble/ALDashboard/test/test_pdf_label_fields_api.py
+++ b/docassemble/ALDashboard/test/test_pdf_label_fields_api.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import base64
 import unittest
 from pathlib import Path

--- a/docassemble/ALDashboard/test/test_pdf_repair.py
+++ b/docassemble/ALDashboard/test/test_pdf_repair.py
@@ -1,3 +1,4 @@
+# do not pre-load
 """Tests for the pdf_repair module.
 
 These tests exercise logic that does NOT require Ghostscript or ocrmypdf

--- a/docassemble/ALDashboard/test/test_review_screen_generator.py
+++ b/docassemble/ALDashboard/test/test_review_screen_generator.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 
 from docassemble.ALDashboard.review_screen_generator import generate_review_screen_yaml

--- a/docassemble/ALDashboard/test/test_translation_validation.py
+++ b/docassemble/ALDashboard/test/test_translation_validation.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 
 import pandas as pd

--- a/docassemble/ALDashboard/test/test_usage_heatmap.py
+++ b/docassemble/ALDashboard/test/test_usage_heatmap.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import ast
 import unittest
 from typing import Dict

--- a/docassemble/ALDashboard/test/test_yaml_formatter.py
+++ b/docassemble/ALDashboard/test/test_yaml_formatter.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import importlib
 import sys
 import types


### PR DESCRIPTION
Add # do not pre-load to prevent tests from slowing down startup time