### PR TITLE
Story table generator migrated to Python/API/YAML dashboard

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -69,6 +69,7 @@ __all__ = [
     "install_fonts",
     "list_installed_fonts",
     "dashboard_get_session_variables",
+    "dashboard_find_session_filename",
     "dashboard_session_activity",
     "make_usage_rows",
     "compute_heatmap_styles",
@@ -625,6 +626,36 @@ def dashboard_get_session_variables(session_id: str, filename: str):
     """
     user_dict = get_session_variables(filename, session_id, secret=None, simplify=False)
     return serializable_dict(user_dict, include_internal=False)
+
+
+def dashboard_find_session_filename(session_id: str) -> Optional[str]:
+    """
+    Return the filename for a saved interview session key, when it can be
+    identified unambiguously.
+    """
+    session_id = str(session_id or "").strip()
+    if not session_id:
+        return None
+
+    find_session_query = text("""
+SELECT
+    filename,
+    MAX(modtime) AS modtime
+FROM
+    userdict
+WHERE
+    key = :session_id
+GROUP BY
+    filename
+ORDER BY
+    modtime DESC;
+        """)
+    with db.connect() as con:
+        rows = list(con.execute(find_session_query, {"session_id": session_id}))
+
+    if len(rows) == 1:
+        return str(rows[0].filename)
+    return None
 
 
 class ALPackageInstaller(DAObject):

--- a/docassemble/ALDashboard/alkiln_story.py
+++ b/docassemble/ALDashboard/alkiln_story.py
@@ -90,6 +90,8 @@ class StoryOptions:
     scenario_description: str = "Generated scenario"
     yaml_file_name: str = "interview.yml"
     question_id: str = "review_screen"
+    include_trigger_column: bool = False
+    synthesize_target_number: bool = True
     ignore_anywhere_in_var_name: Sequence[str] = tuple(
         DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME
     )
@@ -124,6 +126,8 @@ def _story_row(
     name: str,
     value: Any,
     ignore_anywhere: Sequence[str],
+    include_trigger_column: bool,
+    trigger: str = "",
 ) -> Optional[str]:
     if _is_ignored_name(name, ignore_anywhere):
         return None
@@ -138,7 +142,9 @@ def _story_row(
             "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/"
             "automated_integrated_testing/#there_is_another-loop --- "
         )
-    return f"| {name} | {value} |  |"
+    if include_trigger_column:
+        return f"| {name} | {value} | {trigger} |"
+    return f"| {name} | {value} |"
 
 
 def _parse_value(name: str, value: Any, options: StoryOptions) -> List[str]:
@@ -165,17 +171,27 @@ def _parse_object(
     rows: List[str] = []
     class_name = value.get("_class")
     is_class = isinstance(class_name, str) and "DADict" not in class_name
+    elements = value.get("elements")
 
     instance_name = value.get("instanceName")
     if isinstance(instance_name, str) and instance_name and name != instance_name:
         rows.extend(_single_row(name, instance_name, options))
 
+    if isinstance(elements, list) and options.synthesize_target_number:
+        rows.extend(_single_row(f"{name}.target_number", len(elements), options))
+
     if "elements" in value:
-        rows.extend(_parse_elements(name, value["elements"], options))
+        rows.extend(_parse_elements(name, elements, options))
 
     for key, item in value.items():
         key_text = str(key)
         if key_text == "elements":
+            continue
+        if (
+            options.synthesize_target_number
+            and isinstance(elements, list)
+            and key_text in {"there_are_any", "there_is_another", "target_number"}
+        ):
             continue
         if key_text in options.ignore_if_is_key or _is_ignored_name(
             key_text, options.ignore_anywhere_in_var_name
@@ -232,6 +248,7 @@ def _single_row(name: str, value: Any, options: StoryOptions) -> List[str]:
         name=name,
         value=formatted_value,
         ignore_anywhere=options.ignore_anywhere_in_var_name,
+        include_trigger_column=options.include_trigger_column,
     )
     return [row] if row else []
 
@@ -257,6 +274,82 @@ def default_yaml_file_name(
     return fallback
 
 
+def load_docassemble_json_text(json_text: str) -> Dict[str, Any]:
+    """Load docassemble's variables JSON from pasted textarea text.
+
+    Some docassemble textarea submissions can contain literal control
+    characters inside string values where the original exported JSON had
+    escaped sequences such as ``\r\n``. Python's default JSON parser rejects
+    that, while the story generator should still accept the pasted export.
+    """
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError:
+        try:
+            data = json.loads(json_text, strict=False)
+        except json.JSONDecodeError:
+            data = json.loads(
+                _escape_likely_unescaped_inner_quotes(json_text),
+                strict=False,
+            )
+    if not isinstance(data, dict):
+        raise ValueError("Docassemble JSON must be a JSON object.")
+    return data
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    slash_count = 0
+    pos = index - 1
+    while pos >= 0 and text[pos] == "\\":
+        slash_count += 1
+        pos -= 1
+    return slash_count % 2 == 1
+
+
+def _next_non_space(text: str, start: int) -> tuple[int, str]:
+    pos = start
+    while pos < len(text) and text[pos] in " \t\r\n":
+        pos += 1
+    if pos >= len(text):
+        return pos, ""
+    return pos, text[pos]
+
+
+def _escape_likely_unescaped_inner_quotes(json_text: str) -> str:
+    """Escape quotes that look like text inside a JSON string value.
+
+    This is intentionally a fallback for pasted docassemble exports. It leaves
+    normal JSON alone and handles textarea-shaped input where escaped quotes in
+    large descriptive strings have become bare quotes.
+    """
+    output: List[str] = []
+    in_string = False
+    for index, char in enumerate(json_text):
+        if char != '"' or _is_escaped(json_text, index):
+            output.append(char)
+            continue
+
+        if not in_string:
+            in_string = True
+            output.append(char)
+            continue
+
+        _next_index, next_char = _next_non_space(json_text, index + 1)
+        closes_string = next_char in {"", ":", "}", "]"}
+        if next_char == ",":
+            _after_comma_index, after_comma_char = _next_non_space(
+                json_text, _next_index + 1
+            )
+            closes_string = after_comma_char in {'"', "}", "]"}
+
+        if closes_string:
+            in_string = False
+            output.append(char)
+        else:
+            output.append('\\"')
+    return "".join(output)
+
+
 def build_feature_text(rows: Sequence[str], options: StoryOptions) -> str:
     lines = [
         f"Feature: {options.feature_description or options.scenario_description}",
@@ -264,8 +357,11 @@ def build_feature_text(rows: Sequence[str], options: StoryOptions) -> str:
         f"Scenario: {options.scenario_description}",
         f'  Given I start the interview at "{options.yaml_file_name}"',
         f'  And the user gets to "{options.question_id}" with this data:',
-        "    | var | value | trigger |",
     ]
+    if options.include_trigger_column:
+        lines.append("    | var | value | trigger |")
+    else:
+        lines.append("    | var | value |")
     lines.extend(f"    {row}" for row in rows)
     return "\n".join(lines)
 

--- a/docassemble/ALDashboard/alkiln_story.py
+++ b/docassemble/ALDashboard/alkiln_story.py
@@ -14,16 +14,28 @@ DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME = [
     "al_version",
     "al_session_store_default_filename",
     "all_answer_sets",
+    "all_reserved_names",
+    "all_template_fields",
+    "al_interview_languages",
+    "al_name_suffixes",
+    "al_name_titles",
     "menu_items",
     "._",
     "_attachment",
     "_bundle",
+    "available_efile_courts",
+    "available_templates",
+    "combined_fields",
     "court_emails",
+    "document_templates",
     "download_titles",
     "form_approved_for_email_filing",
     "github_user",
     "interview_metadata",
     "interview_short_title",
+    "just_bmc_courts",
+    "just_district_courts",
+    "legalserver_data",
     "macourts",
     "package_name",
     "package_version_number",
@@ -48,6 +60,7 @@ DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME = [
     "_internal",
     "nav",
     "url_args",
+    "valid_housing_courts",
     "_class",
     "auto_gather",
     "instanceName",
@@ -73,6 +86,79 @@ DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME = [
     "complete_attribute",
 ]
 
+DEFAULT_IGNORE_IF_TOP_LEVEL_KEY = [
+    "DA",
+    "DABreadCrumbs",
+    "DAGlobal",
+    "DAGoogleAPI",
+    "DAOAuth",
+    "DARedis",
+    "DAValidationError",
+    "DAWeb",
+    "DAWebError",
+    "STOP_RENDERING",
+    "_attachment_email_address",
+    "_attachment_include_editable",
+    "_back_one",
+    "_checkboxes",
+    "_datatypes",
+    "_email_attachments",
+    "_files",
+    "_question_name",
+    "_question_number",
+    "_save_as",
+    "_success",
+    "_the_image",
+    "_track_location",
+    "_tracker",
+    "_varnames",
+    "action_arguments",
+    "background_error_action",
+    "chat_partners_available",
+    "command",
+    "countries_list",
+    "device",
+    "device_local",
+    "dispatch",
+    "incoming_email",
+    "interface",
+    "interview_email",
+    "json_response",
+    "last_access_days",
+    "last_access_delta",
+    "last_access_hours",
+    "last_access_minutes",
+    "last_access_time",
+    "location_known",
+    "location_returned",
+    "logic_explanation",
+    "message",
+    "multi_user",
+    "prevent_going_back",
+    "raw",
+    "referring_url",
+    "returning_user",
+    "role",
+    "role_event",
+    "role_needed",
+    "section_links",
+    "server_capabilities",
+    "session_local",
+    "session_tags",
+    "start_time",
+    "task_not_yet_performed",
+    "task_performed",
+    "track_location",
+    "url_args",
+    "user_dict",
+    "user_info",
+    "user_lat_lon",
+    "user_local",
+    "user_logged_in",
+    "user_privileges",
+    "will_send_to_real_court",
+]
+
 DEFAULT_IGNORE_IF_IS_KEY = [
     "all_courts",
     "alt_text",
@@ -81,6 +167,57 @@ DEFAULT_IGNORE_IF_IS_KEY = [
     "object_type",
     "gathered",
     "minimum_number",
+    # Imported names used only for Python type annotations can be serialized
+    # into docassemble variables, but they are not interview answers.
+    "Annotated",
+    "Any",
+    "Callable",
+    "ClassVar",
+    "Concatenate",
+    "Dict",
+    "Fields",
+    "Final",
+    "ForwardRef",
+    "FrozenSet",
+    "Generic",
+    "Iterable",
+    "Iterator",
+    "List",
+    "Literal",
+    "Mapping",
+    "MutableMapping",
+    "MutableSequence",
+    "MutableSet",
+    "NewType",
+    "NoReturn",
+    "NotRequired",
+    "Optional",
+    "ParamSpec",
+    "Protocol",
+    "Required",
+    "Sequence",
+    "Set",
+    "Self",
+    "Tuple",
+    "Type",
+    "TypeAlias",
+    "TypeGuard",
+    "TypeVar",
+    "TypedDict",
+    "Union",
+    "Unpack",
+]
+
+DEFAULT_IGNORE_IF_CLASS_NAME_CONTAINS = [
+    "docassemble.AssemblyLine.al_document.DALazyAttribute",
+    "docassemble.base.util.DACloudStorage",
+    "docassemble.base.util.DAFile",
+    "docassemble.base.util.DAFileCollection",
+    "docassemble.base.util.DAFileList",
+    "docassemble.base.util.DALazyTemplate",
+    "docassemble.base.util.DAStaticFile",
+    "docassemble.base.util.DAStore",
+    "S3Backend",
 ]
 
 
@@ -95,7 +232,11 @@ class StoryOptions:
     ignore_anywhere_in_var_name: Sequence[str] = tuple(
         DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME
     )
+    ignore_if_top_level_key: Sequence[str] = tuple(DEFAULT_IGNORE_IF_TOP_LEVEL_KEY)
     ignore_if_is_key: Sequence[str] = tuple(DEFAULT_IGNORE_IF_IS_KEY)
+    ignore_if_class_name_contains: Sequence[str] = tuple(
+        DEFAULT_IGNORE_IF_CLASS_NAME_CONTAINS
+    )
 
 
 def _format_value(value: Any) -> Any:
@@ -111,6 +252,13 @@ def _format_value(value: Any) -> Any:
 
 def _is_ignored_name(name: str, ignore_anywhere: Sequence[str]) -> bool:
     return any(to_ignore and to_ignore in name for to_ignore in ignore_anywhere)
+
+
+def _is_ignored_class(value: Mapping[str, Any], ignore_classes: Sequence[str]) -> bool:
+    class_name = value.get("_class")
+    return isinstance(class_name, str) and any(
+        to_ignore and to_ignore in class_name for to_ignore in ignore_classes
+    )
 
 
 def _object_name(is_class: bool, name: str, key: str) -> str:
@@ -148,11 +296,21 @@ def _story_row(
 
 
 def _parse_value(name: str, value: Any, options: StoryOptions) -> List[str]:
+    if not name and isinstance(value, Mapping):
+        rows: List[str] = []
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text in options.ignore_if_top_level_key:
+                continue
+            rows.extend(_parse_value(key_text, item, options))
+        return rows
     if name in options.ignore_if_is_key or _is_ignored_name(
         name, options.ignore_anywhere_in_var_name
     ):
         return []
     if isinstance(value, Mapping):
+        if _is_ignored_class(value, options.ignore_if_class_name_contains):
+            return []
         return _parse_object(name, value, options)
     if isinstance(value, list):
         return _parse_array(name, value, options)
@@ -257,7 +415,12 @@ def rows_from_variables(
     variables: Mapping[str, Any], *, options: Optional[StoryOptions] = None
 ) -> List[str]:
     story_options = options or StoryOptions()
-    all_rows = _parse_value("", variables, story_options)
+    all_rows: List[str] = []
+    for key, item in variables.items():
+        key_text = str(key)
+        if key_text in story_options.ignore_if_top_level_key:
+            continue
+        all_rows.extend(_parse_value(key_text, item, story_options))
     rows: List[str] = []
     for row in all_rows:
         if isinstance(row, str) and row not in rows:

--- a/docassemble/ALDashboard/alkiln_story.py
+++ b/docassemble/ALDashboard/alkiln_story.py
@@ -520,8 +520,10 @@ def rows_from_variables(
             continue
         all_rows.extend(_parse_value(key_text, item, story_options))
     rows: List[str] = []
+    seen_rows: set[str] = set()
     for row in all_rows:
-        if isinstance(row, str) and row not in rows:
+        if isinstance(row, str) and row not in seen_rows:
+            seen_rows.add(row)
             rows.append(row)
     return rows
 
@@ -631,8 +633,7 @@ def build_feature_preview_markdown(feature_text: str) -> str:
     """Format feature text for docassemble's markdown preview as a code block."""
     normalized_text = str(feature_text).replace("\r\n", "\n").replace("\r", "\n")
     return "\n".join(
-        "    " if line == "" else f"    {line}"
-        for line in normalized_text.split("\n")
+        "    " if line == "" else f"    {line}" for line in normalized_text.split("\n")
     )
 
 
@@ -741,7 +742,9 @@ def load_docassemble_yaml_text(
     for doc in docs:
         expanded_docs.append(doc)
         for include_ref in _iter_include_strings(doc.get("include")):
-            include_path = _resolve_local_include_path(include_ref, normalized_source_path)
+            include_path = _resolve_local_include_path(
+                include_ref, normalized_source_path
+            )
             if not include_path or include_path in seen_paths:
                 continue
             try:
@@ -936,20 +939,26 @@ def _should_skip_heuristic_variable(name: str) -> bool:
     )
 
 
-def _add_related_variable_rows(rows: List[str], name: str, options: StoryOptions) -> None:
+def _add_related_variable_rows(
+    rows: List[str], name: str, options: StoryOptions
+) -> None:
     normalized_name = _normalize_index_placeholders(name)
     if normalized_name.endswith(".name.first"):
         _add_unique_row(
             rows,
             normalized_name[: -len(".first")] + ".last",
-            _default_value_for_variable_name(normalized_name[: -len(".first")] + ".last"),
+            _default_value_for_variable_name(
+                normalized_name[: -len(".first")] + ".last"
+            ),
             options,
         )
     elif normalized_name.endswith(".address.address"):
         base = normalized_name[: -len(".address")]
         for suffix in (".city", ".state", ".zip"):
             field_name = base + suffix
-            _add_unique_row(rows, field_name, _default_value_for_variable_name(field_name), options)
+            _add_unique_row(
+                rows, field_name, _default_value_for_variable_name(field_name), options
+            )
     elif normalized_name.endswith(".target_number"):
         list_name = normalized_name[: -len(".target_number")]
         _add_people_list_rows(rows, list_name, options)
@@ -1019,15 +1028,26 @@ def _field_rows(variable: str, field_info: Mapping[str, Any]) -> List[tuple[str,
         for index, choice in enumerate(choices):
             if isinstance(choice, (str, int, float, bool)):
                 checkbox_rows.append(
-                    (f"{normalized_variable}['{choice}']", True if index == 0 else False)
+                    (
+                        f"{normalized_variable}['{choice}']",
+                        True if index == 0 else False,
+                    )
                 )
         if checkbox_rows:
             return checkbox_rows
     first_choice = _first_choice_value(field_info)
-    if first_choice is not None and datatype not in {"yesno", "yesnowide", "truefalse", "boolean"}:
+    if first_choice is not None and datatype not in {
+        "yesno",
+        "yesnowide",
+        "truefalse",
+        "boolean",
+    }:
         return [(normalized_variable, first_choice)]
     return [
-        (normalized_variable, _default_value_for_yaml_field(normalized_variable, field_info))
+        (
+            normalized_variable,
+            _default_value_for_yaml_field(normalized_variable, field_info),
+        )
     ]
 
 
@@ -1121,24 +1141,32 @@ def _add_people_list_rows(
     rows: List[str], list_name: str, options: StoryOptions, *, target_number: int = 1
 ) -> None:
     normalized_list_name = _normalize_index_placeholders(list_name)
-    _add_unique_row(rows, f"{normalized_list_name}.target_number", target_number, options)
+    _add_unique_row(
+        rows, f"{normalized_list_name}.target_number", target_number, options
+    )
     _add_unique_row(rows, f"{normalized_list_name}[0].name.first", "Jane", options)
     _add_unique_row(rows, f"{normalized_list_name}[0].name.last", "Smith", options)
 
 
-def _doc_field_variable_and_info(doc: Mapping[str, Any]) -> tuple[Optional[str], Dict[str, Any]]:
+def _doc_field_variable_and_info(
+    doc: Mapping[str, Any],
+) -> tuple[Optional[str], Dict[str, Any]]:
     explicit = doc.get("field")
     if not _looks_like_variable_name(explicit):
         return (None, {})
     field_info = {
-        str(key): value for key, value in doc.items() if str(key) not in DOC_NON_FIELD_KEYS
+        str(key): value
+        for key, value in doc.items()
+        if str(key) not in DOC_NON_FIELD_KEYS
     }
     return (str(explicit).strip(), field_info)
 
 
 def _set_variables_from_doc(doc: Mapping[str, Any]) -> List[str]:
     variables: List[str] = []
-    has_prompt = isinstance(doc.get("question"), str) or isinstance(doc.get("subquestion"), str)
+    has_prompt = isinstance(doc.get("question"), str) or isinstance(
+        doc.get("subquestion"), str
+    )
     if not has_prompt:
         return variables
     for key in ("sets", "only sets"):
@@ -1154,7 +1182,9 @@ def _set_variables_from_doc(doc: Mapping[str, Any]) -> List[str]:
 
 def _resolve_code_reference(text: str, aliases: Mapping[str, str]) -> str:
     cleaned = text.strip()
-    for alias, replacement in sorted(aliases.items(), key=lambda item: len(item[0]), reverse=True):
+    for alias, replacement in sorted(
+        aliases.items(), key=lambda item: len(item[0]), reverse=True
+    ):
         if cleaned == alias or cleaned.startswith(alias + "."):
             cleaned = replacement + cleaned[len(alias) :]
             break
@@ -1190,7 +1220,9 @@ def _parse_simple_python_expression(expression: str) -> Optional[Any]:
     return None
 
 
-def _parse_method_call_arguments(arguments_text: str) -> tuple[List[Any], Dict[str, Any]]:
+def _parse_method_call_arguments(
+    arguments_text: str,
+) -> tuple[List[Any], Dict[str, Any]]:
     if not arguments_text.strip():
         return ([], {})
     try:
@@ -1248,10 +1280,10 @@ def _al_fields_method_rows(
             if normalized_object_name.endswith(".address")
             else f"{normalized_object_name}.address"
         )
-        rows: List[tuple[str, Any]] = []
+        address_rows: List[tuple[str, Any]] = []
         if kwargs.get("allow_no_address") is True:
-            rows.append((f"{address_root}.has_no_address", False))
-        rows.extend(
+            address_rows.append((f"{address_root}.has_no_address", False))
+        address_rows.extend(
             [
                 (f"{address_root}.address", "123 Main St"),
                 (f"{address_root}.unit", "Sample answer"),
@@ -1261,12 +1293,12 @@ def _al_fields_method_rows(
             ]
         )
         if kwargs.get("show_county") is True:
-            rows.append((f"{address_root}.county", "Suffolk"))
+            address_rows.append((f"{address_root}.county", "Suffolk"))
         if kwargs.get("show_country") is True:
-            rows.append((f"{address_root}.country", "US"))
+            address_rows.append((f"{address_root}.country", "US"))
         if kwargs.get("ask_if_impounded") is True:
-            rows.append((f"{address_root}.impounded", False))
-        return rows
+            address_rows.append((f"{address_root}.impounded", False))
+        return address_rows
     if method_name == "gender_fields":
         return [(f"{normalized_object_name}.gender", "female")]
     if method_name == "language_fields":
@@ -1407,7 +1439,9 @@ def rows_from_yaml_heuristics(
 
         single_field_variable, single_field_info = _doc_field_variable_and_info(doc)
         if single_field_variable:
-            for row_name, row_value in _field_rows(single_field_variable, single_field_info):
+            for row_name, row_value in _field_rows(
+                single_field_variable, single_field_info
+            ):
                 _add_inferred_row(
                     rows,
                     row_name,

--- a/docassemble/ALDashboard/alkiln_story.py
+++ b/docassemble/ALDashboard/alkiln_story.py
@@ -1,8 +1,13 @@
+import ast
+import glob
 import json
+import os
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+
+from ruamel.yaml import YAML
 
 DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME = [
     "AL_DEFAULT_COUNTRY",
@@ -237,6 +242,99 @@ class StoryOptions:
     ignore_if_class_name_contains: Sequence[str] = tuple(
         DEFAULT_IGNORE_IF_CLASS_NAME_CONTAINS
     )
+
+
+COMMON_AL_PEOPLE_LISTS = {
+    "users",
+    "other_parties",
+    "children",
+    "parents",
+    "spouses",
+    "guardians",
+    "caregivers",
+    "attorneys",
+    "witnesses",
+    "translators",
+    "interested_parties",
+    "decedents",
+    "adoptees",
+    "creditors",
+    "debt_collectors",
+    "chiropractors",
+    "defendants",
+    "respondents",
+    "plaintiffs",
+    "petitioners",
+}
+
+FIELD_NON_VARIABLE_KEYS = {
+    "label",
+    "datatype",
+    "input type",
+    "required",
+    "required if",
+    "show if",
+    "hide if",
+    "code",
+    "default",
+    "help",
+    "hint",
+    "note",
+    "html",
+    "under text",
+    "maxlength",
+    "minlength",
+    "min",
+    "max",
+    "step",
+    "validation messages",
+    "choice variable",
+    "choices",
+    "none of the above",
+    "address autocomplete",
+    "disable others",
+    "js show if",
+    "js hide if",
+    "field",
+}
+
+
+DOC_NON_FIELD_KEYS = {
+    "id",
+    "question",
+    "subquestion",
+    "event",
+    "mandatory",
+    "comment",
+    "help",
+    "under",
+    "progress",
+    "section",
+    "sections",
+    "review",
+    "attachment",
+    "template",
+    "content",
+    "table",
+    "buttons",
+    "continue button field",
+    "validation code",
+    "decorations",
+    "decoration",
+    "features",
+    "metadata",
+    "include",
+    "modules",
+    "objects",
+    "code",
+    "language",
+    "translations",
+    "terms",
+    "default screen parts",
+    "depends on",
+    "sets",
+    "only sets",
+}
 
 
 def _format_value(value: Any) -> Any:
@@ -529,6 +627,15 @@ def build_feature_text(rows: Sequence[str], options: StoryOptions) -> str:
     return "\n".join(lines)
 
 
+def build_feature_preview_markdown(feature_text: str) -> str:
+    """Format feature text for docassemble's markdown preview as a code block."""
+    normalized_text = str(feature_text).replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(
+        "    " if line == "" else f"    {line}"
+        for line in normalized_text.split("\n")
+    )
+
+
 def story_from_docassemble_json(
     data: Mapping[str, Any], *, options: Optional[StoryOptions] = None
 ) -> Dict[str, Any]:
@@ -539,12 +646,856 @@ def story_from_docassemble_json(
             "Docassemble JSON must be an object or contain variables object."
         )
     rows = rows_from_variables(variables, options=story_options)
+    feature_text = build_feature_text(rows, story_options)
     return {
         "rows": rows,
-        "feature_text": build_feature_text(rows, story_options),
+        "feature_text": feature_text,
+        "preview_markdown": build_feature_preview_markdown(feature_text),
         "row_count": len(rows),
         "yaml_file_name": story_options.yaml_file_name,
         "question_id": story_options.question_id,
         "feature_description": story_options.feature_description,
         "scenario_description": story_options.scenario_description,
+    }
+
+
+def _load_yaml_documents(yaml_text: Any) -> List[Mapping[str, Any]]:
+    if isinstance(yaml_text, (bytes, bytearray)):
+        yaml_text = bytes(yaml_text).decode("utf-8", errors="replace")
+    yaml = YAML(typ="safe")
+    yaml.allow_duplicate_keys = True
+    docs = []
+    for doc in yaml.load_all(yaml_text):
+        if isinstance(doc, Mapping):
+            docs.append(doc)
+    return docs
+
+
+def _repo_root_for_path(path: str) -> str:
+    current = os.path.abspath(os.path.dirname(path))
+    while True:
+        if os.path.isdir(os.path.join(current, ".git")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return os.path.abspath(os.path.dirname(path))
+        current = parent
+
+
+def _iter_include_strings(include_value: Any) -> List[str]:
+    if isinstance(include_value, str):
+        return [include_value]
+    if isinstance(include_value, list):
+        return [item for item in include_value if isinstance(item, str)]
+    return []
+
+
+def _resolve_local_include_path(include_ref: str, source_path: str) -> Optional[str]:
+    include_ref = str(include_ref or "").strip()
+    if not include_ref:
+        return None
+    source_dir = os.path.dirname(os.path.abspath(source_path))
+    if ":" not in include_ref:
+        candidate = os.path.abspath(os.path.join(source_dir, include_ref))
+        return candidate if os.path.exists(candidate) else None
+
+    package_name, relative_path = include_ref.split(":", 1)
+    relative_path = relative_path.strip()
+    if not relative_path:
+        return None
+    package_path = os.path.join(*package_name.split("."))
+    home_dir = os.path.expanduser("~")
+    repo_root = _repo_root_for_path(source_path)
+    search_patterns = [
+        os.path.join(repo_root, package_path, relative_path),
+        os.path.join(repo_root, package_path, "data", "questions", relative_path),
+        os.path.join(home_dir, "docassemble-*", package_path, relative_path),
+        os.path.join(
+            home_dir, "docassemble-*", package_path, "data", "questions", relative_path
+        ),
+    ]
+    for pattern in search_patterns:
+        for candidate in glob.glob(pattern):
+            if os.path.exists(candidate):
+                return os.path.abspath(candidate)
+    return None
+
+
+def load_docassemble_yaml_text(
+    yaml_text: Any,
+    *,
+    source_path: Optional[str] = None,
+    _seen_paths: Optional[set[str]] = None,
+) -> List[Mapping[str, Any]]:
+    docs = _load_yaml_documents(yaml_text)
+    if not source_path or not os.path.exists(source_path):
+        return docs
+
+    seen_paths = _seen_paths if _seen_paths is not None else set()
+    normalized_source_path = os.path.abspath(source_path)
+    if normalized_source_path in seen_paths:
+        return docs
+    seen_paths.add(normalized_source_path)
+
+    expanded_docs: List[Mapping[str, Any]] = []
+    for doc in docs:
+        expanded_docs.append(doc)
+        for include_ref in _iter_include_strings(doc.get("include")):
+            include_path = _resolve_local_include_path(include_ref, normalized_source_path)
+            if not include_path or include_path in seen_paths:
+                continue
+            try:
+                with open(include_path, "r", encoding="utf-8") as include_file:
+                    expanded_docs.extend(
+                        load_docassemble_yaml_text(
+                            include_file.read(),
+                            source_path=include_path,
+                            _seen_paths=seen_paths,
+                        )
+                    )
+            except OSError:
+                continue
+    return expanded_docs
+
+
+def _clean_yaml_filename(filename: str, fallback: str = "interview.yml") -> str:
+    filename = str(filename or "").strip()
+    if not filename:
+        return fallback
+    if ":" in filename:
+        return filename.rsplit(":", 1)[-1].split("/")[-1] or fallback
+    return os.path.basename(filename) or fallback
+
+
+def _looks_like_variable_name(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text or "${" in text or "\n" in text:
+        return False
+    if text.startswith(("if ", "for ", "while ", "return ")):
+        return False
+    return bool(
+        re.match(
+            r"^[A-Za-z_][\w]*(?:\[[^\]\n]+\]|\.[A-Za-z_][\w]*|\[['\"][^'\"]+['\"]\])*$",
+            text,
+        )
+    )
+
+
+def _default_value_for_field(field_info: Mapping[str, Any]) -> Any:
+    if "default" in field_info and field_info.get("default") not in (None, ""):
+        value = field_info.get("default")
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (str, int, float)):
+            normalized_value = _normalize_yaml_default_value(value)
+            if normalized_value is not None:
+                return normalized_value
+    datatype = str(field_info.get("datatype") or "").strip().lower()
+    input_type = str(field_info.get("input type") or "").strip().lower()
+    if datatype in {"yesno", "yesnowide", "truefalse", "boolean"}:
+        return True
+    if datatype in {"integer", "number", "float", "currency", "range"}:
+        return 1
+    if datatype == "date":
+        return "01/02/2026"
+    if input_type in {"checkboxes", "checkbox"}:
+        return True
+    if input_type in {"email"}:
+        return "user@example.com"
+    return "Sample answer"
+
+
+def _field_labels(field_info: Mapping[str, Any]) -> List[str]:
+    labels: List[str] = []
+    for key, value in field_info.items():
+        key_text = str(key).strip()
+        if key_text in FIELD_NON_VARIABLE_KEYS or key_text == "field":
+            continue
+        if isinstance(value, str) and _looks_like_variable_name(value):
+            labels.append(key_text)
+    return labels
+
+
+def _example_value_from_field_info(field_info: Mapping[str, Any]) -> Optional[str]:
+    for key in ("under text", "hint", "help", "note"):
+        value = field_info.get(key)
+        if not isinstance(value, str):
+            continue
+        match = re.search(r"(?:example|e\.g\.)\s*:\s*([A-Za-z0-9 .'-]+)", value, re.I)
+        if match:
+            return match.group(1).strip().strip(".")
+    return None
+
+
+def _default_value_for_yaml_field(variable: str, field_info: Mapping[str, Any]) -> Any:
+    base_value = _default_value_for_field(field_info)
+    if base_value != "Sample answer":
+        return base_value
+
+    example_value = _example_value_from_field_info(field_info)
+    if example_value:
+        return example_value
+
+    labels = " ".join(_field_labels(field_info)).lower()
+    variable_name = variable.lower()
+    if "year" in labels or variable_name.endswith("_year"):
+        return "2023"
+
+    min_length = field_info.get("minlength")
+    if isinstance(min_length, int) and min_length > 0:
+        fill = "1" if "vin" in labels or variable_name == "vin" else "A"
+        return fill * min_length
+
+    return _default_value_for_variable_name(variable)
+
+
+def _normalize_index_placeholders(name: str) -> str:
+    return re.sub(r"\[[A-Za-z_][A-Za-z0-9_]*\]", "[0]", name)
+
+
+def _normalize_yaml_default_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip()
+    expression_match = re.fullmatch(r"\$\{\s*(.*?)\s*\}", normalized)
+    expression = expression_match.group(1).strip() if expression_match else normalized
+    if expression in {"today()", "today"}:
+        return "today"
+    if expression_match:
+        return None
+    return value
+
+
+def _add_unique_row(
+    rows: List[str], name: str, value: Any, options: StoryOptions
+) -> None:
+    normalized_name = _normalize_index_placeholders(name)
+    if not _looks_like_variable_name(normalized_name):
+        return
+    row_items = _single_row(normalized_name, value, options)
+    for row in row_items:
+        if row not in rows:
+            rows.append(row)
+
+
+def _default_value_for_variable_name(name: str) -> Any:
+    if name.endswith(".signature"):
+        return "/placeholder_signature.png"
+    if name.endswith(".name.title"):
+        return "Mr."
+    if name.endswith(".name.first"):
+        return "Jane"
+    if name.endswith(".name.last"):
+        return "Smith"
+    if name.endswith(".name.suffix"):
+        return "Jr."
+    if name.endswith(".address.address"):
+        return "123 Main St"
+    if name.endswith(".address.city"):
+        return "Boston"
+    if name.endswith(".address.state"):
+        return "MA"
+    if name.endswith(".address.zip"):
+        return "02108"
+    if name.endswith(".address.county"):
+        return "Suffolk"
+    if name.endswith(".address.country"):
+        return "US"
+    if name.endswith(".address.has_no_address"):
+        return False
+    if name.endswith(".address.impounded"):
+        return False
+    if name.endswith(".email"):
+        return "user@example.com"
+    if name.endswith(".phone_number"):
+        return "6175551212"
+    if name.endswith(".gender"):
+        return "female"
+    if name.endswith(".language"):
+        return "en"
+    if name.endswith(".language_other"):
+        return "Spanish"
+    if name.endswith(".person_type"):
+        return "ALIndividual"
+    return "Sample answer"
+
+
+def _should_skip_heuristic_variable(name: str) -> bool:
+    normalized_name = _normalize_index_placeholders(name)
+    lower_name = normalized_name.lower()
+    return (
+        lower_name.startswith("al_")
+        or normalized_name.startswith("AL_")
+        or lower_name.startswith("share_interview_")
+        or lower_name.startswith("tell_a_friend_")
+        or lower_name.startswith("trial_court_address.")
+        or lower_name.startswith("appeals_court_address.")
+        or lower_name.endswith(".there_is_another")
+    )
+
+
+def _add_related_variable_rows(rows: List[str], name: str, options: StoryOptions) -> None:
+    normalized_name = _normalize_index_placeholders(name)
+    if normalized_name.endswith(".name.first"):
+        _add_unique_row(
+            rows,
+            normalized_name[: -len(".first")] + ".last",
+            _default_value_for_variable_name(normalized_name[: -len(".first")] + ".last"),
+            options,
+        )
+    elif normalized_name.endswith(".address.address"):
+        base = normalized_name[: -len(".address")]
+        for suffix in (".city", ".state", ".zip"):
+            field_name = base + suffix
+            _add_unique_row(rows, field_name, _default_value_for_variable_name(field_name), options)
+    elif normalized_name.endswith(".target_number"):
+        list_name = normalized_name[: -len(".target_number")]
+        _add_people_list_rows(rows, list_name, options)
+
+
+def _add_inferred_row(
+    rows: List[str],
+    name: str,
+    value: Any,
+    options: StoryOptions,
+    *,
+    with_related: bool = True,
+    overwrite_existing_variable: bool = False,
+) -> None:
+    normalized_name = _normalize_index_placeholders(name)
+    if _should_skip_heuristic_variable(normalized_name):
+        return
+    if not overwrite_existing_variable:
+        prefix = f"| {normalized_name} |"
+        if any(row.startswith(prefix) for row in rows):
+            return
+    resolved_value = value
+    if resolved_value in (None, "", "Sample answer"):
+        resolved_value = _default_value_for_variable_name(normalized_name)
+    _add_unique_row(rows, normalized_name, resolved_value, options)
+    if with_related:
+        _add_related_variable_rows(rows, normalized_name, options)
+
+
+def _choice_entries(field_info: Mapping[str, Any]) -> List[Any]:
+    choices = field_info.get("choices")
+    if isinstance(choices, list):
+        entries: List[Any] = []
+        for choice in choices:
+            if isinstance(choice, Mapping):
+                if "value" in choice:
+                    entries.append(choice.get("value"))
+                elif len(choice) == 1:
+                    entries.append(next(iter(choice.values())))
+            else:
+                entries.append(choice)
+        return [item for item in entries if item not in (None, "")]
+    return []
+
+
+def _first_choice_value(field_info: Mapping[str, Any]) -> Optional[Any]:
+    for choice in _choice_entries(field_info):
+        if isinstance(choice, (str, int, float, bool)):
+            return _normalize_yaml_default_value(choice)
+    buttons = field_info.get("buttons")
+    if isinstance(buttons, list):
+        for button in buttons:
+            if isinstance(button, Mapping) and button.get("value") is not None:
+                value = button.get("value")
+                if isinstance(value, (str, int, float, bool)):
+                    return value
+    return None
+
+
+def _field_rows(variable: str, field_info: Mapping[str, Any]) -> List[tuple[str, Any]]:
+    normalized_variable = _normalize_index_placeholders(variable)
+    datatype = str(field_info.get("datatype") or "").strip().lower()
+    input_type = str(field_info.get("input type") or "").strip().lower()
+    if datatype == "checkboxes" or input_type == "checkboxes":
+        checkbox_rows: List[tuple[str, Any]] = []
+        choices = _choice_entries(field_info)
+        for index, choice in enumerate(choices):
+            if isinstance(choice, (str, int, float, bool)):
+                checkbox_rows.append(
+                    (f"{normalized_variable}['{choice}']", True if index == 0 else False)
+                )
+        if checkbox_rows:
+            return checkbox_rows
+    first_choice = _first_choice_value(field_info)
+    if first_choice is not None and datatype not in {"yesno", "yesnowide", "truefalse", "boolean"}:
+        return [(normalized_variable, first_choice)]
+    return [
+        (normalized_variable, _default_value_for_yaml_field(normalized_variable, field_info))
+    ]
+
+
+def _field_variable_and_info(field: Any) -> tuple[Optional[str], Dict[str, Any]]:
+    if isinstance(field, str):
+        return (field.strip(), {})
+    if not isinstance(field, Mapping):
+        return (None, {})
+    field_info = dict(field)
+    explicit = field.get("field")
+    if _looks_like_variable_name(explicit):
+        return (str(explicit).strip(), field_info)
+    for key, value in field.items():
+        key_text = str(key).strip()
+        if key_text in FIELD_NON_VARIABLE_KEYS:
+            continue
+        if _looks_like_variable_name(value):
+            return (str(value).strip(), field_info)
+    return (None, field_info)
+
+
+def _declared_al_people_lists(docs: Sequence[Mapping[str, Any]]) -> set[str]:
+    people_lists = set(COMMON_AL_PEOPLE_LISTS)
+    people_lists.update(_assemblyline_people_lists_from_checkout())
+    for doc in docs:
+        objects = doc.get("objects")
+        if not isinstance(objects, list):
+            continue
+        for item in objects:
+            if not isinstance(item, Mapping):
+                continue
+            for name, class_info in item.items():
+                if "ALPeopleList" in str(class_info) and _looks_like_variable_name(
+                    name
+                ):
+                    people_lists.add(_normalize_index_placeholders(str(name).strip()))
+    return people_lists
+
+
+def _assemblyline_people_lists_from_checkout() -> set[str]:
+    baseline_path = os.path.expanduser(
+        "~/docassemble-AssemblyLine/docassemble/AssemblyLine/data/questions/ql_baseline.yml"
+    )
+    if not os.path.exists(baseline_path):
+        return set()
+    try:
+        with open(baseline_path, "r", encoding="utf-8") as baseline_file:
+            docs = load_docassemble_yaml_text(baseline_file.read())
+    except Exception:
+        return set()
+    people_lists: set[str] = set()
+    for doc in docs:
+        objects = doc.get("objects")
+        if not isinstance(objects, list):
+            continue
+        for item in objects:
+            if not isinstance(item, Mapping):
+                continue
+            for name, class_info in item.items():
+                if "ALPeopleList" in str(class_info) and _looks_like_variable_name(
+                    name
+                ):
+                    people_lists.add(_normalize_index_placeholders(str(name).strip()))
+    return people_lists
+
+
+def _code_blocks_from_doc(doc: Mapping[str, Any]) -> List[str]:
+    blocks: List[str] = []
+    for key in (
+        "code",
+        "mandatory",
+        "initial",
+        "validation code",
+        "reconsider",
+        "depends on",
+    ):
+        value = doc.get(key)
+        if isinstance(value, str):
+            blocks.append(value)
+    fields = doc.get("fields")
+    if isinstance(fields, list):
+        for field in fields:
+            if isinstance(field, Mapping):
+                code = field.get("code")
+                if isinstance(code, str):
+                    blocks.append(code)
+    return blocks
+
+
+def _add_people_list_rows(
+    rows: List[str], list_name: str, options: StoryOptions, *, target_number: int = 1
+) -> None:
+    normalized_list_name = _normalize_index_placeholders(list_name)
+    _add_unique_row(rows, f"{normalized_list_name}.target_number", target_number, options)
+    _add_unique_row(rows, f"{normalized_list_name}[0].name.first", "Jane", options)
+    _add_unique_row(rows, f"{normalized_list_name}[0].name.last", "Smith", options)
+
+
+def _doc_field_variable_and_info(doc: Mapping[str, Any]) -> tuple[Optional[str], Dict[str, Any]]:
+    explicit = doc.get("field")
+    if not _looks_like_variable_name(explicit):
+        return (None, {})
+    field_info = {
+        str(key): value for key, value in doc.items() if str(key) not in DOC_NON_FIELD_KEYS
+    }
+    return (str(explicit).strip(), field_info)
+
+
+def _set_variables_from_doc(doc: Mapping[str, Any]) -> List[str]:
+    variables: List[str] = []
+    has_prompt = isinstance(doc.get("question"), str) or isinstance(doc.get("subquestion"), str)
+    if not has_prompt:
+        return variables
+    for key in ("sets", "only sets"):
+        raw_value = doc.get(key)
+        if isinstance(raw_value, list):
+            for item in raw_value:
+                if _looks_like_variable_name(item):
+                    variables.append(str(item).strip())
+        elif _looks_like_variable_name(raw_value):
+            variables.append(str(raw_value).strip())
+    return variables
+
+
+def _resolve_code_reference(text: str, aliases: Mapping[str, str]) -> str:
+    cleaned = text.strip()
+    for alias, replacement in sorted(aliases.items(), key=lambda item: len(item[0]), reverse=True):
+        if cleaned == alias or cleaned.startswith(alias + "."):
+            cleaned = replacement + cleaned[len(alias) :]
+            break
+    return _normalize_index_placeholders(cleaned)
+
+
+def _parse_simple_python_value(expression: str) -> Optional[Any]:
+    expression = expression.strip()
+    if not expression:
+        return None
+    try:
+        value = ast.literal_eval(expression)
+    except (ValueError, SyntaxError):
+        if expression in {"True", "False", "None"}:
+            return {"True": True, "False": False, "None": None}[expression]
+        return None
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list) and value:
+        first_value = value[0]
+        if isinstance(first_value, (str, int, float, bool)):
+            return first_value
+    return None
+
+
+def _parse_simple_python_expression(expression: str) -> Optional[Any]:
+    try:
+        value = ast.literal_eval(expression)
+    except (ValueError, SyntaxError):
+        return None
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return None
+
+
+def _parse_method_call_arguments(arguments_text: str) -> tuple[List[Any], Dict[str, Any]]:
+    if not arguments_text.strip():
+        return ([], {})
+    try:
+        parsed = ast.parse(f"_f({arguments_text})", mode="eval")
+    except SyntaxError:
+        return ([], {})
+    if not isinstance(parsed.body, ast.Call):
+        return ([], {})
+    args: List[Any] = []
+    kwargs: Dict[str, Any] = {}
+    for arg in parsed.body.args:
+        value = _parse_simple_python_expression(ast.unparse(arg))
+        if value is not None:
+            args.append(value)
+    for keyword in parsed.body.keywords:
+        if keyword.arg is None:
+            continue
+        value = _parse_simple_python_expression(ast.unparse(keyword.value))
+        if value is not None:
+            kwargs[keyword.arg] = value
+    return (args, kwargs)
+
+
+def _al_fields_method_rows(
+    object_name: str, method_name: str, arguments_text: str
+) -> List[tuple[str, Any]]:
+    args, kwargs = _parse_method_call_arguments(arguments_text)
+    normalized_object_name = _normalize_index_placeholders(object_name)
+    if method_name == "name_fields":
+        person_or_business = kwargs.get("person_or_business")
+        if person_or_business is None and args:
+            person_or_business = args[0]
+        show_suffix = kwargs.get("show_suffix", True)
+        show_title = kwargs.get("show_title", False)
+        if person_or_business == "business":
+            return [(f"{normalized_object_name}.name.first", "Acme LLC")]
+        rows: List[tuple[str, Any]] = []
+        if person_or_business not in {"person", None}:
+            rows.append((f"{normalized_object_name}.person_type", "ALIndividual"))
+        if show_title:
+            rows.append((f"{normalized_object_name}.name.title", "Mr."))
+        rows.extend(
+            [
+                (f"{normalized_object_name}.name.first", "Jane"),
+                (f"{normalized_object_name}.name.middle", "Sample answer"),
+                (f"{normalized_object_name}.name.last", "Smith"),
+            ]
+        )
+        if show_suffix:
+            rows.append((f"{normalized_object_name}.name.suffix", "Jr."))
+        return rows
+    if method_name == "address_fields":
+        address_root = (
+            normalized_object_name
+            if normalized_object_name.endswith(".address")
+            else f"{normalized_object_name}.address"
+        )
+        rows: List[tuple[str, Any]] = []
+        if kwargs.get("allow_no_address") is True:
+            rows.append((f"{address_root}.has_no_address", False))
+        rows.extend(
+            [
+                (f"{address_root}.address", "123 Main St"),
+                (f"{address_root}.unit", "Sample answer"),
+                (f"{address_root}.city", "Boston"),
+                (f"{address_root}.state", "MA"),
+                (f"{address_root}.zip", "02108"),
+            ]
+        )
+        if kwargs.get("show_county") is True:
+            rows.append((f"{address_root}.county", "Suffolk"))
+        if kwargs.get("show_country") is True:
+            rows.append((f"{address_root}.country", "US"))
+        if kwargs.get("ask_if_impounded") is True:
+            rows.append((f"{address_root}.impounded", False))
+        return rows
+    if method_name == "gender_fields":
+        return [(f"{normalized_object_name}.gender", "female")]
+    if method_name == "language_fields":
+        return [(f"{normalized_object_name}.language", "en")]
+    if method_name == "pronoun_fields":
+        return [(f"{normalized_object_name}.pronouns['he/him/his']", True)]
+    if method_name == "contact_fields":
+        return []
+    return []
+
+
+def _gathered_people_list_name(reference: str, people_lists: set[str]) -> Optional[str]:
+    normalized_reference = _normalize_index_placeholders(reference)
+    if normalized_reference in people_lists:
+        return normalized_reference
+    root_name = normalized_reference.split(".", 1)[0]
+    if root_name in people_lists:
+        return root_name
+    return None
+
+
+def _add_code_block_rows(
+    rows: List[str], code_block: str, people_lists: set[str], options: StoryOptions
+) -> None:
+    aliases: Dict[str, str] = {}
+    for raw_line in code_block.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        helper_match = re.match(
+            r"([A-Za-z_][\w]*(?:\[[^\]]+\])?(?:\.[A-Za-z_][\w]*)*)\.(name_fields|address_fields|gender_fields|pronoun_fields|language_fields|contact_fields)\((.*)\)\s*$",
+            line,
+        )
+        if helper_match:
+            resolved_name = _resolve_code_reference(helper_match.group(1), aliases)
+            for row_name, row_value in _al_fields_method_rows(
+                resolved_name, helper_match.group(2), helper_match.group(3)
+            ):
+                _add_inferred_row(
+                    rows,
+                    row_name,
+                    row_value,
+                    options,
+                    with_related=False,
+                    overwrite_existing_variable=True,
+                )
+            continue
+
+        loop_match = re.match(
+            r"for\s+([A-Za-z_][\w]*)\s+in\s+([A-Za-z_][\w]*(?:\[[^\]]+\])?(?:\.[A-Za-z_][\w]*)*)\s*:",
+            line,
+        )
+        if loop_match:
+            aliases[loop_match.group(1)] = _resolve_code_reference(
+                loop_match.group(2), aliases
+            )
+            continue
+
+        for match in re.finditer(
+            r"\b([A-Za-z_][\w]*(?:\[[^\]]+\])?(?:\.[A-Za-z_][\w]*)*)\.gather\s*\(",
+            line,
+        ):
+            gathered_name = _gathered_people_list_name(
+                _resolve_code_reference(match.group(1), aliases), people_lists
+            )
+            if gathered_name:
+                _add_people_list_rows(rows, gathered_name, options)
+
+        if not line.startswith(("if ", "elif ", "while ")):
+            assignment_parts = [part.strip() for part in line.split("=")]
+            if len(assignment_parts) >= 2:
+                assigned_value = _parse_simple_python_value(assignment_parts[-1])
+                if assigned_value is not None:
+                    for left_side in assignment_parts[:-1]:
+                        resolved_name = _resolve_code_reference(left_side, aliases)
+                        if _looks_like_variable_name(resolved_name):
+                            _add_inferred_row(
+                                rows,
+                                resolved_name,
+                                assigned_value,
+                                options,
+                            )
+                    continue
+
+            resolved_name = _resolve_code_reference(line, aliases)
+            if _looks_like_variable_name(resolved_name):
+                _add_inferred_row(
+                    rows,
+                    resolved_name,
+                    _default_value_for_variable_name(resolved_name),
+                    options,
+                )
+                continue
+
+        condition_match = re.match(
+            r"(?:if|elif)\s+([A-Za-z_][\w]*(?:\[[^\]]+\])?(?:\.[A-Za-z_][\w]*)*)\s*==\s*(.+?)\s*:\s*$",
+            line,
+        )
+        if condition_match:
+            resolved_name = _resolve_code_reference(condition_match.group(1), aliases)
+            value = _parse_simple_python_value(condition_match.group(2))
+            if value is not None:
+                _add_inferred_row(rows, resolved_name, value, options)
+            continue
+
+        membership_match = re.match(
+            r"(?:if|elif)\s+([A-Za-z_][\w]*(?:\[[^\]]+\])?(?:\.[A-Za-z_][\w]*)*)\s+in\s+(.+?)\s*:\s*$",
+            line,
+        )
+        if membership_match:
+            resolved_name = _resolve_code_reference(membership_match.group(1), aliases)
+            value = _parse_simple_python_value(membership_match.group(2))
+            if value is not None:
+                _add_inferred_row(rows, resolved_name, value, options)
+
+
+def rows_from_yaml_heuristics(
+    yaml_text: str,
+    *,
+    options: Optional[StoryOptions] = None,
+    source_path: Optional[str] = None,
+) -> List[str]:
+    story_options = options or StoryOptions()
+    primary_docs = _load_yaml_documents(yaml_text)
+    docs = load_docassemble_yaml_text(yaml_text, source_path=source_path)
+    people_lists = _declared_al_people_lists(docs)
+    rows: List[str] = []
+
+    for doc in docs:
+        fields = doc.get("fields")
+        if isinstance(fields, list):
+            for field in fields:
+                variable, field_info = _field_variable_and_info(field)
+                if variable:
+                    for row_name, row_value in _field_rows(variable, field_info):
+                        _add_inferred_row(rows, row_name, row_value, story_options)
+
+        single_field_variable, single_field_info = _doc_field_variable_and_info(doc)
+        if single_field_variable:
+            for row_name, row_value in _field_rows(single_field_variable, single_field_info):
+                _add_inferred_row(
+                    rows,
+                    row_name,
+                    row_value,
+                    story_options,
+                    overwrite_existing_variable=True,
+                )
+
+        for set_variable in _set_variables_from_doc(doc):
+            _add_inferred_row(
+                rows,
+                set_variable,
+                _default_value_for_variable_name(set_variable),
+                story_options,
+                overwrite_existing_variable=True,
+            )
+
+    for doc in primary_docs:
+        continue_button_field = doc.get("continue button field")
+        if _looks_like_variable_name(continue_button_field):
+            _add_inferred_row(
+                rows,
+                str(continue_button_field),
+                True,
+                story_options,
+                overwrite_existing_variable=True,
+            )
+
+        for code_block in _code_blocks_from_doc(doc):
+            _add_code_block_rows(rows, code_block, people_lists, story_options)
+
+    return rows
+
+
+def detect_yaml_ending_screen(
+    yaml_text: str,
+    fallback: str = "review_screen",
+    *,
+    source_path: Optional[str] = None,
+) -> str:
+    docs = load_docassemble_yaml_text(yaml_text, source_path=source_path)
+    final_candidate: Optional[str] = None
+    for doc in docs:
+        candidate: Optional[str] = None
+        screen_id = doc.get("id")
+        if isinstance(screen_id, str) and screen_id.strip():
+            candidate = screen_id.strip()
+        event = doc.get("event")
+        if isinstance(event, str) and event.strip():
+            normalized = event.strip()
+            if normalized not in {"restart", "exit", "logout"}:
+                candidate = candidate or normalized
+        continue_button_field = doc.get("continue button field")
+        if isinstance(continue_button_field, str) and continue_button_field.strip():
+            candidate = candidate or continue_button_field.strip()
+        if candidate:
+            final_candidate = candidate
+    return final_candidate or fallback
+
+
+def story_from_docassemble_yaml(
+    yaml_text: str,
+    *,
+    filename: str = "interview.yml",
+    options: Optional[StoryOptions] = None,
+) -> Dict[str, Any]:
+    yaml_file_name = _clean_yaml_filename(filename)
+    if options is None:
+        story_options = StoryOptions(
+            yaml_file_name=yaml_file_name,
+            question_id=detect_yaml_ending_screen(yaml_text, source_path=filename),
+        )
+    else:
+        story_options = options
+    rows = rows_from_yaml_heuristics(
+        yaml_text,
+        options=story_options,
+        source_path=filename if os.path.exists(filename) else None,
+    )
+    feature_text = build_feature_text(rows, story_options)
+    return {
+        "rows": rows,
+        "feature_text": feature_text,
+        "preview_markdown": build_feature_preview_markdown(feature_text),
+        "row_count": len(rows),
+        "yaml_file_name": story_options.yaml_file_name,
+        "question_id": story_options.question_id,
+        "feature_description": story_options.feature_description,
+        "scenario_description": story_options.scenario_description,
+        "source_type": "yaml",
     }

--- a/docassemble/ALDashboard/alkiln_story.py
+++ b/docassemble/ALDashboard/alkiln_story.py
@@ -2,9 +2,10 @@ import ast
 import glob
 import json
 import os
+import posixpath
 import re
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Dict, List, Optional
 
 from ruamel.yaml import YAML
@@ -266,6 +267,9 @@ COMMON_AL_PEOPLE_LISTS = {
     "plaintiffs",
     "petitioners",
 }
+
+
+_DEFAULT_YAML_SOURCE_PATH = object()
 
 FIELD_NON_VARIABLE_KEYS = {
     "label",
@@ -691,34 +695,82 @@ def _iter_include_strings(include_value: Any) -> List[str]:
     return []
 
 
+def _is_path_within_root(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath([os.path.realpath(path), os.path.realpath(root)]) == (
+            os.path.realpath(root)
+        )
+    except ValueError:
+        return False
+
+
+def _normalize_yaml_source_path(source_path: Optional[str]) -> Optional[str]:
+    path = str(source_path or "").strip()
+    if not path:
+        return None
+    normalized = os.path.abspath(path)
+    if not os.path.isfile(normalized):
+        return None
+    if not normalized.lower().endswith((".yml", ".yaml")):
+        return None
+    return normalized
+
+
+def _normalize_include_relative_path(include_path: str) -> Optional[str]:
+    normalized = str(include_path or "").strip().replace("\\", "/")
+    if not normalized:
+        return None
+    if posixpath.isabs(normalized):
+        return None
+    normalized = posixpath.normpath(normalized)
+    if normalized in {"", ".", ".."} or normalized.startswith("../"):
+        return None
+    if not normalized.lower().endswith((".yml", ".yaml")):
+        return None
+    return normalized
+
+
 def _resolve_local_include_path(include_ref: str, source_path: str) -> Optional[str]:
     include_ref = str(include_ref or "").strip()
     if not include_ref:
         return None
-    source_dir = os.path.dirname(os.path.abspath(source_path))
+    normalized_source_path = _normalize_yaml_source_path(source_path)
+    if not normalized_source_path:
+        return None
+    source_dir = os.path.realpath(os.path.dirname(normalized_source_path))
     if ":" not in include_ref:
-        candidate = os.path.abspath(os.path.join(source_dir, include_ref))
-        return candidate if os.path.exists(candidate) else None
+        relative_path = _normalize_include_relative_path(include_ref)
+        if not relative_path:
+            return None
+        candidate = os.path.realpath(
+            os.path.join(source_dir, *relative_path.split("/"))
+        )
+        if not _is_path_within_root(candidate, source_dir):
+            return None
+        return candidate if os.path.isfile(candidate) else None
 
     package_name, relative_path = include_ref.split(":", 1)
-    relative_path = relative_path.strip()
+    relative_path = _normalize_include_relative_path(relative_path)
     if not relative_path:
         return None
     package_path = os.path.join(*package_name.split("."))
     home_dir = os.path.expanduser("~")
-    repo_root = _repo_root_for_path(source_path)
+    repo_root = _repo_root_for_path(normalized_source_path)
     search_patterns = [
-        os.path.join(repo_root, package_path, relative_path),
-        os.path.join(repo_root, package_path, "data", "questions", relative_path),
-        os.path.join(home_dir, "docassemble-*", package_path, relative_path),
-        os.path.join(
-            home_dir, "docassemble-*", package_path, "data", "questions", relative_path
-        ),
+        os.path.join(repo_root, package_path),
+        os.path.join(repo_root, package_path, "data", "questions"),
+        os.path.join(home_dir, "docassemble-*", package_path),
+        os.path.join(home_dir, "docassemble-*", package_path, "data", "questions"),
     ]
     for pattern in search_patterns:
-        for candidate in glob.glob(pattern):
-            if os.path.exists(candidate):
-                return os.path.abspath(candidate)
+        for base_dir in glob.glob(pattern):
+            if not os.path.isdir(base_dir):
+                continue
+            candidate = os.path.realpath(
+                os.path.join(base_dir, *relative_path.split("/"))
+            )
+            if _is_path_within_root(candidate, base_dir) and os.path.isfile(candidate):
+                return candidate
     return None
 
 
@@ -729,11 +781,11 @@ def load_docassemble_yaml_text(
     _seen_paths: Optional[set[str]] = None,
 ) -> List[Mapping[str, Any]]:
     docs = _load_yaml_documents(yaml_text)
-    if not source_path or not os.path.exists(source_path):
+    normalized_source_path = _normalize_yaml_source_path(source_path)
+    if not normalized_source_path:
         return docs
 
     seen_paths = _seen_paths if _seen_paths is not None else set()
-    normalized_source_path = os.path.abspath(source_path)
     if normalized_source_path in seen_paths:
         return docs
     seen_paths.add(normalized_source_path)
@@ -1506,20 +1558,35 @@ def story_from_docassemble_yaml(
     yaml_text: str,
     *,
     filename: str = "interview.yml",
+    source_path: Optional[str] | object = _DEFAULT_YAML_SOURCE_PATH,
     options: Optional[StoryOptions] = None,
 ) -> Dict[str, Any]:
     yaml_file_name = _clean_yaml_filename(filename)
+    if source_path is _DEFAULT_YAML_SOURCE_PATH:
+        resolved_source_path = _normalize_yaml_source_path(filename)
+    else:
+        resolved_source_path = (
+            _normalize_yaml_source_path(source_path)
+            if isinstance(source_path, str)
+            else None
+        )
     if options is None:
         story_options = StoryOptions(
             yaml_file_name=yaml_file_name,
-            question_id=detect_yaml_ending_screen(yaml_text, source_path=filename),
+            question_id=detect_yaml_ending_screen(
+                yaml_text, source_path=resolved_source_path
+            ),
         )
     else:
-        story_options = options
+        story_options = (
+            options
+            if options.yaml_file_name == yaml_file_name
+            else replace(options, yaml_file_name=yaml_file_name)
+        )
     rows = rows_from_yaml_heuristics(
         yaml_text,
         options=story_options,
-        source_path=filename if os.path.exists(filename) else None,
+        source_path=resolved_source_path,
     )
     feature_text = build_feature_text(rows, story_options)
     return {

--- a/docassemble/ALDashboard/alkiln_story.py
+++ b/docassemble/ALDashboard/alkiln_story.py
@@ -1,0 +1,291 @@
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME = [
+    "AL_DEFAULT_COUNTRY",
+    "AL_ORGANIZATION_HOMEPAGE",
+    "AL_ORGANIZATION_TITLE",
+    "al_enable_incomplete_downloads",
+    "al_logo",
+    "al_menu_items",
+    "al_version",
+    "al_session_store_default_filename",
+    "all_answer_sets",
+    "menu_items",
+    "._",
+    "_attachment",
+    "_bundle",
+    "court_emails",
+    "download_titles",
+    "form_approved_for_email_filing",
+    "github_user",
+    "interview_metadata",
+    "interview_short_title",
+    "macourts",
+    "package_name",
+    "package_version_number",
+    "preferred_court",
+    "signature_fields",
+    "speak_text",
+    "started_on_phone",
+    "user_has_saved_answers",
+    "github_repo_name",
+    "allow_cron",
+    "allowed_courts",
+    "_geocoded",
+    ".uses_parts",
+    ".court_code",
+    ".department",
+    ".division",
+    ".fax",
+    ".has_po_box",
+    "county_dict",
+    "countyinfo",
+    "mimetype",
+    "_internal",
+    "nav",
+    "url_args",
+    "_class",
+    "auto_gather",
+    "instanceName",
+    "multi_user",
+    "file_info",
+    "persistent",
+    "private",
+    "convert_to_pdf_a",
+    "convert_to_tagged_pdf",
+    "extension",
+    "valid_formats",
+    "encrypted",
+    "has_specific_filename",
+    "geolocate_response",
+    "norm_long",
+    "city_only",
+    "geolocated",
+    "orig_address",
+    "latitude",
+    "longitude",
+    "norm",
+    "geolocate_success",
+    "complete_attribute",
+]
+
+DEFAULT_IGNORE_IF_IS_KEY = [
+    "all_courts",
+    "alt_text",
+    "ask_number",
+    "ask_object_type",
+    "object_type",
+    "gathered",
+    "minimum_number",
+]
+
+
+@dataclass(frozen=True)
+class StoryOptions:
+    feature_description: str = "Generated docassemble test"
+    scenario_description: str = "Generated scenario"
+    yaml_file_name: str = "interview.yml"
+    question_id: str = "review_screen"
+    ignore_anywhere_in_var_name: Sequence[str] = tuple(
+        DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME
+    )
+    ignore_if_is_key: Sequence[str] = tuple(DEFAULT_IGNORE_IF_IS_KEY)
+
+
+def _format_value(value: Any) -> Any:
+    if isinstance(value, str):
+        text = json.dumps(value, ensure_ascii=False)[1:-1]
+        return re.sub(
+            r"(\d\d\d\d)-(\d\d)-(\d\d)T\d\d:\d\d:\d\d-\d\d:\d\d",
+            r"\2/\3/\1",
+            text,
+        )
+    return value
+
+
+def _is_ignored_name(name: str, ignore_anywhere: Sequence[str]) -> bool:
+    return any(to_ignore and to_ignore in name for to_ignore in ignore_anywhere)
+
+
+def _object_name(is_class: bool, name: str, key: str) -> str:
+    if not name:
+        return key
+    if is_class:
+        return f"{name}.{key}"
+    return f"{name}['{key}']"
+
+
+def _story_row(
+    *,
+    name: str,
+    value: Any,
+    ignore_anywhere: Sequence[str],
+) -> Optional[str]:
+    if _is_ignored_name(name, ignore_anywhere):
+        return None
+
+    value = _format_value(value)
+    if name.endswith(".filename") and value == "canvas.png":
+        name = name[: -len(".filename")]
+        value = ""
+    if name.endswith(".there_is_another"):
+        value = (
+            "--- invalid. See docs at "
+            "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/"
+            "automated_integrated_testing/#there_is_another-loop --- "
+        )
+    return f"| {name} | {value} |  |"
+
+
+def _parse_value(name: str, value: Any, options: StoryOptions) -> List[str]:
+    if name in options.ignore_if_is_key or _is_ignored_name(
+        name, options.ignore_anywhere_in_var_name
+    ):
+        return []
+    if isinstance(value, Mapping):
+        return _parse_object(name, value, options)
+    if isinstance(value, list):
+        return _parse_array(name, value, options)
+    if value is None:
+        return _single_row(name, "None", options)
+    if isinstance(value, bool):
+        return _single_row(name, str(value), options)
+    if isinstance(value, (str, int, float)):
+        return _single_row(name, value, options)
+    return _single_row(name, str(value), options)
+
+
+def _parse_object(
+    name: str, value: Mapping[str, Any], options: StoryOptions
+) -> List[str]:
+    rows: List[str] = []
+    class_name = value.get("_class")
+    is_class = isinstance(class_name, str) and "DADict" not in class_name
+
+    instance_name = value.get("instanceName")
+    if isinstance(instance_name, str) and instance_name and name != instance_name:
+        rows.extend(_single_row(name, instance_name, options))
+
+    if "elements" in value:
+        rows.extend(_parse_elements(name, value["elements"], options))
+
+    for key, item in value.items():
+        key_text = str(key)
+        if key_text == "elements":
+            continue
+        if key_text in options.ignore_if_is_key or _is_ignored_name(
+            key_text, options.ignore_anywhere_in_var_name
+        ):
+            continue
+        rows.extend(_parse_value(_object_name(is_class, name, key_text), item, options))
+    return rows
+
+
+def _parse_elements(name: str, value: Any, options: StoryOptions) -> List[str]:
+    rows: List[str] = []
+    if isinstance(value, Mapping):
+        were_checkboxes = False
+        any_true = False
+        for key, item in value.items():
+            if isinstance(item, bool):
+                were_checkboxes = True
+                any_true = any_true or item
+                rows.extend(
+                    _single_row(_object_name(False, name, str(key)), str(item), options)
+                )
+            else:
+                rows.extend(
+                    _parse_value(_object_name(False, name, str(key)), item, options)
+                )
+        if were_checkboxes and not any_true:
+            rows.extend(_single_row(_object_name(False, name, "None"), "True", options))
+        return rows
+    return _parse_value(name, value, options)
+
+
+def _parse_array(name: str, value: Sequence[Any], options: StoryOptions) -> List[str]:
+    rows: List[str] = []
+    for index, item in enumerate(value):
+        rows.extend(_parse_value(f"{name}[{index}]", item, options))
+    return rows
+
+
+def _single_row(name: str, value: Any, options: StoryOptions) -> List[str]:
+    if isinstance(value, str) and value in {"True", "False"}:
+        formatted_value: Any = value
+    elif isinstance(value, str):
+        formatted_value = value
+    elif isinstance(value, bool):
+        formatted_value = str(value)
+    else:
+        formatted_value = value
+    if isinstance(formatted_value, str) and formatted_value.lower() in {
+        "true",
+        "false",
+    }:
+        formatted_value = formatted_value[:1].upper() + formatted_value[1:].lower()
+    row = _story_row(
+        name=name,
+        value=formatted_value,
+        ignore_anywhere=options.ignore_anywhere_in_var_name,
+    )
+    return [row] if row else []
+
+
+def rows_from_variables(
+    variables: Mapping[str, Any], *, options: Optional[StoryOptions] = None
+) -> List[str]:
+    story_options = options or StoryOptions()
+    all_rows = _parse_value("", variables, story_options)
+    rows: List[str] = []
+    for row in all_rows:
+        if isinstance(row, str) and row not in rows:
+            rows.append(row)
+    return rows
+
+
+def default_yaml_file_name(
+    data: Mapping[str, Any], fallback: str = "interview.yml"
+) -> str:
+    interview_path = data.get("i")
+    if isinstance(interview_path, str) and interview_path.strip():
+        return interview_path.rsplit(":", 1)[-1]
+    return fallback
+
+
+def build_feature_text(rows: Sequence[str], options: StoryOptions) -> str:
+    lines = [
+        f"Feature: {options.feature_description or options.scenario_description}",
+        "",
+        f"Scenario: {options.scenario_description}",
+        f'  Given I start the interview at "{options.yaml_file_name}"',
+        f'  And the user gets to "{options.question_id}" with this data:',
+        "    | var | value | trigger |",
+    ]
+    lines.extend(f"    {row}" for row in rows)
+    return "\n".join(lines)
+
+
+def story_from_docassemble_json(
+    data: Mapping[str, Any], *, options: Optional[StoryOptions] = None
+) -> Dict[str, Any]:
+    story_options = options or StoryOptions(yaml_file_name=default_yaml_file_name(data))
+    variables = data.get("variables", data)
+    if not isinstance(variables, Mapping):
+        raise ValueError(
+            "Docassemble JSON must be an object or contain variables object."
+        )
+    rows = rows_from_variables(variables, options=story_options)
+    return {
+        "rows": rows,
+        "feature_text": build_feature_text(rows, story_options),
+        "row_count": len(rows),
+        "yaml_file_name": story_options.yaml_file_name,
+        "question_id": story_options.question_id,
+        "feature_description": story_options.feature_description,
+        "scenario_description": story_options.scenario_description,
+    }

--- a/docassemble/ALDashboard/api_dashboard.py
+++ b/docassemble/ALDashboard/api_dashboard.py
@@ -509,10 +509,10 @@ def dashboard_interview_lint():
     )
 
 
-@app.route(f"{DASHBOARD_API_BASE_PATH}/interview/story", methods=["POST"])
+@app.route(f"{DASHBOARD_API_BASE_PATH}/kiln/story", methods=["POST"])
 @csrf.exempt
 @cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
-def dashboard_interview_story():
+def dashboard_kiln_story():
     return _run_endpoint(alkiln_story_payload_from_request, dashboard_alkiln_story_task)
 
 

--- a/docassemble/ALDashboard/api_dashboard.py
+++ b/docassemble/ALDashboard/api_dashboard.py
@@ -25,6 +25,7 @@ from .api_dashboard_utils import (
     DASHBOARD_API_BASE_PATH,
     DashboardAPIValidationError,
     _validate_upload_size,
+    alkiln_story_payload_from_request,
     autolabel_payload_from_request,
     bootstrap_payload_from_request,
     docx_runs_payload_from_request,
@@ -57,6 +58,7 @@ ASYNC_CELERY_MODULE = "docassemble.ALDashboard.api_dashboard_worker"
 if not in_celery:
     from .api_dashboard_worker import (
         dashboard_autolabel_task,
+        dashboard_alkiln_story_task,
         dashboard_bootstrap_task,
         dashboard_docx_runs_task,
         dashboard_interview_lint_task,
@@ -505,6 +507,13 @@ def dashboard_interview_lint():
     return _run_endpoint(
         interview_lint_payload_from_request, dashboard_interview_lint_task
     )
+
+
+@app.route(f"{DASHBOARD_API_BASE_PATH}/interview/story", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def dashboard_interview_story():
+    return _run_endpoint(alkiln_story_payload_from_request, dashboard_alkiln_story_task)
 
 
 @app.route(f"{DASHBOARD_API_BASE_PATH}/yaml/check", methods=["POST"])

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1653,6 +1653,77 @@ def yaml_reformat_payload_from_options(
     }
 
 
+def alkiln_story_payload_from_request() -> Dict[str, Any]:
+    raw = merge_raw_options(_request_dict())
+    return alkiln_story_payload_from_options(raw)
+
+
+def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, Any]:
+    from .alkiln_story import (
+        DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME,
+        StoryOptions,
+        default_yaml_file_name,
+        story_from_docassemble_json,
+    )
+
+    raw = merge_raw_options(raw_options)
+    data = raw.get("data")
+    json_text = raw.get("json_text") or raw.get("json")
+    variables = raw.get("variables")
+
+    if data is None and json_text is not None:
+        if not isinstance(json_text, str) or not json_text.strip():
+            raise DashboardAPIValidationError("json_text must be non-empty JSON.")
+        try:
+            data = json.loads(json_text)
+        except json.JSONDecodeError as exc:
+            raise DashboardAPIValidationError("json_text must be valid JSON.") from exc
+    elif data is None and variables is not None:
+        data = {"variables": variables}
+    elif data is None and any(
+        key in raw
+        for key in (
+            "i",
+            "variables",
+        )
+    ):
+        data = raw
+
+    if not isinstance(data, dict):
+        raise DashboardAPIValidationError(
+            "Provide docassemble JSON as `data`, `json_text`, or `variables`."
+        )
+
+    ignore_anywhere = _load_string_list_field(
+        raw.get("ignore_anywhere_in_var_name"),
+        field_name="ignore_anywhere_in_var_name",
+    )
+    if ignore_anywhere is None:
+        ignore_anywhere = list(DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME)
+
+    yaml_file_name = str(
+        raw.get("yaml_file_name")
+        or raw.get("interview_path")
+        or default_yaml_file_name(data)
+    ).strip()
+    question_id = str(raw.get("question_id") or "review_screen").strip()
+    feature_description = str(
+        raw.get("feature_description") or "Generated docassemble test"
+    ).strip()
+    scenario_description = str(
+        raw.get("scenario_description") or "Generated scenario"
+    ).strip()
+
+    options = StoryOptions(
+        feature_description=feature_description,
+        scenario_description=scenario_description,
+        yaml_file_name=yaml_file_name or "interview.yml",
+        question_id=question_id or "review_screen",
+        ignore_anywhere_in_var_name=ignore_anywhere,
+    )
+    return story_from_docassemble_json(data, options=options)
+
+
 def _prepare_pdf_upload(raw_options: Mapping[str, Any]) -> Dict[str, Any]:
     raw = merge_raw_options(raw_options)
     filename = str(raw.get("filename") or "upload.pdf")
@@ -2115,6 +2186,37 @@ def build_openapi_spec() -> Dict[str, Any]:
                     ),
                 }
             },
+            f"{DASHBOARD_API_BASE_PATH}/interview/story": {
+                "post": {
+                    "summary": "Convert docassemble interview JSON to an ALKiln story",
+                    "description": (
+                        "Accepts docassemble JSON as `data`, `json_text`, or `variables` "
+                        "and returns ALKiln table rows plus complete Gherkin feature text."
+                    ),
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {"type": "object"},
+                                        "json_text": {"type": "string"},
+                                        "variables": {"type": "object"},
+                                        "yaml_file_name": {"type": "string"},
+                                        "question_id": {"type": "string"},
+                                        "feature_description": {"type": "string"},
+                                        "scenario_description": {"type": "string"},
+                                        "ignore_anywhere_in_var_name": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            },
             f"{DASHBOARD_API_BASE_PATH}/pdf/label-fields": {
                 "post": {
                     "summary": "Detect and optionally relabel PDF fields (alias)",
@@ -2216,6 +2318,7 @@ def build_docs_html() -> str:
     <li><code>POST {DASHBOARD_API_BASE_PATH}/review-screen/draft</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/docx/validate</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/interview/lint</code></li>
+    <li><code>POST {DASHBOARD_API_BASE_PATH}/interview/story</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/yaml/check</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/yaml/reformat</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/pdf/label-fields</code></li>

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1671,8 +1671,37 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
     data = raw.get("data")
     json_text = raw.get("json_text") or raw.get("json")
     variables = raw.get("variables")
+    session_id = str(raw.get("session_id") or raw.get("key") or "").strip()
 
-    if data is None and json_text is not None:
+    if data is None and session_id:
+        from .aldashboard import (
+            dashboard_find_session_filename,
+            dashboard_get_session_variables,
+        )
+
+        session_filename = str(
+            raw.get("filename") or raw.get("interview_path") or ""
+        ).strip()
+        if not session_filename:
+            found_filename = dashboard_find_session_filename(session_id)
+            if not found_filename:
+                raise DashboardAPIValidationError(
+                    "filename or interview_path is required when session_id cannot be resolved unambiguously."
+                )
+            session_filename = found_filename
+        try:
+            data = {
+                "i": session_filename,
+                "variables": dashboard_get_session_variables(
+                    session_id=session_id,
+                    filename=session_filename,
+                ),
+            }
+        except Exception as exc:
+            raise DashboardAPIValidationError(
+                "Could not load variables for the requested session."
+            ) from exc
+    elif data is None and json_text is not None:
         if not isinstance(json_text, str) or not json_text.strip():
             raise DashboardAPIValidationError("json_text must be non-empty JSON.")
         try:
@@ -2195,12 +2224,13 @@ def build_openapi_spec() -> Dict[str, Any]:
                     ),
                 }
             },
-            f"{DASHBOARD_API_BASE_PATH}/interview/story": {
+            f"{DASHBOARD_API_BASE_PATH}/kiln/story": {
                 "post": {
-                    "summary": "Convert docassemble interview JSON to an ALKiln story",
+                    "summary": "Convert docassemble JSON or a saved session to an ALKiln story",
                     "description": (
-                        "Accepts docassemble JSON as `data`, `json_text`, or `variables` "
-                        "and returns ALKiln table rows plus complete Gherkin feature text."
+                        "Accepts docassemble JSON as `data`, `json_text`, or `variables`, "
+                        "or a saved interview `session_id`, and returns ALKiln table rows "
+                        "plus complete Gherkin feature text."
                     ),
                     "requestBody": {
                         "content": {
@@ -2211,6 +2241,19 @@ def build_openapi_spec() -> Dict[str, Any]:
                                         "data": {"type": "object"},
                                         "json_text": {"type": "string"},
                                         "variables": {"type": "object"},
+                                        "session_id": {
+                                            "type": "string",
+                                            "description": (
+                                                "Saved docassemble session key to convert directly."
+                                            ),
+                                        },
+                                        "filename": {
+                                            "type": "string",
+                                            "description": (
+                                                "Interview filename for session_id, for example "
+                                                "docassemble.pkg:data/questions/interview.yml."
+                                            ),
+                                        },
                                         "yaml_file_name": {"type": "string"},
                                         "question_id": {"type": "string"},
                                         "feature_description": {"type": "string"},
@@ -2329,7 +2372,7 @@ def build_docs_html() -> str:
     <li><code>POST {DASHBOARD_API_BASE_PATH}/review-screen/draft</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/docx/validate</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/interview/lint</code></li>
-    <li><code>POST {DASHBOARD_API_BASE_PATH}/interview/story</code></li>
+    <li><code>POST {DASHBOARD_API_BASE_PATH}/kiln/story</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/yaml/check</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/yaml/reformat</code></li>
     <li><code>POST {DASHBOARD_API_BASE_PATH}/pdf/label-fields</code></li>
@@ -2347,6 +2390,7 @@ def build_docs_html() -> str:
     <li><code>/docx/relabel</code> can replace or skip labels by index and add labels via explicit updates or paragraph-range rules.</li>
     <li><code>/yaml/check</code> runs DAYamlChecker and classifies returned issues into <code>errors</code> and <code>warnings</code>.</li>
     <li><code>/yaml/reformat</code> uses DAYamlChecker's formatter and returns the updated YAML as <code>formatted_yaml</code>.</li>
+    <li><code>/kiln/story</code> accepts docassemble JSON or <code>session_id</code> with optional <code>filename</code>/<code>interview_path</code>, then converts the variables into ALKiln feature text.</li>
     <li><code>/jobs/&lt;job_id&gt;/download</code> streams file outputs from async job results. Use <code>?index=1</code> or <code>?field=...</code> when multiple file artifacts exist.</li>
     <li>Most endpoints accept <code>mode=async</code> and can be polled via <code>/jobs/&lt;job_id&gt;</code>.</li>
     <li><code>/bootstrap/compile</code> requires <code>node</code>/<code>npm</code> on PATH and outbound HTTPS; first run may be slower while dependencies install.</li>

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1655,23 +1655,101 @@ def yaml_reformat_payload_from_options(
 
 def alkiln_story_payload_from_request() -> Dict[str, Any]:
     raw = merge_raw_options(_request_dict())
-    return alkiln_story_payload_from_options(raw)
+    upload: Optional[Dict[str, Any]] = None
+    if "file" in request.files:
+        upload = _read_single_upload(field_name="file")
+    elif "files" in request.files:
+        uploads = _read_multi_uploads(field_name="files")
+        upload = uploads[0] if uploads else None
+    return alkiln_story_payload_from_options(raw, upload=upload)
 
 
-def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, Any]:
+def alkiln_story_payload_from_options(
+    raw_options: Mapping[str, Any], *, upload: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     from .alkiln_story import (
         DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME,
         StoryOptions,
         default_yaml_file_name,
         load_docassemble_json_text,
+        story_from_docassemble_yaml,
         story_from_docassemble_json,
+        detect_yaml_ending_screen,
     )
 
     raw = merge_raw_options(raw_options)
     data = raw.get("data")
     json_text = raw.get("json_text") or raw.get("json")
+    yaml_text = raw.get("yaml_text") or raw.get("yaml_content")
     variables = raw.get("variables")
     session_id = str(raw.get("session_id") or raw.get("key") or "").strip()
+    source_token = str(
+        raw.get("source_token")
+        or raw.get("playground_source_token")
+        or raw.get("yaml_source_token")
+        or ""
+    ).strip()
+    playground_project = str(raw.get("playground_project") or "").strip()
+    playground_yaml_file = str(raw.get("playground_yaml_file") or "").strip()
+    yaml_source_filename = str(
+        raw.get("filename") or raw.get("yaml_file_name") or ""
+    ).strip()
+    yaml_source_path: Optional[str] = None
+
+    if upload is None and raw.get("file_content_base64") is not None:
+        filename = str(raw.get("filename") or "upload.yml")
+        content = decode_base64_content(raw.get("file_content_base64"))
+        _validate_upload_size(content)
+        upload = {"filename": filename, "content": content}
+
+    if yaml_text is None and upload is not None:
+        filename = str(upload.get("filename") or "upload.yml")
+        content = upload.get("content")
+        if not isinstance(content, (bytes, bytearray)):
+            raise DashboardAPIValidationError("Upload content must be bytes.")
+        if not filename.lower().endswith((".yml", ".yaml")):
+            raise DashboardAPIValidationError(
+                "Only YAML uploads are supported for heuristic story generation.",
+                status_code=415,
+            )
+        yaml_text = bytes(content).decode("utf-8", errors="replace")
+        yaml_source_filename = filename
+
+    if yaml_text is None and source_token:
+        from .interview_linter import _resolve_source_token
+
+        source_path = _resolve_source_token(source_token)
+        if not source_path or not os.path.exists(source_path):
+            raise DashboardAPIValidationError(
+                f"Could not resolve YAML source token {source_token!r}."
+            )
+        with open(source_path, "r", encoding="utf-8") as source_file:
+            yaml_text = source_file.read()
+        yaml_source_path = source_path
+        yaml_source_filename = raw.get("filename") or source_token
+
+    if yaml_text is None and playground_yaml_file:
+        from .interview_linter import list_playground_yaml_files
+
+        playground_files = list_playground_yaml_files(playground_project or "default")
+        selected_file = next(
+            (
+                item
+                for item in playground_files
+                if item.get("label") == playground_yaml_file
+                or item.get("token") == playground_yaml_file
+            ),
+            None,
+        )
+        if not selected_file:
+            raise DashboardAPIValidationError(
+                f"Could not find playground YAML file {playground_yaml_file!r}."
+            )
+        source_path = str(selected_file.get("token") or "")
+        with open(source_path, "r", encoding="utf-8") as source_file:
+            yaml_text = source_file.read()
+        yaml_source_path = source_path
+        yaml_source_filename = str(selected_file.get("label") or playground_yaml_file)
 
     if data is None and session_id:
         from .aldashboard import (
@@ -1701,6 +1779,9 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
             raise DashboardAPIValidationError(
                 "Could not load variables for the requested session."
             ) from exc
+    elif data is None and yaml_text is not None:
+        if not isinstance(yaml_text, str) or not yaml_text.strip():
+            raise DashboardAPIValidationError("yaml_text must be non-empty YAML.")
     elif data is None and json_text is not None:
         if not isinstance(json_text, str) or not json_text.strip():
             raise DashboardAPIValidationError("json_text must be non-empty JSON.")
@@ -1719,9 +1800,11 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
     ):
         data = raw
 
-    if not isinstance(data, dict):
+    if yaml_text is None and not isinstance(data, dict):
         raise DashboardAPIValidationError(
-            "Provide docassemble JSON as `data`, `json_text`, or `variables`."
+            "Provide docassemble JSON as `data`, `json_text`, or `variables`, "
+            "or YAML as `yaml_text`, `file_content_base64`, multipart `file`, "
+            "`source_token`, or `playground_project` with `playground_yaml_file`."
         )
 
     ignore_anywhere = _load_string_list_field(
@@ -1731,12 +1814,24 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
     if ignore_anywhere is None:
         ignore_anywhere = list(DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME)
 
-    yaml_file_name = str(
-        raw.get("yaml_file_name")
-        or raw.get("interview_path")
-        or default_yaml_file_name(data)
-    ).strip()
-    question_id = str(raw.get("question_id") or "review_screen").strip()
+    if yaml_text is not None:
+        yaml_default_name = (
+            yaml_source_filename or raw.get("interview_path") or "interview.yml"
+        )
+        question_default = detect_yaml_ending_screen(
+            yaml_text, source_path=yaml_source_path
+        )
+    else:
+        yaml_default_name = raw.get("interview_path") or default_yaml_file_name(data)
+        question_default = "review_screen"
+
+    if raw.get("yaml_file_name"):
+        yaml_file_name = str(raw.get("yaml_file_name")).strip()
+    elif yaml_text is not None:
+        yaml_file_name = os.path.basename(str(yaml_default_name).rsplit(":", 1)[-1])
+    else:
+        yaml_file_name = str(yaml_default_name).strip()
+    question_id = str(raw.get("question_id") or question_default).strip()
     feature_description = str(
         raw.get("feature_description") or "Generated docassemble test"
     ).strip()
@@ -1759,6 +1854,12 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
         synthesize_target_number=synthesize_target_number,
         ignore_anywhere_in_var_name=ignore_anywhere,
     )
+    if yaml_text is not None:
+        return story_from_docassemble_yaml(
+            yaml_text,
+            filename=yaml_source_path or yaml_file_name,
+            options=options,
+        )
     return story_from_docassemble_json(data, options=options)
 
 
@@ -2226,11 +2327,12 @@ def build_openapi_spec() -> Dict[str, Any]:
             },
             f"{DASHBOARD_API_BASE_PATH}/kiln/story": {
                 "post": {
-                    "summary": "Convert docassemble JSON or a saved session to an ALKiln story",
+                    "summary": "Convert docassemble JSON, YAML, or a saved session to an ALKiln story",
                     "description": (
                         "Accepts docassemble JSON as `data`, `json_text`, or `variables`, "
-                        "or a saved interview `session_id`, and returns ALKiln table rows "
-                        "plus complete Gherkin feature text."
+                        "a saved interview `session_id`, or interview YAML via `yaml_text`, "
+                        "upload, source token, or playground selection. YAML input uses "
+                        "heuristics to create table rows and detect the ending screen."
                     ),
                     "requestBody": {
                         "content": {
@@ -2240,6 +2342,11 @@ def build_openapi_spec() -> Dict[str, Any]:
                                     "properties": {
                                         "data": {"type": "object"},
                                         "json_text": {"type": "string"},
+                                        "yaml_text": {"type": "string"},
+                                        "file_content_base64": {"type": "string"},
+                                        "source_token": {"type": "string"},
+                                        "playground_project": {"type": "string"},
+                                        "playground_yaml_file": {"type": "string"},
                                         "variables": {"type": "object"},
                                         "session_id": {
                                             "type": "string",

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -203,6 +203,58 @@ def _validate_upload_size(
         )
 
 
+def _read_text_file_with_size_limit(
+    path: str, *, max_upload_bytes: int = DEFAULT_MAX_UPLOAD_BYTES
+) -> str:
+    try:
+        file_size = os.path.getsize(path)
+    except OSError as exc:
+        raise DashboardAPIValidationError(f"Could not inspect file {path!r}.") from exc
+    if file_size <= 0:
+        raise DashboardAPIValidationError("Source file is empty.")
+    if file_size > max_upload_bytes:
+        raise DashboardAPIValidationError(
+            f"Source file is larger than {max_upload_bytes} bytes.", status_code=413
+        )
+    with open(path, "r", encoding="utf-8") as source_file:
+        return source_file.read()
+
+
+def _find_playground_yaml_source(
+    playground_project: str, selected_value: str
+) -> Dict[str, str]:
+    from .interview_linter import list_playground_yaml_files
+
+    playground_files = list_playground_yaml_files(playground_project or "default")
+    selected_file = next(
+        (
+            item
+            for item in playground_files
+            if item.get("label") == selected_value
+            or item.get("token") == selected_value
+        ),
+        None,
+    )
+    if not selected_file:
+        raise DashboardAPIValidationError(
+            "Could not find the requested Playground YAML file."
+        )
+    source_path = str(selected_file.get("token") or "").strip()
+    source_name = str(
+        selected_file.get("label") or os.path.basename(source_path)
+    ).strip()
+    if not source_path or not os.path.exists(source_path):
+        raise DashboardAPIValidationError(
+            "Could not resolve the requested Playground YAML file."
+        )
+    if not source_name.lower().endswith((".yml", ".yaml")):
+        raise DashboardAPIValidationError(
+            "Only YAML sources are supported for heuristic story generation.",
+            status_code=415,
+        )
+    return {"path": source_path, "filename": source_name}
+
+
 def _read_single_upload(*, field_name: str = "file") -> Dict[str, Any]:
     if field_name in request.files:
         upload = request.files[field_name]
@@ -1704,52 +1756,53 @@ def alkiln_story_payload_from_options(
 
     if yaml_text is None and upload is not None:
         filename = str(upload.get("filename") or "upload.yml")
-        content = upload.get("content")
-        if not isinstance(content, (bytes, bytearray)):
+        upload_content = upload.get("content")
+        if not isinstance(upload_content, (bytes, bytearray)):
             raise DashboardAPIValidationError("Upload content must be bytes.")
         if not filename.lower().endswith((".yml", ".yaml")):
             raise DashboardAPIValidationError(
                 "Only YAML uploads are supported for heuristic story generation.",
                 status_code=415,
             )
-        yaml_text = bytes(content).decode("utf-8", errors="replace")
+        yaml_text = bytes(upload_content).decode("utf-8", errors="replace")
         yaml_source_filename = filename
 
     if yaml_text is None and source_token:
         from .interview_linter import _resolve_source_token
 
-        source_path = _resolve_source_token(source_token)
+        if source_token.startswith("ref:"):
+            source_path = _resolve_source_token(source_token)
+            yaml_source_filename = str(
+                raw.get("filename") or os.path.basename(str(source_path or ""))
+            ).strip()
+        else:
+            selected_source = _find_playground_yaml_source(
+                playground_project, source_token
+            )
+            source_path = selected_source["path"]
+            yaml_source_filename = str(
+                raw.get("filename") or selected_source["filename"]
+            ).strip()
         if not source_path or not os.path.exists(source_path):
             raise DashboardAPIValidationError(
                 f"Could not resolve YAML source token {source_token!r}."
             )
-        with open(source_path, "r", encoding="utf-8") as source_file:
-            yaml_text = source_file.read()
+        if not yaml_source_filename.lower().endswith((".yml", ".yaml")):
+            raise DashboardAPIValidationError(
+                "Only YAML sources are supported for heuristic story generation.",
+                status_code=415,
+            )
+        yaml_text = _read_text_file_with_size_limit(source_path)
         yaml_source_path = source_path
-        yaml_source_filename = raw.get("filename") or source_token
 
     if yaml_text is None and playground_yaml_file:
-        from .interview_linter import list_playground_yaml_files
-
-        playground_files = list_playground_yaml_files(playground_project or "default")
-        selected_file = next(
-            (
-                item
-                for item in playground_files
-                if item.get("label") == playground_yaml_file
-                or item.get("token") == playground_yaml_file
-            ),
-            None,
+        selected_source = _find_playground_yaml_source(
+            playground_project, playground_yaml_file
         )
-        if not selected_file:
-            raise DashboardAPIValidationError(
-                f"Could not find playground YAML file {playground_yaml_file!r}."
-            )
-        source_path = str(selected_file.get("token") or "")
-        with open(source_path, "r", encoding="utf-8") as source_file:
-            yaml_text = source_file.read()
+        source_path = selected_source["path"]
+        yaml_text = _read_text_file_with_size_limit(source_path)
         yaml_source_path = source_path
-        yaml_source_filename = str(selected_file.get("label") or playground_yaml_file)
+        yaml_source_filename = str(selected_source["filename"] or playground_yaml_file)
 
     if data is None and session_id:
         from .aldashboard import (
@@ -1800,12 +1853,15 @@ def alkiln_story_payload_from_options(
     ):
         data = raw
 
-    if yaml_text is None and not isinstance(data, dict):
-        raise DashboardAPIValidationError(
-            "Provide docassemble JSON as `data`, `json_text`, or `variables`, "
-            "or YAML as `yaml_text`, `file_content_base64`, multipart `file`, "
-            "`source_token`, or `playground_project` with `playground_yaml_file`."
-        )
+    docassemble_data: Optional[Mapping[str, Any]] = None
+    if yaml_text is None:
+        if not isinstance(data, dict):
+            raise DashboardAPIValidationError(
+                "Provide docassemble JSON as `data`, `json_text`, or `variables`, "
+                "or YAML as `yaml_text`, `file_content_base64`, multipart `file`, "
+                "`source_token`, or `playground_project` with `playground_yaml_file`."
+            )
+        docassemble_data = data
 
     ignore_anywhere = _load_string_list_field(
         raw.get("ignore_anywhere_in_var_name"),
@@ -1822,7 +1878,10 @@ def alkiln_story_payload_from_options(
             yaml_text, source_path=yaml_source_path
         )
     else:
-        yaml_default_name = raw.get("interview_path") or default_yaml_file_name(data)
+        assert docassemble_data is not None
+        yaml_default_name = raw.get("interview_path") or default_yaml_file_name(
+            docassemble_data
+        )
         question_default = "review_screen"
 
     if raw.get("yaml_file_name"):
@@ -1860,7 +1919,8 @@ def alkiln_story_payload_from_options(
             filename=yaml_source_path or yaml_file_name,
             options=options,
         )
-    return story_from_docassemble_json(data, options=options)
+    assert docassemble_data is not None
+    return story_from_docassemble_json(docassemble_data, options=options)
 
 
 def _prepare_pdf_upload(raw_options: Mapping[str, Any]) -> Dict[str, Any]:

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1916,7 +1916,8 @@ def alkiln_story_payload_from_options(
     if yaml_text is not None:
         return story_from_docassemble_yaml(
             yaml_text,
-            filename=yaml_source_path or yaml_file_name,
+            filename=yaml_file_name,
+            source_path=yaml_source_path,
             options=options,
         )
     assert docassemble_data is not None

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1663,6 +1663,7 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
         DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME,
         StoryOptions,
         default_yaml_file_name,
+        load_docassemble_json_text,
         story_from_docassemble_json,
     )
 
@@ -1675,8 +1676,8 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
         if not isinstance(json_text, str) or not json_text.strip():
             raise DashboardAPIValidationError("json_text must be non-empty JSON.")
         try:
-            data = json.loads(json_text)
-        except json.JSONDecodeError as exc:
+            data = load_docassemble_json_text(json_text)
+        except (json.JSONDecodeError, ValueError) as exc:
             raise DashboardAPIValidationError("json_text must be valid JSON.") from exc
     elif data is None and variables is not None:
         data = {"variables": variables}
@@ -1713,12 +1714,20 @@ def alkiln_story_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[st
     scenario_description = str(
         raw.get("scenario_description") or "Generated scenario"
     ).strip()
+    include_trigger_column = parse_bool(
+        raw.get("include_trigger_column"), default=False
+    )
+    synthesize_target_number = parse_bool(
+        raw.get("synthesize_target_number"), default=True
+    )
 
     options = StoryOptions(
         feature_description=feature_description,
         scenario_description=scenario_description,
         yaml_file_name=yaml_file_name or "interview.yml",
         question_id=question_id or "review_screen",
+        include_trigger_column=include_trigger_column,
+        synthesize_target_number=synthesize_target_number,
         ignore_anywhere_in_var_name=ignore_anywhere,
     )
     return story_from_docassemble_json(data, options=options)
@@ -2206,6 +2215,8 @@ def build_openapi_spec() -> Dict[str, Any]:
                                         "question_id": {"type": "string"},
                                         "feature_description": {"type": "string"},
                                         "scenario_description": {"type": "string"},
+                                        "include_trigger_column": {"type": "boolean"},
+                                        "synthesize_target_number": {"type": "boolean"},
                                         "ignore_anywhere_in_var_name": {
                                             "type": "array",
                                             "items": {"type": "string"},

--- a/docassemble/ALDashboard/api_dashboard_worker.py
+++ b/docassemble/ALDashboard/api_dashboard_worker.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from docassemble.webapp.worker_common import bg_context, workerapp  # type: ignore[import-untyped]
 
 from .api_dashboard_utils import (
+    alkiln_story_payload_from_options,
     autolabel_payload_from_options,
     bootstrap_payload_from_options,
     docx_labeler_suggest_payload_from_options,
@@ -34,6 +35,12 @@ def dashboard_translation_task(payload: Dict[str, Any]) -> Dict[str, Any]:
 def dashboard_autolabel_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     with bg_context():
         return autolabel_payload_from_options(payload)
+
+
+@workerapp.task
+def dashboard_alkiln_story_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    with bg_context():
+        return alkiln_story_payload_from_options(payload)
 
 
 @workerapp.task

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -297,7 +297,8 @@ code: |
   if story_input_type == "yaml":
     story_result = story_from_docassemble_yaml(
       story_yaml_text,
-      filename=selected_playground_file if story_source == "playground" else yaml_file_name,
+      filename=story_default_yaml_file_name if story_source == "playground" else yaml_file_name,
+      source_path=selected_playground_file if story_source == "playground" else None,
       options=story_options,
     )
   else:

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -12,9 +12,11 @@ metadata:
 modules:
   - .alkiln_story
   - .aldashboard
+  - .interview_linter
 ---
 objects:
   - story_download: DAFile
+  - yaml_upload: DAFile
 ---
 mandatory: True
 code: |
@@ -23,6 +25,13 @@ code: |
     selected_interview_filename
     skip_step_one_sessions
     selected_session_id
+  elif story_source == "yaml_upload":
+    yaml_upload
+  elif story_source == "playground":
+    selected_playground_project
+    selected_playground_file
+  elif story_source == "pasted_yaml":
+    pasted_yaml
   else:
     pasted_json
   story_result
@@ -45,6 +54,9 @@ fields:
     choices:
       - Saved interview session: session
       - Pasted JSON: pasted_json
+      - Uploaded YAML: yaml_upload
+      - YAML in playground: playground
+      - Pasted YAML: pasted_yaml
     default: session
 ---
 code: |
@@ -138,12 +150,47 @@ fields:
     rows: 12
 ---
 question: |
+  Upload interview YAML
+fields:
+  - YAML file: yaml_upload
+    datatype: file
+---
+question: |
+  Select playground project
+fields:
+  - Playground project: selected_playground_project
+    datatype: combobox
+    code: |
+      list_playground_projects()
+---
+question: |
+  Select playground YAML
+fields:
+  - YAML file: selected_playground_file
+    datatype: combobox
+    code: |
+      {
+        item["token"]: item["label"]
+        for item in list_playground_yaml_files(selected_playground_project)
+      }
+validation code: |
+  if not selected_playground_file:
+    validation_error("Select a YAML file.")
+---
+question: |
+  Paste interview YAML
+fields:
+  - Docassemble YAML: pasted_yaml
+    input type: area
+    rows: 12
+---
+question: |
   Story options
 fields:
   - YAML file name: yaml_file_name
-    default: ${ selected_interview_filename if story_source == "session" else "interview.yml" }
+    default: ${ story_default_yaml_file_name }
   - Question ID: question_id
-    default: review_screen
+    default: ${ story_default_question_id }
   - Feature description: feature_description
     default: Generated docassemble test
   - Scenario description: scenario_description
@@ -171,14 +218,47 @@ fields:
       contains one of these strings.
 ---
 code: |
+  if story_source == "session":
+    story_default_yaml_file_name = selected_interview_filename
+    story_default_question_id = "review_screen"
+  elif story_source == "yaml_upload":
+    story_default_yaml_file_name = yaml_upload.filename
+    story_default_question_id = detect_yaml_ending_screen(yaml_upload.slurp())
+  elif story_source == "playground":
+    with open(selected_playground_file, "r", encoding="utf-8") as story_yaml_file:
+      selected_playground_yaml_text = story_yaml_file.read()
+    story_default_yaml_file_name = selected_playground_file.split("/")[-1]
+    story_default_question_id = detect_yaml_ending_screen(
+      selected_playground_yaml_text,
+      source_path=selected_playground_file,
+    )
+  elif story_source == "pasted_yaml":
+    story_default_yaml_file_name = "interview.yml"
+    story_default_question_id = detect_yaml_ending_screen(pasted_yaml)
+  else:
+    story_default_yaml_file_name = "interview.yml"
+    story_default_question_id = "review_screen"
+---
+code: |
   import json
   if story_source == "session":
     story_data = {
       "i": selected_interview_filename,
       "variables": selected_session_variables,
     }
+    story_input_type = "json"
+  elif story_source == "yaml_upload":
+    story_yaml_text = yaml_upload.slurp()
+    story_input_type = "yaml"
+  elif story_source == "playground":
+    story_yaml_text = selected_playground_yaml_text
+    story_input_type = "yaml"
+  elif story_source == "pasted_yaml":
+    story_yaml_text = pasted_yaml
+    story_input_type = "yaml"
   else:
     story_data = load_docassemble_json_text(pasted_json)
+    story_input_type = "json"
   ignore_anywhere = json.loads(ignore_anywhere_text) if ignore_anywhere_text.strip() else []
   story_options = StoryOptions(
     feature_description=feature_description,
@@ -189,7 +269,14 @@ code: |
     synthesize_target_number=synthesize_target_number,
     ignore_anywhere_in_var_name=ignore_anywhere,
   )
-  story_result = story_from_docassemble_json(story_data, options=story_options)
+  if story_input_type == "yaml":
+    story_result = story_from_docassemble_yaml(
+      story_yaml_text,
+      filename=selected_playground_file if story_source == "playground" else yaml_file_name,
+      options=story_options,
+    )
+  else:
+    story_result = story_from_docassemble_json(story_data, options=story_options)
   story_download.initialize(
     filename=output_file_name if output_file_name.endswith(".feature") else output_file_name + ".feature"
   )
@@ -204,6 +291,4 @@ subquestion: |
 
   **[Download story](${ story_download.url_for(attachment=True) })**
 
-  ```gherkin
-  ${ story_result["feature_text"] }
-  ```
+  ${ story_result["preview_markdown"] }

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -176,6 +176,15 @@ fields:
 validation code: |
   if not selected_playground_file:
     validation_error("Select a YAML file.")
+  allowed_playground_files = {
+    item["token"]: item["label"]
+    for item in list_playground_yaml_files(selected_playground_project)
+  }
+  if selected_playground_file not in allowed_playground_files:
+    validation_error(
+      "Select a YAML file from the chosen Playground project.",
+      field="selected_playground_file",
+    )
 ---
 question: |
   Paste interview YAML
@@ -259,7 +268,23 @@ code: |
   else:
     story_data = load_docassemble_json_text(pasted_json)
     story_input_type = "json"
-  ignore_anywhere = json.loads(ignore_anywhere_text) if ignore_anywhere_text.strip() else []
+  if ignore_anywhere_text.strip():
+    try:
+      ignore_anywhere = json.loads(ignore_anywhere_text)
+    except (ValueError, json.JSONDecodeError):
+      validation_error(
+        'Ignore Anywhere must be valid JSON, such as [] or ["name", "address"].',
+        field="ignore_anywhere_text",
+      )
+    if not isinstance(ignore_anywhere, list) or any(
+      not isinstance(item, str) for item in ignore_anywhere
+    ):
+      validation_error(
+        "Ignore Anywhere must be a JSON list of strings.",
+        field="ignore_anywhere_text",
+      )
+  else:
+    ignore_anywhere = []
   story_options = StoryOptions(
     feature_description=feature_description,
     scenario_description=scenario_description,

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -11,13 +11,20 @@ metadata:
 ---
 modules:
   - .alkiln_story
+  - .aldashboard
 ---
 objects:
   - story_download: DAFile
 ---
 mandatory: True
 code: |
-  pasted_json
+  story_source
+  if story_source == "session":
+    selected_interview_filename
+    skip_step_one_sessions
+    selected_session_id
+  else:
+    pasted_json
   story_result
   show_results
 ---
@@ -31,13 +38,110 @@ code: |
 question: |
   Generate an ALKiln story
 subquestion: |
+  Choose the source for the story table.
+fields:
+  - Source: story_source
+    datatype: radio
+    choices:
+      - Saved interview session: session
+      - Pasted JSON: pasted_json
+    default: session
+---
+code: |
+  interviews = {interview["filename"]: interview for interview in interview_menu()}
+  story_interview_choices = {}
+  for interview_filename, interview_info in sorted(
+    interviews.items(),
+    key=lambda item: (
+      item[1].get("title") or item[0]
+      if isinstance(item[1], dict)
+      else item[0]
+    ),
+  ):
+    interview_title = (
+      interview_info.get("title")
+      if isinstance(interview_info, dict)
+      else interview_filename
+    )
+    story_interview_choices[interview_filename] = (
+      f"{interview_title} | {interview_filename}"
+    )
+---
+question: |
+  Select an interview
+subquestion: |
+  Pick the interview whose saved answers you want to convert.
+fields:
+  - Interview: selected_interview_filename
+    datatype: combobox
+    code: |
+      story_interview_choices
+  - Skip sessions that are still on the first page: skip_step_one_sessions
+    datatype: yesno
+    default: True
+---
+code: |
+  import json
+
+  def _story_progress_label(progress, num_keys):
+    if progress is not None and str(progress).strip():
+      try:
+        return f"{float(progress):.2f}%"
+      except Exception:
+        return str(progress)
+    return f"Step {num_keys}"
+
+  story_session_choices = {}
+  for saved_session in speedy_get_sessions(
+    filename=selected_interview_filename,
+    filter_step1=skip_step_one_sessions,
+  ):
+    session_title = saved_session.title or saved_session.auto_title or saved_session.key
+    story_session_choices[saved_session.key] = (
+      f"{session_title} | {saved_session.key} | "
+      f"{format_date(saved_session.modtime, 'MMM d YYYY')} | "
+      f"{_story_progress_label(saved_session.progress, saved_session.num_keys)}"
+    )
+---
+question: |
+  Select a session
+subquestion: |
+  The progress value is shown when the interview saved it, so you can pick a recent and fairly complete run.
+fields:
+  - Session: selected_session_id
+    datatype: combobox
+    code: |
+      story_session_choices
+validation code: |
+  if not story_session_choices:
+    validation_error("No saved sessions were found for this interview.")
+  try:
+    selected_session_variables = dashboard_get_session_variables(
+      session_id=selected_session_id,
+      filename=selected_interview_filename,
+    )
+  except Exception as err:
+    validation_error(
+      "Could not load variables for this session. It may be encrypted with "
+      "a key that is not available to the dashboard, or the session may not "
+      f"contain a complete interview dictionary. Details: {err}",
+      field="selected_session_id",
+    )
+---
+question: |
+  Generate an ALKiln story
+subquestion: |
   Paste the JSON output from a docassemble interview.
 fields:
   - Docassemble JSON: pasted_json
     input type: area
     rows: 12
+---
+question: |
+  Story options
+fields:
   - YAML file name: yaml_file_name
-    default: interview.yml
+    default: ${ selected_interview_filename if story_source == "session" else "interview.yml" }
   - Question ID: question_id
     default: review_screen
   - Feature description: feature_description
@@ -68,7 +172,13 @@ fields:
 ---
 code: |
   import json
-  story_data = load_docassemble_json_text(pasted_json)
+  if story_source == "session":
+    story_data = {
+      "i": selected_interview_filename,
+      "variables": selected_session_variables,
+    }
+  else:
+    story_data = load_docassemble_json_text(pasted_json)
   ignore_anywhere = json.loads(ignore_anywhere_text) if ignore_anywhere_text.strip() else []
   story_options = StoryOptions(
     feature_description=feature_description,

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -46,6 +46,18 @@ fields:
     default: Generated scenario
   - Output file name: output_file_name
     default: generated_story.feature
+  - Include legacy trigger column: include_trigger_column
+    datatype: yesno
+    default: False
+    help: |
+      Current ALKiln supports 2-column story tables. Use this only when you
+      know you need the older 3-column table format.
+  - Add target_number rows for lists: synthesize_target_number
+    datatype: yesno
+    default: True
+    help: |
+      ALKiln uses target_number rows to safely handle lists that may ask
+      there_are_any or there_is_another questions.
   - Ignore variable names containing: ignore_anywhere_text
     input type: area
     rows: 8
@@ -56,13 +68,15 @@ fields:
 ---
 code: |
   import json
-  story_data = json.loads(pasted_json)
+  story_data = load_docassemble_json_text(pasted_json)
   ignore_anywhere = json.loads(ignore_anywhere_text) if ignore_anywhere_text.strip() else []
   story_options = StoryOptions(
     feature_description=feature_description,
     scenario_description=scenario_description,
     yaml_file_name=yaml_file_name,
     question_id=question_id,
+    include_trigger_column=include_trigger_column,
+    synthesize_target_number=synthesize_target_number,
     ignore_anywhere_in_var_name=ignore_anywhere,
   )
   story_result = story_from_docassemble_json(story_data, options=story_options)

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -1,0 +1,85 @@
+---
+include:
+  - nav.yml
+---
+metadata:
+  title: ALKiln story generator
+  temporary session: True
+  required privileges:
+    - admin
+    - developer
+---
+modules:
+  - .alkiln_story
+---
+objects:
+  - story_download: DAFile
+---
+mandatory: True
+code: |
+  pasted_json
+  story_result
+  show_results
+---
+code: |
+  import json
+  default_ignore_anywhere_text = json.dumps(
+    sorted(DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME),
+    indent=2,
+  )
+---
+question: |
+  Generate an ALKiln story
+subquestion: |
+  Paste the JSON output from a docassemble interview.
+fields:
+  - Docassemble JSON: pasted_json
+    input type: area
+    rows: 12
+  - YAML file name: yaml_file_name
+    default: interview.yml
+  - Question ID: question_id
+    default: review_screen
+  - Feature description: feature_description
+    default: Generated docassemble test
+  - Scenario description: scenario_description
+    default: Generated scenario
+  - Output file name: output_file_name
+    default: generated_story.feature
+  - Ignore variable names containing: ignore_anywhere_text
+    input type: area
+    rows: 8
+    default: ${ default_ignore_anywhere_text }
+    help: |
+      JSON list of strings. A generated row is skipped when its variable name
+      contains one of these strings.
+---
+code: |
+  import json
+  story_data = json.loads(pasted_json)
+  ignore_anywhere = json.loads(ignore_anywhere_text) if ignore_anywhere_text.strip() else []
+  story_options = StoryOptions(
+    feature_description=feature_description,
+    scenario_description=scenario_description,
+    yaml_file_name=yaml_file_name,
+    question_id=question_id,
+    ignore_anywhere_in_var_name=ignore_anywhere,
+  )
+  story_result = story_from_docassemble_json(story_data, options=story_options)
+  story_download.initialize(
+    filename=output_file_name if output_file_name.endswith(".feature") else output_file_name + ".feature"
+  )
+  story_download.write(story_result["feature_text"])
+  story_download.commit()
+---
+event: show_results
+question: |
+  ALKiln story
+subquestion: |
+  Rows generated: **${ story_result["row_count"] }**
+
+  **[Download story](${ story_download.url_for(attachment=True) })**
+
+  ```gherkin
+  ${ story_result["feature_text"] }
+  ```

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -104,6 +104,9 @@ data:
   - name: Interview style check (lint)
     url: ${ interview_url(i=user_info().package + ":interview_linter.yml", reset=1) }
     image: spell-check
+  - name: Generate an ALKiln story
+    url: ${ interview_url(i=user_info().package + ":alkiln_story.yml", reset=1) }
+    image: book
   - name: Reformat YAML and Python
     url: ${ interview_url(i=user_info().package + ":yaml_formatter.yml", reset=1) }
     image: magic

--- a/docassemble/ALDashboard/test/fixture_interview_answers.json
+++ b/docassemble/ALDashboard/test/fixture_interview_answers.json
@@ -1,0 +1,83 @@
+{
+  "interview_short_title": "Ask the Appeals Court to Stop Your Eviction",
+  "acknowledged_information_use": {
+    "_class": "docassemble.base.util.DADict",
+    "instanceName": "acknowledged_information_use",
+    "elements": {
+      "I accept the terms of use.": true
+    },
+    "auto_gather": false,
+    "ask_number": false,
+    "minimum_number": null,
+    "object_type": null,
+    "object_type_parameters": {},
+    "complete_attribute": null,
+    "ask_object_type": false,
+    "gathered": true
+  },
+  "eviction_notice": {
+    "_class": "docassemble.base.util.DAStaticFile",
+    "instanceName": "eviction_notice",
+    "extension": "png",
+    "mimetype": "image/png",
+    "package": "docassemble.MotionToStayEviction",
+    "filename": "48_Hour_Notice.png",
+    "alt_text": "An example 48-Hour Notice. Title reads \"48 hours notice to vacate premises\", will be addressed to the tenant, signed by a landlord or attorney, and will include the contact information of the constable."
+  },
+  "users": {
+    "_class": "docassemble.AssemblyLine.al_general.ALPeopleList",
+    "instanceName": "users",
+    "elements": [
+      {
+        "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+        "name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "first": "John",
+          "middle": "",
+          "last": "Brown",
+          "uses_parts": true
+        },
+        "address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "address": "7 Millbrook Street",
+          "city": "WORCESTER",
+          "state": "MA",
+          "zip": "01605"
+        }
+      }
+    ],
+    "there_are_any": true,
+    "target_number": 1,
+    "gathered": true
+  },
+  "other_parties": {
+    "_class": "docassemble.AssemblyLine.al_general.ALPeopleList",
+    "instanceName": "other_parties",
+    "elements": [
+      {
+        "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+        "name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "first": "Steven",
+          "middle": "",
+          "last": "Brown",
+          "uses_parts": true
+        },
+        "address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "address": "68 Windsor Street",
+          "city": "WORCESTER",
+          "state": "MA",
+          "zip": "01605"
+        }
+      }
+    ],
+    "there_are_any": true,
+    "target_number": 1,
+    "gathered": true
+  },
+  "eviction_date": "2026-03-10T00:00:00-04:00",
+  "signature_choice": "typed_signature",
+  "typed_signature": "users[0].typed_signature",
+  "comments_to_clerk": "aoeuaoeuaeo"
+}

--- a/docassemble/ALDashboard/test/fixture_interview_answers_lists.json
+++ b/docassemble/ALDashboard/test/fixture_interview_answers_lists.json
@@ -1,0 +1,52 @@
+{
+  "users": {
+    "_class": "docassemble.base.core.DAList",
+    "instanceName": "users",
+    "elements": [
+      {
+        "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+        "name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "first": "Ada",
+          "middle": "",
+          "last": "Lovelace",
+          "uses_parts": true
+        },
+        "address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "address": "1 Main St",
+          "city": "WORCESTER",
+          "state": "MA",
+          "zip": "01605"
+        }
+      },
+      {
+        "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+        "name": {
+          "_class": "docassemble.base.util.IndividualName",
+          "first": "Grace",
+          "middle": "",
+          "last": "Hopper",
+          "uses_parts": true
+        },
+        "address": {
+          "_class": "docassemble.AssemblyLine.al_general.ALAddress",
+          "address": "2 Main St",
+          "city": "WORCESTER",
+          "state": "MA",
+          "zip": "01605"
+        }
+      }
+    ],
+    "there_are_any": true,
+    "gathered": true
+  },
+  "choices": {
+    "_class": "docassemble.base.core.DADict",
+    "elements": {
+      "apple": false,
+      "banana": false
+    },
+    "gathered": true
+  }
+}

--- a/docassemble/ALDashboard/test/fixture_interview_answers_textarea_newlines.json
+++ b/docassemble/ALDashboard/test/fixture_interview_answers_textarea_newlines.json
@@ -1,0 +1,4 @@
+{
+  "note": "Line one\\r\\nLine two",
+  "description": "Safe JSON export with escaped CRLF text."
+}

--- a/docassemble/ALDashboard/test/fixture_interview_answers_unescaped_quotes.json
+++ b/docassemble/ALDashboard/test/fixture_interview_answers_unescaped_quotes.json
@@ -1,0 +1,12 @@
+{
+  "eviction_notice": {
+    "_class": "docassemble.base.util.DAStaticFile",
+    "instanceName": "eviction_notice",
+    "extension": "png",
+    "mimetype": "image/png",
+    "package": "docassemble.MotionToStayEviction",
+    "filename": "48_Hour_Notice.png",
+    "alt_text": "An example 48-Hour Notice. Title reads \"48 hours notice to vacate premises\", will be addressed to the tenant, signed by a landlord or attorney, and will include the contact information of the constable."
+  },
+  "accepted": true
+}

--- a/docassemble/ALDashboard/test/test_alkiln_story.py
+++ b/docassemble/ALDashboard/test/test_alkiln_story.py
@@ -77,6 +77,72 @@ class TestALKilnStory(unittest.TestCase):
         self.assertIn("| users[1].name['first'] | Grace |", rows)
         self.assertNotIn("| users.there_are_any | True |", rows)
 
+    def test_rows_from_variables_skips_type_annotation_imports(self):
+        rows = rows_from_variables(
+            {
+                "Dict": None,
+                "Tuple": None,
+                "Fields": None,
+                "Optional": None,
+                "List": None,
+                "Union": None,
+                "Iterable": None,
+                "Callable": None,
+                "name": "Ada",
+            },
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertEqual(rows, ["| name | Ada |"])
+
+    def test_rows_from_variables_skips_file_helper_objects(self):
+        rows = rows_from_variables(
+            {
+                "uploaded_file": {
+                    "_class": "docassemble.base.util.DAFile",
+                    "filename": "secret.pdf",
+                    "number": 42,
+                    "ok": True,
+                },
+                "logo": {
+                    "_class": "docassemble.base.util.DAStaticFile",
+                    "filename": "logo.png",
+                    "package": "docassemble.demo",
+                },
+                "name": "Ada",
+            },
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertEqual(rows, ["| name | Ada |"])
+
+    def test_rows_from_variables_skips_reference_cache_roots(self):
+        rows = rows_from_variables(
+            {
+                "legalserver_data": {"documents": [{"name": "Cached PDF"}]},
+                "valid_housing_courts": [{"name": "Housing Court"}],
+                "all_reserved_names": {"elements": {"x": True}},
+                "name": "Ada",
+            },
+        )
+        self.assertEqual(rows, ["| name | Ada |"])
+
+    def test_rows_from_variables_skips_documented_top_level_reserved_names(self):
+        rows = rows_from_variables(
+            {
+                "device": "phone",
+                "session_tags": ["draft"],
+                "start_time": "2026-05-19T10:30:00-04:00",
+                "user_lat_lon": "42,-71",
+                "name": "Ada",
+                "child": {"name": "Grace"},
+            },
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| name | Ada |", rows)
+        self.assertIn("| child['name'] | Grace |", rows)
+        self.assertNotIn("| device | phone |", rows)
+        self.assertNotIn("| session_tags[0] | draft |", rows)
+        self.assertNotIn("| user_lat_lon | 42,-71 |", rows)
+
     def test_rows_from_variables_can_emit_legacy_trigger_column(self):
         rows = rows_from_variables(
             {"name": "Ada"},
@@ -176,10 +242,12 @@ class TestALKilnStory(unittest.TestCase):
 
     def test_openapi_and_mcp_include_story_endpoint(self):
         spec = build_openapi_spec()
-        self.assertIn("/al/api/v1/dashboard/interview/story", spec["paths"])
+        self.assertIn("/al/api/v1/dashboard/kiln/story", spec["paths"])
+        self.assertNotIn("/al/api/v1/dashboard/interview/story", spec["paths"])
+        self.assertNotIn("/al/api/v1/dashboard/interview/kiln-fixture", spec["paths"])
         tools = openapi_to_mcp_tools(spec, namespace="aldashboard")
         names = [tool["name"] for tool in tools]
-        self.assertIn("aldashboard.post_al_api_v1_dashboard_interview_story", names)
+        self.assertIn("aldashboard.post_al_api_v1_dashboard_kiln_story", names)
 
 
 if __name__ == "__main__":

--- a/docassemble/ALDashboard/test/test_alkiln_story.py
+++ b/docassemble/ALDashboard/test/test_alkiln_story.py
@@ -1,8 +1,11 @@
 # do not pre-load
+import json
 import unittest
+from pathlib import Path
 
 from docassemble.ALDashboard.alkiln_story import (
     StoryOptions,
+    load_docassemble_json_text,
     rows_from_variables,
     story_from_docassemble_json,
 )
@@ -11,6 +14,12 @@ from docassemble.ALDashboard.api_dashboard_utils import (
     build_openapi_spec,
 )
 from docassemble.ALDashboard.mcp_registry import openapi_to_mcp_tools
+
+FIXTURES_DIR = Path(__file__).parent
+
+
+def read_fixture(name):
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
 
 
 class TestALKilnStory(unittest.TestCase):
@@ -25,9 +34,9 @@ class TestALKilnStory(unittest.TestCase):
             },
             options=StoryOptions(ignore_anywhere_in_var_name=[]),
         )
-        self.assertIn("| users.name['first'] | Ada |  |", rows)
-        self.assertIn("| users.name['last'] | Lovelace |  |", rows)
-        self.assertIn("| started | 05/19/2026 |  |", rows)
+        self.assertIn("| users.name['first'] | Ada |", rows)
+        self.assertIn("| users.name['last'] | Lovelace |", rows)
+        self.assertIn("| started | 05/19/2026 |", rows)
 
     def test_rows_from_variables_handles_checkbox_elements_and_none(self):
         rows = rows_from_variables(
@@ -39,9 +48,44 @@ class TestALKilnStory(unittest.TestCase):
             },
             options=StoryOptions(ignore_anywhere_in_var_name=[]),
         )
-        self.assertIn("| fruit['apple'] | False |  |", rows)
-        self.assertIn("| fruit['banana'] | False |  |", rows)
-        self.assertIn("| fruit['None'] | True |  |", rows)
+        self.assertIn("| fruit['apple'] | False |", rows)
+        self.assertIn("| fruit['banana'] | False |", rows)
+        self.assertIn("| fruit['None'] | True |", rows)
+
+    def test_rows_from_variables_synthesizes_target_number_for_lists(self):
+        rows = rows_from_variables(
+            {
+                "users": {
+                    "_class": "docassemble.base.core.DAList",
+                    "elements": [
+                        {
+                            "_class": "docassemble.base.util.Individual",
+                            "name": {"first": "Ada"},
+                        },
+                        {
+                            "_class": "docassemble.base.util.Individual",
+                            "name": {"first": "Grace"},
+                        },
+                    ],
+                    "there_are_any": True,
+                }
+            },
+            options=StoryOptions(ignore_anywhere_in_var_name=["_class"]),
+        )
+        self.assertIn("| users.target_number | 2 |", rows)
+        self.assertIn("| users[0].name['first'] | Ada |", rows)
+        self.assertIn("| users[1].name['first'] | Grace |", rows)
+        self.assertNotIn("| users.there_are_any | True |", rows)
+
+    def test_rows_from_variables_can_emit_legacy_trigger_column(self):
+        rows = rows_from_variables(
+            {"name": "Ada"},
+            options=StoryOptions(
+                ignore_anywhere_in_var_name=[],
+                include_trigger_column=True,
+            ),
+        )
+        self.assertEqual(rows, ["| name | Ada |  |"])
 
     def test_story_from_docassemble_json_builds_feature_text(self):
         result = story_from_docassemble_json(
@@ -61,7 +105,8 @@ class TestALKilnStory(unittest.TestCase):
         self.assertIn(
             'And the user gets to "review" with this data:', result["feature_text"]
         )
-        self.assertIn("| x | 1 |  |", result["feature_text"])
+        self.assertIn("| var | value |", result["feature_text"])
+        self.assertIn("| x | 1 |", result["feature_text"])
 
     def test_api_payload_accepts_json_text(self):
         payload = alkiln_story_payload_from_options(
@@ -72,10 +117,62 @@ class TestALKilnStory(unittest.TestCase):
                 "ignore_anywhere_in_var_name": [],
             }
         )
-        self.assertEqual(payload["rows"], ["| name | Ada |  |"])
+        self.assertEqual(payload["rows"], ["| name | Ada |"])
         self.assertIn(
             'Given I start the interview at "test.yml"', payload["feature_text"]
         )
+
+    def test_load_docassemble_json_text_accepts_fixture_textarea_newlines(self):
+        json_text = read_fixture("fixture_interview_answers_textarea_newlines.json")
+        textarea_text = json_text.replace("\\\\r\\\\n", "\r\n")
+        with self.assertRaises(ValueError):
+            # The strict parser path is expected to reject this textarea-shaped
+            # variant before the fallback accepts it below.
+            json.loads(textarea_text)
+
+        data = load_docassemble_json_text(textarea_text)
+        self.assertEqual(data["note"], "Line one\r\nLine two")
+
+        payload = alkiln_story_payload_from_options({"json_text": textarea_text})
+        self.assertGreater(payload["row_count"], 0)
+        self.assertIn("| var | value |", payload["feature_text"])
+
+    def test_load_docassemble_json_text_repairs_unescaped_inner_quotes(self):
+        json_text = read_fixture("fixture_interview_answers_unescaped_quotes.json")
+        textarea_text = json_text.replace('\\"', '"')
+        with self.assertRaises(ValueError):
+            json.loads(textarea_text)
+
+        data = load_docassemble_json_text(textarea_text)
+        self.assertIn(
+            'Title reads "48 hours notice to vacate premises"',
+            data["eviction_notice"]["alt_text"],
+        )
+        payload = alkiln_story_payload_from_options({"json_text": textarea_text})
+        self.assertIn("| accepted | True |", payload["feature_text"])
+
+    def test_trimmed_real_fixture_excludes_verbose_court_information(self):
+        json_text = read_fixture("fixture_interview_answers.json")
+        data = load_docassemble_json_text(json_text)
+        self.assertNotIn("courts", data)
+        self.assertNotIn("appeals_court", data)
+        self.assertLess(len(json_text), 4000)
+
+        payload = alkiln_story_payload_from_options({"json_text": json_text})
+        self.assertIn("| users.target_number | 1 |", payload["feature_text"])
+        self.assertIn("| eviction_date | 03/10/2026 |", payload["feature_text"])
+        self.assertNotIn("Massachusetts Appeals Court", payload["feature_text"])
+
+    def test_list_fixture_covers_target_numbers_and_checkbox_none(self):
+        json_text = read_fixture("fixture_interview_answers_lists.json")
+        payload = alkiln_story_payload_from_options(
+            {"json_text": json_text, "ignore_anywhere_in_var_name": ["_class"]}
+        )
+        rows = payload["rows"]
+        self.assertIn("| users.target_number | 2 |", rows)
+        self.assertIn("| users[0].name.first | Ada |", rows)
+        self.assertIn("| users[1].name.last | Hopper |", rows)
+        self.assertIn("| choices['None'] | True |", rows)
 
     def test_openapi_and_mcp_include_story_endpoint(self):
         spec = build_openapi_spec()

--- a/docassemble/ALDashboard/test/test_alkiln_story.py
+++ b/docassemble/ALDashboard/test/test_alkiln_story.py
@@ -435,6 +435,86 @@ question: Done
         self.assertIn("| users[0].address.address | 123 Main St |", result["rows"])
         self.assertIn("| users[0].address.city | Boston |", result["rows"])
 
+    def test_story_from_docassemble_yaml_blocks_parent_directory_includes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            nested_dir = temp_path / "nested"
+            nested_dir.mkdir()
+            shared_path = temp_path / "shared.yml"
+            shared_path.write_text(
+                """---
+question: Shared
+fields:
+  - Acknowledge: acknowledged_information_use
+    datatype: yesno
+""",
+                encoding="utf-8",
+            )
+            main_path = nested_dir / "main.yml"
+            main_path.write_text(
+                """---
+include:
+  - ../shared.yml
+---
+fields:
+  - Name: user_name
+---
+event: final_screen
+question: Done
+""",
+                encoding="utf-8",
+            )
+            result = story_from_docassemble_yaml(
+                main_path.read_text(encoding="utf-8"),
+                filename=str(main_path),
+                options=StoryOptions(
+                    yaml_file_name="main.yml",
+                    question_id="final_screen",
+                    ignore_anywhere_in_var_name=[],
+                ),
+            )
+        self.assertIn("| user_name | Sample answer |", result["rows"])
+        self.assertNotIn("| acknowledged_information_use | True |", result["rows"])
+
+    def test_story_from_docassemble_yaml_blocks_absolute_includes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            shared_path = temp_path / "shared.yml"
+            shared_path.write_text(
+                """---
+question: Shared
+fields:
+  - Acknowledge: acknowledged_information_use
+    datatype: yesno
+""",
+                encoding="utf-8",
+            )
+            main_path = temp_path / "main.yml"
+            main_path.write_text(
+                f"""---
+include:
+  - {shared_path}
+---
+fields:
+  - Name: user_name
+---
+event: final_screen
+question: Done
+""",
+                encoding="utf-8",
+            )
+            result = story_from_docassemble_yaml(
+                main_path.read_text(encoding="utf-8"),
+                filename=str(main_path),
+                options=StoryOptions(
+                    yaml_file_name="main.yml",
+                    question_id="final_screen",
+                    ignore_anywhere_in_var_name=[],
+                ),
+            )
+        self.assertIn("| user_name | Sample answer |", result["rows"])
+        self.assertNotIn("| acknowledged_information_use | True |", result["rows"])
+
     def test_story_from_docassemble_yaml_detects_filename_and_ending_screen(self):
         yaml_text = """---
 id: intro
@@ -499,6 +579,31 @@ question: Done
         self.assertEqual(payload["yaml_file_name"], "uploaded_interview.yml")
         self.assertEqual(payload["question_id"], "final")
         self.assertIn("| user_name | Sample answer |", payload["rows"])
+
+    def test_api_payload_inline_yaml_does_not_expand_includes_from_yaml_file_name(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source_path = temp_path / "existing.yml"
+            source_path.write_text("---\nquestion: Placeholder\n", encoding="utf-8")
+            (temp_path / "shared.yml").write_text(
+                """---
+question: Shared
+fields:
+  - Acknowledge: acknowledged_information_use
+    datatype: yesno
+""",
+                encoding="utf-8",
+            )
+            payload = alkiln_story_payload_from_options(
+                {
+                    "yaml_text": "---\ninclude:\n  - shared.yml\n---\nfields:\n  - Name: user_name\n---\nid: final\nquestion: Done\n",
+                    "yaml_file_name": str(source_path),
+                    "ignore_anywhere_in_var_name": [],
+                }
+            )
+        self.assertEqual(payload["yaml_file_name"], "existing.yml")
+        self.assertIn("| user_name | Sample answer |", payload["rows"])
+        self.assertNotIn("| acknowledged_information_use | True |", payload["rows"])
 
     def test_api_payload_rejects_arbitrary_source_token_paths(self):
         with self.assertRaises(DashboardAPIValidationError) as exc:

--- a/docassemble/ALDashboard/test/test_alkiln_story.py
+++ b/docassemble/ALDashboard/test/test_alkiln_story.py
@@ -1,12 +1,18 @@
 # do not pre-load
+import base64
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
 from docassemble.ALDashboard.alkiln_story import (
     StoryOptions,
+    build_feature_preview_markdown,
+    detect_yaml_ending_screen,
     load_docassemble_json_text,
     rows_from_variables,
+    rows_from_yaml_heuristics,
+    story_from_docassemble_yaml,
     story_from_docassemble_json,
 )
 from docassemble.ALDashboard.api_dashboard_utils import (
@@ -173,6 +179,19 @@ class TestALKilnStory(unittest.TestCase):
         )
         self.assertIn("| var | value |", result["feature_text"])
         self.assertIn("| x | 1 |", result["feature_text"])
+        self.assertEqual(
+            result["preview_markdown"],
+            build_feature_preview_markdown(result["feature_text"]),
+        )
+
+    def test_build_feature_preview_markdown_preserves_blank_lines(self):
+        preview = build_feature_preview_markdown(
+            "Feature: Story\n\nScenario: Preview\n  Given x < y"
+        )
+        self.assertTrue(all(line.startswith("    ") for line in preview.split("\n")))
+        self.assertIn("    \n", preview)
+        self.assertIn("    Scenario: Preview", preview)
+        self.assertIn("    Feature: Story", preview)
 
     def test_api_payload_accepts_json_text(self):
         payload = alkiln_story_payload_from_options(
@@ -187,6 +206,285 @@ class TestALKilnStory(unittest.TestCase):
         self.assertIn(
             'Given I start the interview at "test.yml"', payload["feature_text"]
         )
+
+    def test_rows_from_yaml_heuristics_extracts_fields_and_continue_button(self):
+        yaml_text = """---
+question: Name
+fields:
+  - First name: users[0].name.first
+  - Last name: users[0].name.last
+  - Is active?: is_active
+    datatype: yesno
+---
+question: Done
+continue button field: saw_done_screen
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| users[0].name.first | Jane |", rows)
+        self.assertIn("| users[0].name.last | Smith |", rows)
+        self.assertIn("| is_active | True |", rows)
+        self.assertIn("| saw_done_screen | True |", rows)
+
+    def test_rows_from_yaml_heuristics_normalizes_today_default(self):
+        yaml_text = """---
+question: Signature
+fields:
+  - Signature date: principal_signature_date
+    datatype: date
+    default: ${ today() }
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| principal_signature_date | today |", rows)
+        self.assertNotIn("| principal_signature_date | ${ today() } |", rows)
+
+    def test_rows_from_yaml_heuristics_uses_examples_and_minlength(self):
+        yaml_text = """---
+question: Vehicle
+fields:
+  - Vehicle year: vehicle_year
+  - Vehicle make: vehicle_make
+    under text: "example: Kia"
+  - Vehicle Identification Number (VIN): VIN
+    minlength: 17
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| vehicle_year | 2023 |", rows)
+        self.assertIn("| vehicle_make | Kia |", rows)
+        self.assertIn("| VIN | 11111111111111111 |", rows)
+
+    def test_rows_from_yaml_heuristics_supports_peoplelist_fields_helpers(self):
+        yaml_text = """---
+fields:
+  - code: |
+      users[i].name_fields(show_title=True)
+  - code: |
+      users[i].address_fields(show_country=True, show_county=True, allow_no_address=True, ask_if_impounded=True)
+  - code: |
+      users[i].gender_fields()
+  - code: |
+      users[i].language_fields()
+  - code: |
+      users[i].pronoun_fields()
+---
+fields:
+  - code: |
+      other_parties[i].name_fields(person_or_business='business')
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| users[0].name.title | Mr. |", rows)
+        self.assertIn("| users[0].name.first | Jane |", rows)
+        self.assertIn("| users[0].name.suffix | Jr. |", rows)
+        self.assertIn("| users[0].address.has_no_address | False |", rows)
+        self.assertIn("| users[0].address.country | US |", rows)
+        self.assertIn("| users[0].address.county | Suffolk |", rows)
+        self.assertIn("| users[0].address.impounded | False |", rows)
+        self.assertIn("| users[0].gender | female |", rows)
+        self.assertIn("| users[0].language | en |", rows)
+        self.assertIn("| users[0].pronouns['he/him/his'] | True |", rows)
+        self.assertIn("| other_parties[0].name.first | Acme LLC |", rows)
+        self.assertNotIn("| other_parties[0].name.last | Smith |", rows)
+
+    def test_rows_from_yaml_heuristics_adds_assemblyline_people_for_gather(self):
+        yaml_text = """---
+objects:
+  - children: ALPeopleList.using(ask_number=True)
+---
+mandatory: True
+code: |
+  users.gather()
+  children.gather()
+---
+event: download
+question: Download
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| users.target_number | 1 |", rows)
+        self.assertIn("| users[0].name.first | Jane |", rows)
+        self.assertIn("| children.target_number | 1 |", rows)
+        self.assertIn("| children[0].name.last | Smith |", rows)
+
+    def test_rows_from_yaml_heuristics_handles_single_field_sets_and_checkboxes(self):
+        yaml_text = """---
+question: Role
+field: person_answering
+datatype: radio
+choices:
+  - Tenant: tenant
+  - Attorney: attorney
+---
+question: Terms
+fields:
+  - Accept terms: acknowledged_information_use
+    datatype: checkboxes
+    choices:
+      - I accept the terms of use.
+      - Email me updates.
+---
+question: Address
+sets:
+  - users[0].address.address
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| person_answering | tenant |", rows)
+        self.assertIn(
+            "| acknowledged_information_use['I accept the terms of use.'] | True |",
+            rows,
+        )
+        self.assertIn(
+            "| acknowledged_information_use['Email me updates.'] | False |",
+            rows,
+        )
+        self.assertIn("| users[0].address.address | 123 Main St |", rows)
+        self.assertIn("| users[0].address.city | Boston |", rows)
+        self.assertIn("| users[0].address.state | MA |", rows)
+        self.assertIn("| users[0].address.zip | 02108 |", rows)
+
+    def test_rows_from_yaml_heuristics_extracts_direct_code_references(self):
+        yaml_text = """---
+objects:
+  - users[i].attorney: ALPeopleList.using(ask_number=True)
+---
+mandatory: True
+code: |
+  users[0].address.address
+  users[0].signature
+  users[0].attorney.target_number = 1
+  users[0].attorney[0].address.address
+"""
+        rows = rows_from_yaml_heuristics(
+            yaml_text,
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| users[0].address.address | 123 Main St |", rows)
+        self.assertIn("| users[0].address.city | Boston |", rows)
+        self.assertIn("| users[0].signature | /placeholder_signature.png |", rows)
+        self.assertIn("| users[0].attorney.target_number | 1 |", rows)
+        self.assertIn("| users[0].attorney[0].name.first | Jane |", rows)
+        self.assertIn("| users[0].attorney[0].address.address | 123 Main St |", rows)
+
+    def test_story_from_docassemble_yaml_loads_local_includes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            shared_path = temp_path / "shared.yml"
+            shared_path.write_text(
+                """---
+question: Shared
+fields:
+  - Acknowledge: acknowledged_information_use
+    datatype: yesno
+""",
+                encoding="utf-8",
+            )
+            main_path = temp_path / "main.yml"
+            main_path.write_text(
+                """---
+include:
+  - shared.yml
+---
+mandatory: True
+code: |
+  users[0].address.address
+---
+event: final_screen
+question: Done
+""",
+                encoding="utf-8",
+            )
+            result = story_from_docassemble_yaml(
+                main_path.read_text(encoding="utf-8"),
+                filename=str(main_path),
+                options=StoryOptions(
+                    yaml_file_name="main.yml",
+                    question_id="final_screen",
+                    ignore_anywhere_in_var_name=[],
+                ),
+            )
+        self.assertIn("| acknowledged_information_use | True |", result["rows"])
+        self.assertIn("| users[0].address.address | 123 Main St |", result["rows"])
+        self.assertIn("| users[0].address.city | Boston |", result["rows"])
+
+    def test_story_from_docassemble_yaml_detects_filename_and_ending_screen(self):
+        yaml_text = """---
+id: intro
+question: Intro
+---
+event: final_screen
+question: Done
+"""
+        result = story_from_docassemble_yaml(
+            yaml_text,
+            filename="/tmp/example_interview.yml",
+            options=StoryOptions(
+                yaml_file_name="example_interview.yml",
+                question_id=detect_yaml_ending_screen(yaml_text),
+                ignore_anywhere_in_var_name=[],
+            ),
+        )
+        self.assertEqual(result["yaml_file_name"], "example_interview.yml")
+        self.assertEqual(result["question_id"], "final_screen")
+        self.assertIn(
+            'Given I start the interview at "example_interview.yml"',
+            result["feature_text"],
+        )
+        self.assertIn('And the user gets to "final_screen"', result["feature_text"])
+
+    def test_detect_yaml_ending_screen_prefers_sanitized_id(self):
+        yaml_text = """---
+id: download lemon_law_letter
+event: lemon_law_letter_download
+question: Done
+"""
+        self.assertEqual(
+            detect_yaml_ending_screen(yaml_text),
+            "download lemon_law_letter",
+        )
+
+    def test_api_payload_accepts_yaml_text(self):
+        payload = alkiln_story_payload_from_options(
+            {
+                "yaml_text": "---\nfields:\n  - Email: user_email\n    input type: email\n---\nevent: done\nquestion: Done\n",
+                "filename": "intake.yml",
+                "ignore_anywhere_in_var_name": [],
+            }
+        )
+        self.assertEqual(payload["yaml_file_name"], "intake.yml")
+        self.assertEqual(payload["question_id"], "done")
+        self.assertIn("| user_email | user@example.com |", payload["rows"])
+
+    def test_api_payload_accepts_yaml_file_content_base64(self):
+        yaml_text = (
+            "---\nfields:\n  - Name: user_name\n---\nid: final\nquestion: Done\n"
+        )
+        payload = alkiln_story_payload_from_options(
+            {
+                "filename": "uploaded_interview.yml",
+                "file_content_base64": base64.b64encode(
+                    yaml_text.encode("utf-8")
+                ).decode("ascii"),
+                "ignore_anywhere_in_var_name": [],
+            }
+        )
+        self.assertEqual(payload["yaml_file_name"], "uploaded_interview.yml")
+        self.assertEqual(payload["question_id"], "final")
+        self.assertIn("| user_name | Sample answer |", payload["rows"])
 
     def test_load_docassemble_json_text_accepts_fixture_textarea_newlines(self):
         json_text = read_fixture("fixture_interview_answers_textarea_newlines.json")

--- a/docassemble/ALDashboard/test/test_alkiln_story.py
+++ b/docassemble/ALDashboard/test/test_alkiln_story.py
@@ -1,0 +1,89 @@
+# do not pre-load
+import unittest
+
+from docassemble.ALDashboard.alkiln_story import (
+    StoryOptions,
+    rows_from_variables,
+    story_from_docassemble_json,
+)
+from docassemble.ALDashboard.api_dashboard_utils import (
+    alkiln_story_payload_from_options,
+    build_openapi_spec,
+)
+from docassemble.ALDashboard.mcp_registry import openapi_to_mcp_tools
+
+
+class TestALKilnStory(unittest.TestCase):
+    def test_rows_from_variables_handles_nested_objects_and_dates(self):
+        rows = rows_from_variables(
+            {
+                "users": {
+                    "_class": "docassemble.base.util.Individual",
+                    "name": {"first": "Ada", "last": "Lovelace"},
+                },
+                "started": "2026-05-19T10:30:00-04:00",
+            },
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| users.name['first'] | Ada |  |", rows)
+        self.assertIn("| users.name['last'] | Lovelace |  |", rows)
+        self.assertIn("| started | 05/19/2026 |  |", rows)
+
+    def test_rows_from_variables_handles_checkbox_elements_and_none(self):
+        rows = rows_from_variables(
+            {
+                "fruit": {
+                    "_class": "docassemble.base.util.DADict",
+                    "elements": {"apple": False, "banana": False},
+                }
+            },
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertIn("| fruit['apple'] | False |  |", rows)
+        self.assertIn("| fruit['banana'] | False |  |", rows)
+        self.assertIn("| fruit['None'] | True |  |", rows)
+
+    def test_story_from_docassemble_json_builds_feature_text(self):
+        result = story_from_docassemble_json(
+            {"i": "docassemble.demo:data/questions/main.yml", "variables": {"x": 1}},
+            options=StoryOptions(
+                feature_description="Feature title",
+                scenario_description="Scenario title",
+                yaml_file_name="main.yml",
+                question_id="review",
+                ignore_anywhere_in_var_name=[],
+            ),
+        )
+        self.assertEqual(result["row_count"], 1)
+        self.assertIn(
+            'Given I start the interview at "main.yml"', result["feature_text"]
+        )
+        self.assertIn(
+            'And the user gets to "review" with this data:', result["feature_text"]
+        )
+        self.assertIn("| x | 1 |  |", result["feature_text"])
+
+    def test_api_payload_accepts_json_text(self):
+        payload = alkiln_story_payload_from_options(
+            {
+                "json_text": '{"variables": {"name": "Ada"}}',
+                "yaml_file_name": "test.yml",
+                "question_id": "done",
+                "ignore_anywhere_in_var_name": [],
+            }
+        )
+        self.assertEqual(payload["rows"], ["| name | Ada |  |"])
+        self.assertIn(
+            'Given I start the interview at "test.yml"', payload["feature_text"]
+        )
+
+    def test_openapi_and_mcp_include_story_endpoint(self):
+        spec = build_openapi_spec()
+        self.assertIn("/al/api/v1/dashboard/interview/story", spec["paths"])
+        tools = openapi_to_mcp_tools(spec, namespace="aldashboard")
+        names = [tool["name"] for tool in tools]
+        self.assertIn("aldashboard.post_al_api_v1_dashboard_interview_story", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALDashboard/test/test_alkiln_story.py
+++ b/docassemble/ALDashboard/test/test_alkiln_story.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from docassemble.ALDashboard.alkiln_story import (
     StoryOptions,
@@ -16,6 +17,8 @@ from docassemble.ALDashboard.alkiln_story import (
     story_from_docassemble_json,
 )
 from docassemble.ALDashboard.api_dashboard_utils import (
+    DEFAULT_MAX_UPLOAD_BYTES,
+    DashboardAPIValidationError,
     alkiln_story_payload_from_options,
     build_openapi_spec,
 )
@@ -158,6 +161,17 @@ class TestALKilnStory(unittest.TestCase):
             ),
         )
         self.assertEqual(rows, ["| name | Ada |  |"])
+
+    @patch("docassemble.ALDashboard.alkiln_story._parse_value")
+    def test_rows_from_variables_deduplicates_rows_without_quadratic_lookup(
+        self, mock_parse_value
+    ):
+        mock_parse_value.return_value = ["| name | Ada |", "| name | Ada |"]
+        rows = rows_from_variables(
+            {"name": "Ada"},
+            options=StoryOptions(ignore_anywhere_in_var_name=[]),
+        )
+        self.assertEqual(rows, ["| name | Ada |"])
 
     def test_story_from_docassemble_json_builds_feature_text(self):
         result = story_from_docassemble_json(
@@ -485,6 +499,82 @@ question: Done
         self.assertEqual(payload["yaml_file_name"], "uploaded_interview.yml")
         self.assertEqual(payload["question_id"], "final")
         self.assertIn("| user_name | Sample answer |", payload["rows"])
+
+    def test_api_payload_rejects_arbitrary_source_token_paths(self):
+        with self.assertRaises(DashboardAPIValidationError) as exc:
+            alkiln_story_payload_from_options({"source_token": "/etc/passwd"})
+        self.assertIn("Playground YAML file", str(exc.exception))
+
+    def test_api_payload_accepts_playground_source_token_listed_for_project(self):
+        yaml_text = (
+            "---\nfields:\n  - Name: user_name\n---\nid: final\nquestion: Done\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".yml") as temp_yaml:
+            temp_yaml.write(yaml_text.encode("utf-8"))
+            temp_yaml.flush()
+            with patch(
+                "docassemble.ALDashboard.interview_linter.list_playground_yaml_files",
+                return_value=[{"label": "example.yml", "token": temp_yaml.name}],
+            ):
+                payload = alkiln_story_payload_from_options(
+                    {
+                        "playground_project": "demo",
+                        "playground_source_token": temp_yaml.name,
+                        "ignore_anywhere_in_var_name": [],
+                    }
+                )
+        self.assertEqual(payload["yaml_file_name"], "example.yml")
+        self.assertEqual(payload["question_id"], "final")
+        self.assertIn("| user_name | Sample answer |", payload["rows"])
+
+    def test_api_payload_rejects_oversized_ref_source_token_file(self):
+        yaml_text = (
+            "---\nfields:\n  - Name: user_name\n---\nid: final\nquestion: Done\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".yml") as temp_yaml:
+            temp_yaml.write(yaml_text.encode("utf-8"))
+            temp_yaml.flush()
+            with (
+                patch(
+                    "docassemble.ALDashboard.interview_linter._resolve_source_token",
+                    return_value=temp_yaml.name,
+                ),
+                patch(
+                    "docassemble.ALDashboard.api_dashboard_utils.os.path.getsize",
+                    return_value=DEFAULT_MAX_UPLOAD_BYTES + 1,
+                ),
+            ):
+                with self.assertRaises(DashboardAPIValidationError) as exc:
+                    alkiln_story_payload_from_options(
+                        {"source_token": "ref:package:data/questions/example.yml"}
+                    )
+        self.assertEqual(exc.exception.status_code, 413)
+
+    def test_api_payload_rejects_oversized_playground_yaml_file(self):
+        yaml_text = (
+            "---\nfields:\n  - Name: user_name\n---\nid: final\nquestion: Done\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".yml") as temp_yaml:
+            temp_yaml.write(yaml_text.encode("utf-8"))
+            temp_yaml.flush()
+            with (
+                patch(
+                    "docassemble.ALDashboard.interview_linter.list_playground_yaml_files",
+                    return_value=[{"label": "example.yml", "token": temp_yaml.name}],
+                ),
+                patch(
+                    "docassemble.ALDashboard.api_dashboard_utils.os.path.getsize",
+                    return_value=DEFAULT_MAX_UPLOAD_BYTES + 1,
+                ),
+            ):
+                with self.assertRaises(DashboardAPIValidationError) as exc:
+                    alkiln_story_payload_from_options(
+                        {
+                            "playground_project": "demo",
+                            "playground_yaml_file": "example.yml",
+                        }
+                    )
+        self.assertEqual(exc.exception.status_code, 413)
 
     def test_load_docassemble_json_text_accepts_fixture_textarea_newlines(self):
         json_text = read_fixture("fixture_interview_answers_textarea_newlines.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,6 @@ license-files = [
 [project.urls]
 Homepage = "https://courtformsonline.org"
 
-[project.optional-dependencies]
-docassemble = [
-    "docassemble.webapp",
-]
-
 [tool.setuptools.packages.find]
 where = [
     ".",
@@ -219,4 +214,10 @@ dev = [
     "dayamlchecker",
     "types-lxml",
     "xmlschema>=4.3.1",
+]
+
+# Keep the full docassemble stack opt-in for uv without letting `uv sync --group dev`
+# drag `docassemble.webapp` into the default test environment.
+docassemble = [
+    "docassemble.webapp>=1.9.11",
 ]


### PR DESCRIPTION
Adds a way to use the ALKiln story generator from Python. Translates existing functionality from https://github.com/plocket/alkiln_story/, and:

* Makes accessible via /al/dashboard API and adds to OpenAPI.json
* Allows generating directly from a saved interview session
* Adds a heuristic generation option from YAML, which can be uploaded or directed to from a playground

This is relatively large PR with a new feature. It's admin-only and generates code that needs to be edited/tested regardless. In addition most of the new lines are tests and fixtures for those tests.

Going to merge; review comments still welcome.