### PR TITLE
Add primary_person_variable override for labels

### DIFF
--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -511,6 +511,8 @@ def docx_labeler_suggest_payload_from_options(
         field_name="custom_people_names",
         expected_type=list,
     )
+    primary_person_raw = raw.get("primary_person_variable")
+    primary_person_variable = str(primary_person_raw).strip() if primary_person_raw is not None else None
     preferred_variable_names = _load_string_list_field(
         raw.get("preferred_variable_names"),
         field_name="preferred_variable_names",
@@ -559,6 +561,7 @@ def docx_labeler_suggest_payload_from_options(
         aggregated = get_voted_docx_label_suggestions(
             docx_path=temp_path,
             custom_people_names=cast(Any, custom_people_names),
+            primary_person_variable=primary_person_variable,
             preferred_variable_names=preferred_variable_names,
             openai_api=cast(Optional[str], openai_api),
             openai_base_url=cast(Optional[str], openai_base_url),
@@ -751,12 +754,15 @@ def autolabel_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, 
         field_name="custom_people_names",
         expected_type=list,
     )
+    primary_person_raw = raw.get("primary_person_variable")
+    primary_person_variable = str(primary_person_raw).strip() if primary_person_raw is not None else None
 
     temp_path = _write_temp_file(filename, content)
     try:
         guesses = get_labeled_docx_runs(
             temp_path,
             custom_people_names=custom_people_names,
+            primary_person_variable=primary_person_variable,
             openai_api=openai_api_override,
             openai_base_url=openai_base_url_override,
             model=openai_model_override or "gpt-5-nano",
@@ -1081,6 +1087,8 @@ def relabel_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, An
         field_name="custom_people_names",
         expected_type=list,
     )
+    primary_person_raw = raw.get("primary_person_variable")
+    primary_person_variable = str(primary_person_raw).strip() if primary_person_raw is not None else None
 
     try:
         if raw_results is not None:
@@ -1097,6 +1105,7 @@ def relabel_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, An
                 for item in get_labeled_docx_runs(
                     temp_path,
                     custom_people_names=custom_people_names,
+                    primary_person_variable=primary_person_variable,
                     openai_api=openai_api_override,
                     openai_base_url=openai_base_url_override,
                     model=openai_model_override or "gpt-5-nano",

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -2156,6 +2156,11 @@ def docx_labeler_suggest_labels() -> Response:
             elif isinstance(custom_people_raw, list):
                 custom_people_names = custom_people_raw
 
+        primary_person_variable = None
+        primary_person_raw = post_data.get("primary_person_variable")
+        if primary_person_raw and isinstance(primary_person_raw, str):
+            primary_person_variable = primary_person_raw.strip()
+
         (
             preferred_variable_names,
             interview_source_mode,
@@ -2179,6 +2184,7 @@ def docx_labeler_suggest_labels() -> Response:
             "openai_base_url": openai_base_url,
             "generator_models": generator_models,
             "custom_people_names": custom_people_names,
+            "primary_person_variable": primary_person_variable,
             "preferred_variable_names": preferred_variable_names,
             "interview_source_mode": interview_source_mode,
             "playground_project": selected_playground_project,

--- a/docassemble/ALDashboard/data/static/docx_labeler.js
+++ b/docassemble/ALDashboard/data/static/docx_labeler.js
@@ -202,6 +202,7 @@
                 additionalInstructions: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.additionalInstructions) || '',
                 contextText: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.contextText) || '',
                 customPeople: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.customPeople) || '',
+                primaryPersonVariable: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.primaryPersonVariable) || '',
                 promptProfile: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.promptProfile) || 'standard',
                 model: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.model) || 'gpt-5-mini',
                 judgeModel: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.judgeModel) || '',
@@ -2655,6 +2656,7 @@
             if (state.settings.additionalInstructions) formData.append('additional_instructions', state.settings.additionalInstructions);
             if (state.settings.contextText) formData.append('context_text', state.settings.contextText);
             if (state.settings.customPeople) formData.append('custom_people_names', state.settings.customPeople);
+            if (state.settings.primaryPersonVariable) formData.append('primary_person_variable', state.settings.primaryPersonVariable);
             formData.append('prompt_profile', state.settings.promptProfile || 'standard');
             formData.append('model', state.settings.model);
             if (state.settings.judgeModel) formData.append('judge_model', state.settings.judgeModel);

--- a/docassemble/ALDashboard/data/static/docx_labeler.js
+++ b/docassemble/ALDashboard/data/static/docx_labeler.js
@@ -824,14 +824,24 @@
 
         function getEffectiveVariableTree() {
             var sourceState = getActiveInterviewSourceState();
+            var baseTree = AL_VARIABLE_TREE;
+            
+            if (state.settings && state.settings.primaryPersonVariable && state.settings.primaryPersonVariable !== 'users') {
+                baseTree = cloneVariableTree(AL_VARIABLE_TREE);
+                if (baseTree['users']) {
+                    baseTree[state.settings.primaryPersonVariable] = baseTree['users'];
+                    delete baseTree['users'];
+                }
+            }
+
             if (!sourceState.variables.length) {
-                return AL_VARIABLE_TREE;
+                return baseTree;
             }
             return Object.assign(
                 {
                     'Selected interview variables': buildInterviewVariableTree(sourceState.variables)
                 },
-                AL_VARIABLE_TREE
+                baseTree
             );
         }
 

--- a/docassemble/ALDashboard/data/static/docx_labeler.js
+++ b/docassemble/ALDashboard/data/static/docx_labeler.js
@@ -1606,10 +1606,11 @@
         }
 
         function updateSelectionModeInputHints() {
+            var mainPerson = (state.settings && state.settings.primaryPersonVariable && state.settings.primaryPersonVariable !== '') ? state.settings.primaryPersonVariable : 'users';
             if (_selectionMode === 'replace' || _selectionMode === 'insert') {
-                selVarInput.placeholder = '{{ users[0].name.first }}';
+                selVarInput.placeholder = '{{ ' + mainPerson + '[0].name.first }}';
             } else {
-                selVarInput.placeholder = 'users[0].is_active';
+                selVarInput.placeholder = mainPerson + '[0].is_active';
             }
             if (_selMatch && _selMatch.isInsertion) {
                 selOriginalText.textContent = '(insert at cursor)';

--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -93,6 +93,7 @@ def _get_docx_label_rules_addendum(
     *,
     prompt_profile: str = DEFAULT_DOCX_PROMPT_PROFILE,
     prompt_library_path: Optional[str] = None,
+    primary_person_variable: Optional[str] = None,
 ) -> str:
     """Resolve extra prompt rules for the active DOCX prompt profile.
 
@@ -107,7 +108,11 @@ def _get_docx_label_rules_addendum(
         prompt_profile,
         prompt_library_path=prompt_library_path,
     )
-    return str(profile_config.get("rules_addendum") or "")
+    addendum = str(profile_config.get("rules_addendum") or "")
+    if primary_person_variable and primary_person_variable != "users":
+        # safely replace 'users' with the customized primary person in the addendum
+        addendum = addendum.replace("users", primary_person_variable)
+    return addendum
 
 
 def _get_docx_label_temperature(
@@ -2376,6 +2381,7 @@ def get_labeled_docx_runs(
     rules += _get_docx_label_rules_addendum(
         prompt_profile=prompt_profile,
         prompt_library_path=prompt_library_path,
+        primary_person_variable=primary_person_variable,
     )
     if optional_context and optional_context.strip():
         role_description += (

--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -1899,7 +1899,9 @@ def aggregate_docx_label_suggestion_runs(
 
 def get_voted_docx_label_suggestions(
     docx_path: str,
+    *,
     custom_people_names: Optional[List[Tuple[str, str]]] = None,
+    primary_person_variable: Optional[str] = None,
     preferred_variable_names: Optional[Sequence[str]] = None,
     openai_client: Optional[Any] = None,
     openai_api: Optional[str] = None,
@@ -1921,6 +1923,7 @@ def get_voted_docx_label_suggestions(
     Args:
         docx_path: Path to the DOCX file to label.
         custom_people_names: Optional list of custom people-variable descriptions.
+        primary_person_variable: Optional override for the main 'users' equivalent variable.
         preferred_variable_names: Optional preferred variable names to bias prompts.
         openai_client: Optional initialized OpenAI client.
         openai_api: Optional API key override.
@@ -1957,6 +1960,7 @@ def get_voted_docx_label_suggestions(
         suggestions = get_labeled_docx_runs(
             docx_path=docx_path,
             custom_people_names=custom_people_names,
+            primary_person_variable=primary_person_variable,
             preferred_variable_names=preferred_variable_names,
             openai_client=openai_client,
             openai_api=openai_api,
@@ -2174,7 +2178,9 @@ def update_docx(
 
 def get_labeled_docx_runs(
     docx_path: str,
+    *,
     custom_people_names: Optional[List[Tuple[str, str]]] = None,
+    primary_person_variable: Optional[str] = None,
     preferred_variable_names: Optional[Sequence[str]] = None,
     openai_client: Optional[Any] = None,
     openai_api: Optional[str] = None,
@@ -2193,6 +2199,7 @@ def get_labeled_docx_runs(
     Args:
         docx_path: Path to the DOCX file.
         custom_people_names: Optional list of custom ``(name, description)`` pairs.
+        primary_person_variable: Optional override for the main 'users' equivalent variable.
         preferred_variable_names: Optional preferred variable names to bias prompts.
         openai_client: Optional preconfigured OpenAI client.
         openai_api: Optional API key override.
@@ -2217,7 +2224,7 @@ def get_labeled_docx_runs(
         prompt_library_path=prompt_library_path,
     )
 
-    main_person = "users"
+    main_person = (primary_person_variable or "users").strip()
     custom_name_text = ""
     if custom_people_names is not None:
         if not isinstance(custom_people_names, list):
@@ -2230,8 +2237,6 @@ def get_labeled_docx_runs(
                     "Each custom_people_names item must be a [name, description] pair."
                 )
             name, description = item
-            if i == 0:
-                main_person = name
             custom_name_text += f"        {name} ({description})\n"
 
     preferred_name_text = ""

--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -2217,19 +2217,22 @@ def get_labeled_docx_runs(
         prompt_library_path=prompt_library_path,
     )
 
+    main_person = "users"
     custom_name_text = ""
     if custom_people_names is not None:
         if not isinstance(custom_people_names, list):
             raise ValueError(
                 "custom_people_names must be a list of [name, description] pairs."
             )
-        for item in custom_people_names:
+        for i, item in enumerate(custom_people_names):
             if not isinstance(item, (list, tuple)) or len(item) != 2:
                 raise ValueError(
                     "Each custom_people_names item must be a [name, description] pair."
                 )
             name, description = item
-            custom_name_text += f"    {name} ({description}), \n"
+            if i == 0:
+                main_person = name
+            custom_name_text += f"        {name} ({description})\n"
 
     preferred_name_text = ""
     if preferred_variable_names:
@@ -2277,8 +2280,7 @@ def get_labeled_docx_runs(
            asks for a specific person's or entity's actual name.
 
     List names for people:
-{custom_name_text}
-        users (for the person benefiting from the form, especially when for a pro se filer)
+{custom_name_text}{"        users (for the person benefiting from the form, especially when for a pro se filer)\n" if main_person == "users" else ""}
         other_parties (the opposing party in a lawsuit or transactional party)
         plaintiffs
         defendants
@@ -2299,50 +2301,50 @@ def get_labeled_docx_runs(
         interested_parties
 
         Name Forms:
-            users (full name of all users)
-            users[0] (full name of first user)
-            users[0].name.full() (Alternate full name of first user)
-            users[0].name.first (First name only)
-            users[0].name.middle (Middle name only)
-            users[0].name.middle_initial() (First letter of middle name)
-            users[0].name.last (Last name only)
-            users[0].name.suffix (Suffix of user's name only)
+            {main_person} (full name of all people in this list)
+            {main_person}[0] (full name of first person)
+            {main_person}[0].name.full() (Alternate full name of first person)
+            {main_person}[0].name.first (First name only)
+            {main_person}[0].name.middle (Middle name only)
+            {main_person}[0].name.middle_initial() (First letter of middle name)
+            {main_person}[0].name.last (Last name only)
+            {main_person}[0].name.suffix (Suffix of person's name only)
 
-    Attribute names (replace `users` with the appropriate list name):
+    Attribute names (replace `{main_person}` with the appropriate list name):
         Demographic Data:
-            users[0].birthdate (Birthdate)
-            users[0].age_in_years() (Calculated age based on birthdate)
-            users[0].gender (Gender)
-            users[0].gender_female (User is female, for checkbox field)
-            users[0].gender_male (User is male, for checkbox field)
-            users[0].gender_other (User is not male or female, for checkbox field)
-            users[0].gender_nonbinary (User identifies as nonbinary, for checkbox field)
-            users[0].gender_undisclosed (User chose not to disclose gender, for checkbox field)
-            users[0].gender_self_described (User chose to self-describe gender, for checkbox field)
-            user_needs_interpreter (User needs an interpreter, for checkbox field)
-            user_preferred_language (User's preferred language)
+            {main_person}[0].birthdate (Birthdate)
+            {main_person}[0].age_in_years() (Calculated age based on birthdate)
+            {main_person}[0].gender (Gender)
+            {main_person}[0].gender_female (Person is female, for checkbox field)
+            {main_person}[0].gender_male (Person is male, for checkbox field)
+            {main_person}[0].gender_other (Person is not male or female, for checkbox field)
+            {main_person}[0].gender_nonbinary (Person identifies as nonbinary, for checkbox field)
+            {main_person}[0].gender_undisclosed (Person chose not to disclose gender, for checkbox field)
+            {main_person}[0].gender_self_described (Person chose to self-describe gender, for checkbox field)
+            user_needs_interpreter (Person needs an interpreter, for checkbox field)
+            user_preferred_language (Person's preferred language)
 
         Addresses:
-            users[0].address.block() (Full address, on multiple lines)
-            users[0].address.on_one_line() (Full address on one line)
-            users[0].address.line_one() (Line one of the address, including unit or apartment number)
-            users[0].address.line_two() (Line two of the address, usually city, state, and Zip/postal code)
-            users[0].address.address (Street address)
-            users[0].address.unit (Apartment, unit, or suite)
-            users[0].address.city (City or town)
-            users[0].address.state (State, province, or sub-locality)
-            users[0].address.zip (Zip or postal code)
-            users[0].address.county (County or parish)
-            users[0].address.country (Country)
+            {main_person}[0].address.block() (Full address, on multiple lines)
+            {main_person}[0].address.on_one_line() (Full address on one line)
+            {main_person}[0].address.line_one() (Line one of the address, including unit or apartment number)
+            {main_person}[0].address.line_two() (Line two of the address, usually city, state, and Zip/postal code)
+            {main_person}[0].address.address (Street address)
+            {main_person}[0].address.unit (Apartment, unit, or suite)
+            {main_person}[0].address.city (City or town)
+            {main_person}[0].address.state (State, province, or sub-locality)
+            {main_person}[0].address.zip (Zip or postal code)
+            {main_person}[0].address.county (County or parish)
+            {main_person}[0].address.country (Country)
 
         Other Contact Information:
-            users[0].phone_number (Phone number)
-            users[0].mobile_number (A phone number explicitly labeled as the "mobile" number)
-            users[0].phone_numbers() (A list of both mobile and other phone numbers)
-            users[0].email (Email)
+            {main_person}[0].phone_number (Phone number)
+            {main_person}[0].mobile_number (A phone number explicitly labeled as the "mobile" number)
+            {main_person}[0].phone_numbers() (A list of both mobile and other phone numbers)
+            {main_person}[0].email (Email)
 
         Signatures:
-            users[0].signature (Signature)
+            {main_person}[0].signature (Signature)
             signature_date (Date the form is completed)
 
         Information about Court and Court Processes:


### PR DESCRIPTION
Allows explicitly setting the primary user variable (e.g. clients) via settings, rather than implicitly using the first element of custom_people_names.