### PR TITLE
fix: preserve hyperlink position during run defragmentation (fixes #232)

### DIFF
--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -560,12 +560,17 @@ _SAFE_RUN_CHILD_TAGS = {
 }
 
 
-def _run_is_safe_to_defragment(run: Any) -> bool:
-    """Only merge plain-text runs that contain no fields, drawings, or other complex XML."""
-    for child in run._element:
+def _run_element_is_safe_to_defragment(run_element: Any) -> bool:
+    """Only merge plain-text <w:r> elements that contain no complex XML children."""
+    for child in run_element:
         if child.tag not in _SAFE_RUN_CHILD_TAGS:
             return False
     return True
+
+
+def _run_is_safe_to_defragment(run: Any) -> bool:
+    """Only merge plain-text runs that contain no fields, drawings, or other complex XML."""
+    return _run_element_is_safe_to_defragment(run._element)
 
 
 def _collect_paragraphs_from_table(
@@ -624,6 +629,10 @@ def defragment_docx_runs(
 ) -> Tuple[docx.document.Document, dict]:
     """Merge text-only runs within target paragraphs.
 
+    Only consecutive <w:r> siblings with no intervening non-run elements
+    (e.g. hyperlinks) are merged together.  This prevents hyperlinks and
+    other inline elements from being displaced from their original position.
+
     Args:
         document: A loaded ``python-docx`` document or a path to a DOCX file.
         paragraph_numbers: Optional paragraph indexes to limit defragmentation.
@@ -645,23 +654,43 @@ def defragment_docx_runs(
         "runs_removed": 0,
     }
 
+    w_r_tag = qn("w:r")
+
     for paragraph_number, paragraph in enumerate(_collect_target_paragraphs(document)):
         if target_paragraphs is not None and paragraph_number not in target_paragraphs:
             continue
 
-        runs = list(paragraph.runs)
-        if len(runs) <= 1:
-            continue
-        if not all(_run_is_safe_to_defragment(run) for run in runs):
-            continue
+        # Build groups of consecutive <w:r> direct children.  Any non-run
+        # sibling (e.g. <w:hyperlink>) ends the current group so that runs
+        # on opposite sides of such elements are never merged together.
+        run_groups: List[List[Any]] = []
+        current_group: List[Any] = []
+        for child in paragraph._element:
+            if child.tag == w_r_tag:
+                current_group.append(child)
+            else:
+                if current_group:
+                    run_groups.append(current_group)
+                    current_group = []
+        if current_group:
+            run_groups.append(current_group)
 
-        combined_text = "".join(run.text for run in runs)
-        runs[0].text = combined_text
-        for run in runs[1:]:
-            run._element.getparent().remove(run._element)
+        paragraph_changed = False
+        for group in run_groups:
+            if len(group) <= 1:
+                continue
+            if not all(_run_element_is_safe_to_defragment(el) for el in group):
+                continue
 
-        stats["paragraphs_defragmented"] += 1
-        stats["runs_removed"] += len(runs) - 1
+            combined_text = "".join(el.text for el in group)
+            group[0].text = combined_text
+            for el in group[1:]:
+                el.getparent().remove(el)
+                stats["runs_removed"] += 1
+            paragraph_changed = True
+
+        if paragraph_changed:
+            stats["paragraphs_defragmented"] += 1
 
     return document, stats
 

--- a/docassemble/ALDashboard/test/test_docx_wrangling.py
+++ b/docassemble/ALDashboard/test/test_docx_wrangling.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import tempfile
 import threading
 import time
+from typing import Any
 from unittest.mock import patch
 
 import docx
@@ -215,6 +216,62 @@ class TestDocxWranglingUpdateDocx(unittest.TestCase):
         self.assertEqual(len(updated.paragraphs[0].runs), 1)
         self.assertEqual(stats["paragraphs_defragmented"], 1)
         self.assertEqual(stats["runs_removed"], 2)
+
+    def test_defragment_docx_runs_preserves_hyperlink_position(self):
+        """Runs separated by a hyperlink must not be merged across it (issue #232)."""
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+
+        document = docx.Document()
+        paragraph = document.add_paragraph()
+
+        # Remove the empty run that add_paragraph creates
+        for el in list(paragraph._element):
+            if el.tag == qn("w:r"):
+                paragraph._element.remove(el)
+
+        def _make_run(text: str) -> Any:
+            r = OxmlElement("w:r")
+            t = OxmlElement("w:t")
+            t.text = text
+            r.append(t)
+            return r
+
+        def _make_hyperlink(text: str) -> Any:
+            hl = OxmlElement("w:hyperlink")
+            r = OxmlElement("w:r")
+            t = OxmlElement("w:t")
+            t.text = text
+            r.append(t)
+            hl.append(r)
+            return hl
+
+        # Structure: run("text ") + run("before ") + hyperlink("[link]")
+        #            + run(". text ") + run("after")
+        paragraph._element.append(_make_run("text "))
+        paragraph._element.append(_make_run("before "))
+        paragraph._element.append(_make_hyperlink("[link]"))
+        paragraph._element.append(_make_run(". text "))
+        paragraph._element.append(_make_run("after"))
+
+        updated, stats = defragment_docx_runs(document)
+
+        p = updated.paragraphs[0]
+        children = [c for c in p._element if c.tag != qn("w:pPr")]
+
+        # Hyperlink must remain in the middle, not be displaced to the end
+        self.assertEqual(children[0].tag, qn("w:r"), "first child should be a run")
+        self.assertEqual(
+            children[1].tag, qn("w:hyperlink"), "hyperlink must stay in position"
+        )
+        self.assertEqual(children[2].tag, qn("w:r"), "last child should be a run")
+        self.assertEqual(len(children), 3)
+
+        # Consecutive runs on each side of the hyperlink are merged
+        self.assertEqual(children[0].text, "text before ")
+        self.assertEqual(children[2].text, ". text after")
+        self.assertEqual(stats["runs_removed"], 2)
+        self.assertEqual(stats["paragraphs_defragmented"], 1)
 
     def test_update_docx_with_defragment_runs_handles_fragmented_fixture(self):
         fixture_path = Path(__file__).with_name("condo_deed.docx")


### PR DESCRIPTION
paragraph.runs returns all direct-child <w:r> elements across the whole paragraph, including runs on both sides of a <w:hyperlink>.  The old defragmenter merged ALL of them into the first run and removed the rest, leaving the hyperlink element at the end of the paragraph instead of its original position.

Change defragment_docx_runs to group consecutive <w:r> siblings and only merge within each group.  Any non-run sibling (hyperlink, bookmark, etc.) ends the current group, so runs separated by such elements are never merged across them.

Extract _run_element_is_safe_to_defragment that accepts a raw CT_R element and delegate _run_is_safe_to_defragment to it.  Add a regression test.