### PR TITLE
Dont read unused translation columns

### DIFF
--- a/docassemble/ALDashboard/translation.py
+++ b/docassemble/ALDashboard/translation.py
@@ -304,10 +304,13 @@ def translation_file(
                 the_xlsx_file = docassemble.base.functions.package_data_filename(item)
                 if not os.path.isfile(the_xlsx_file):
                     continue
+                # Translation workbooks are fixed to A:H; keep reads narrow so stray cells
+                # in later columns do not inflate the imported sheet width.
                 df = pandas.read_excel(
                     the_xlsx_file,
                     na_values=["NaN", "-NaN", "#NA", "#N/A"],
                     keep_default_na=False,
+                    usecols="A:H",
                 )
                 invalid = False
                 for column_name in (

--- a/docassemble/ALDashboard/translation_validation.py
+++ b/docassemble/ALDashboard/translation_validation.py
@@ -155,5 +155,7 @@ def validate_translation_dataframe(df: pd.DataFrame) -> Dict[str, Any]:
 
 
 def validate_translation_xlsx(path: str) -> Dict[str, Any]:
-    df = pd.read_excel(path)
+    # Translation validation only needs the eight supported columns; revisit this if the
+    # upstream XLSX layout changes.
+    df = pd.read_excel(path, usecols="A:H")
     return validate_translation_dataframe(df)


### PR DESCRIPTION
Columns beyond H are not used by Docassemble, but leaving them in can slow down Docassemble.

I think these changes will just slightly speed up generation of new translations and validation of old ones, not prevent foot gun on new translations.