### PR TITLE
Pdf editor appearance stream fixes - fix issue with checkboxes not having /AP and signature fields silently converted to text

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ celery modules:
   - Output: Relabeled PDF and resulting field names; optional parse stats/base64 output.
 - `POST /al/api/v1/dashboard/pdf/repair`
   - Run a single repair action on an uploaded PDF. Omit `action` to list available actions.
-  - `action` values: `ghostscript_reprint`, `qpdf_repair`, `unlock`, `repair_metadata`, `ocr`.
+  - `action` values: `ghostscript_reprint`, `qpdf_repair`, `restore_checkbox_appearances`, `unlock`, `repair_metadata`, `ocr`.
   - `ghostscript_reprint`: Re-distill through Ghostscript. Optional `preserve_fields=true` to extract and re-apply field locations.
   - `qpdf_repair`: Fix cross-reference tables and rebuild the page tree via pikepdf.
+  - `restore_checkbox_appearances`: Add missing checkbox appearance streams without changing text field appearances.
   - `unlock`: Remove encryption/permissions. Optional `password` parameter.
   - `repair_metadata`: Fix broken catalog/metadata entries (pikepdf, then pdfrw fallback).
   - `ocr`: Add searchable text layer via ocrmypdf. Optional `language` (default `eng`) and `skip_text` (default `true`).

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -512,7 +512,9 @@ def docx_labeler_suggest_payload_from_options(
         expected_type=list,
     )
     primary_person_raw = raw.get("primary_person_variable")
-    primary_person_variable = str(primary_person_raw).strip() if primary_person_raw is not None else None
+    primary_person_variable = (
+        str(primary_person_raw).strip() if primary_person_raw is not None else None
+    )
     preferred_variable_names = _load_string_list_field(
         raw.get("preferred_variable_names"),
         field_name="preferred_variable_names",
@@ -755,7 +757,9 @@ def autolabel_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, 
         expected_type=list,
     )
     primary_person_raw = raw.get("primary_person_variable")
-    primary_person_variable = str(primary_person_raw).strip() if primary_person_raw is not None else None
+    primary_person_variable = (
+        str(primary_person_raw).strip() if primary_person_raw is not None else None
+    )
 
     temp_path = _write_temp_file(filename, content)
     try:
@@ -1088,7 +1092,9 @@ def relabel_payload_from_options(raw_options: Mapping[str, Any]) -> Dict[str, An
         expected_type=list,
     )
     primary_person_raw = raw.get("primary_person_variable")
-    primary_person_variable = str(primary_person_raw).strip() if primary_person_raw is not None else None
+    primary_person_variable = (
+        str(primary_person_raw).strip() if primary_person_raw is not None else None
+    )
 
     try:
         if raw_results is not None:
@@ -2474,7 +2480,8 @@ def build_openapi_spec() -> Dict[str, Any]:
                         "Run a single repair action on an uploaded PDF. "
                         "Send without `action` to list available actions. "
                         "Actions: ghostscript_reprint (re-distill, optionally preserve fields), "
-                        "qpdf_repair (fix xref/page tree), unlock (remove encryption), "
+                        "qpdf_repair (fix xref/page tree), restore_checkbox_appearances "
+                        "(restore missing checkbox appearances), unlock (remove encryption), "
                         "repair_metadata (fix catalog/metadata), ocr (add text layer)."
                     ),
                 }
@@ -2566,7 +2573,7 @@ def build_docs_html() -> str:
     <li><code>/pdf/label-fields</code> is a backward-compatible alias for <code>/pdf/fields/detect</code>.</li>
     <li><code>/pdf/fields/detect</code> supports <code>relabel_with_ai</code> and ordered <code>target_field_names</code>; responses include renamed <code>fields</code>, optional positioned fields, and optional <code>pdf_base64</code>.</li>
     <li><code>/pdf/fields/relabel</code> supports <code>field_name_mapping</code>, ordered <code>target_field_names</code>, or <code>relabel_with_ai</code>; responses include <code>fields</code>, <code>fields_old</code>, and optional <code>pdf_base64</code>.</li>
-    <li><code>/pdf/repair</code> accepts <code>action</code> (ghostscript_reprint, qpdf_repair, unlock, repair_metadata, ocr). Omit <code>action</code> to list available repair actions with descriptions. Action-specific options: <code>preserve_fields</code> (ghostscript), <code>password</code> (unlock), <code>language</code>/<code>skip_text</code> (ocr).</li>
+    <li><code>/pdf/repair</code> accepts <code>action</code> (ghostscript_reprint, qpdf_repair, restore_checkbox_appearances, unlock, repair_metadata, ocr). Omit <code>action</code> to list available repair actions with descriptions. Action-specific options: <code>preserve_fields</code> (ghostscript), <code>password</code> (unlock), <code>language</code>/<code>skip_text</code> (ocr).</li>
   </ul>
   <h2>DOCX Modes</h2>
   <ul>

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -266,6 +266,29 @@ def _collect_fields_with_explicit_background(
     return explicit
 
 
+def _collect_checkbox_border_widths(
+    fields_data: List[Dict[str, Any]],
+) -> Dict[str, str]:
+    """Collect opt-in checkbox border widths keyed by PDF field name."""
+    widths: Dict[str, str] = {}
+    for field in fields_data:
+        try:
+            if str(field.get("type", "")).lower() != "checkbox":
+                continue
+            if not parse_bool(field.get("checkboxBorder"), default=False):
+                continue
+            name = str(field.get("name", "")).strip()
+            if not name:
+                continue
+            width = str(field.get("checkboxBorderWidth") or "thin").strip().lower()
+            if width not in {"thin", "medium", "thick"}:
+                width = "thin"
+            widths[name] = width
+        except Exception:  # nosec B112
+            continue
+    return widths
+
+
 def _apply_pdf_field_visual_defaults(
     pdf_path: str,
     *,
@@ -338,7 +361,10 @@ def _apply_pdf_field_visual_defaults(
                     if named_parent and named_parent is not annot:
                         _set_no_border(named_parent)
 
-                    if field_name in explicit:
+                    is_button_widget = _is_button_widget(named_parent)
+                    if field_name in explicit and (
+                        preserve_button_appearances or not is_button_widget
+                    ):
                         continue
 
                     _clear_background(annot)
@@ -352,9 +378,7 @@ def _apply_pdf_field_visual_defaults(
                     # unchecked visual states that PDF viewers cannot reliably
                     # reconstruct on their own.
                     if "/AP" in annot:
-                        if not preserve_button_appearances or not _is_button_widget(
-                            named_parent
-                        ):
+                        if not preserve_button_appearances or not is_button_widget:
                             del annot["/AP"]
                 except Exception:  # nosec B112
                     continue
@@ -3217,6 +3241,13 @@ def pdf_labeler_apply_fields() -> Response:
             explicit_background_fields = _collect_fields_with_explicit_background(
                 fields_data
             )
+            checkbox_border_widths = _collect_checkbox_border_widths(fields_data)
+            signature_field_names = [
+                str(field.get("name", "")).strip()
+                for field in fields_data
+                if str(field.get("type", "")).lower() == "signature"
+                and str(field.get("name", "")).strip()
+            ]
 
             fields_per_page = build_pdf_export_fields_per_page(
                 fields_data,
@@ -3233,9 +3264,23 @@ def pdf_labeler_apply_fields() -> Response:
 
             set_fields(input_path, output_path, fields_per_page, overwrite=True)
             _apply_checkbox_export_values(output_path, checkbox_export_values)
+            from .pdf_repair import normalize_signature_fields
+
+            normalize_signature_fields(
+                output_path,
+                output_path,
+                signature_field_names,
+            )
             _apply_pdf_field_visual_defaults(
                 output_path,
                 explicit_background_fields=explicit_background_fields,
+            )
+            from .pdf_repair import restore_checkbox_appearances
+
+            restore_checkbox_appearances(
+                output_path,
+                output_path,
+                checkbox_border_widths=checkbox_border_widths,
             )
 
             accessibility_payload = _parse_optional_json_field(
@@ -3902,6 +3947,15 @@ def pdf_labeler_bulk_normalize():
                         explicit_background_fields = (
                             _collect_fields_with_explicit_background(normalized_fields)
                         )
+                        checkbox_border_widths = _collect_checkbox_border_widths(
+                            normalized_fields
+                        )
+                        signature_field_names = [
+                            str(field.get("name", "")).strip()
+                            for field in normalized_fields
+                            if str(field.get("type", "")).lower() == "signature"
+                            and str(field.get("name", "")).strip()
+                        ]
 
                         with tempfile.NamedTemporaryFile(
                             suffix=".pdf", delete=False
@@ -3921,9 +3975,23 @@ def pdf_labeler_bulk_normalize():
                         }
                         if checkbox_values:
                             _apply_checkbox_export_values(output_path, checkbox_values)
+                        from .pdf_repair import normalize_signature_fields
+
+                        normalize_signature_fields(
+                            output_path,
+                            output_path,
+                            signature_field_names,
+                        )
                         _apply_pdf_field_visual_defaults(
                             output_path,
                             explicit_background_fields=explicit_background_fields,
+                        )
+                        from .pdf_repair import restore_checkbox_appearances
+
+                        restore_checkbox_appearances(
+                            output_path,
+                            output_path,
+                            checkbox_border_widths=checkbox_border_widths,
                         )
 
                         # Strip embedded fonts if requested

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -334,6 +334,14 @@ def _apply_pdf_field_visual_defaults(
             if len(mk) == 0:
                 del obj["/MK"]
 
+    def _ensure_standard_text_da(obj: Any) -> None:
+        if obj is None or not hasattr(obj, "get"):
+            return
+        if str(obj.get("/FT", "")) not in {"/Tx", "/Ch"}:
+            return
+        if "/DA" not in obj:
+            obj["/DA"] = pikepdf.String("/Helv 12 Tf 0 g")
+
     def _is_button_widget(named_parent: Optional[Any]) -> bool:
         if named_parent is None or not hasattr(named_parent, "get"):
             return False
@@ -341,9 +349,6 @@ def _apply_pdf_field_visual_defaults(
 
     with pikepdf.open(pdf_path, allow_overwriting_input=True) as pdf:
         acroform = pdf.Root.get("/AcroForm")
-        if isinstance(acroform, pikepdf.Dictionary):
-            acroform["/NeedAppearances"] = True
-
         for page in pdf.pages:
             if "/Annots" not in page:
                 continue
@@ -360,6 +365,9 @@ def _apply_pdf_field_visual_defaults(
                     _set_no_border(annot)
                     if named_parent and named_parent is not annot:
                         _set_no_border(named_parent)
+                    _ensure_standard_text_da(annot)
+                    if named_parent and named_parent is not annot:
+                        _ensure_standard_text_da(named_parent)
 
                     is_button_widget = _is_button_widget(named_parent)
                     if field_name in explicit and (
@@ -382,6 +390,14 @@ def _apply_pdf_field_visual_defaults(
                             del annot["/AP"]
                 except Exception:  # nosec B112
                     continue
+
+        if isinstance(acroform, pikepdf.Dictionary):
+            # Rebuild standard text/list appearances now, then clear the flag so
+            # button widgets keep their authoritative saved /AP streams.
+            acroform["/NeedAppearances"] = True
+            pdf.generate_appearance_streams()
+            if "/NeedAppearances" in acroform:
+                del acroform["/NeedAppearances"]
 
         pdf.save(pdf_path)
 

--- a/docassemble/ALDashboard/data/static/pdf_labeler.js
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.js
@@ -2675,6 +2675,9 @@
             if (repairResult.fields_restored) {
                 summaryParts.push(repairResult.fields_restored + ' fields restored');
             }
+            if (repairResult.appearances_restored) {
+                summaryParts.push(repairResult.appearances_restored + ' appearances restored');
+            }
             if (repairResult.warnings && repairResult.warnings.length) {
                 summaryParts.push(repairResult.warnings.join('; '));
             }
@@ -2943,7 +2946,7 @@
                         font: settings.normalizeFont ? settings.fontName : nextField.font,
                         fontSize: settings.normalizeFontSize ? settings.fontSizePt : nextField.fontSize,
                         autoSize: false,
-                        checkboxStyle: (settings.normalizeCheckboxStyle && settings.checkboxStyle) || nextField.checkboxStyle || 'check',
+                        checkboxStyle: (settings.normalizeCheckboxStyle && settings.checkboxStyle) || nextField.checkboxStyle || 'cross',
                         checkboxExportValue: (settings.normalizeCheckboxStyle && settings.checkboxExportValue) || nextField.checkboxExportValue || 'Yes',
                         allowScroll: false
                     });
@@ -3073,8 +3076,8 @@
                             '<div>' +
                                 '<label class="form-label small text-muted mb-1" for="field-checkbox-style-' + escapeHtml(field.id) + '">Style</label>' +
                                 '<select id="field-checkbox-style-' + escapeHtml(field.id) + '" class="form-select form-select-sm" data-action="field-checkbox-style" data-field-id="' + escapeHtml(field.id) + '">' +
-                                    '<option value="cross"' + ((field.checkboxStyle || 'check') === 'cross' ? ' selected' : '') + '>Cross</option>' +
-                                    '<option value="check"' + ((field.checkboxStyle || 'check') === 'check' ? ' selected' : '') + '>Check</option>' +
+                                    '<option value="cross"' + ((field.checkboxStyle || 'cross') === 'cross' ? ' selected' : '') + '>Cross</option>' +
+                                    '<option value="check"' + ((field.checkboxStyle || 'cross') === 'check' ? ' selected' : '') + '>Check</option>' +
                                     '<option value="circle"' + (field.checkboxStyle === 'circle' ? ' selected' : '') + '>Circle</option>' +
                                     '<option value="star"' + (field.checkboxStyle === 'star' ? ' selected' : '') + '>Star</option>' +
                                     '<option value="diamond"' + (field.checkboxStyle === 'diamond' ? ' selected' : '') + '>Diamond</option>' +
@@ -3084,6 +3087,18 @@
                             '<div>' +
                                 '<label class="form-label small text-muted mb-1" for="field-checkbox-export-value-' + escapeHtml(field.id) + '">Export value</label>' +
                                 '<input id="field-checkbox-export-value-' + escapeHtml(field.id) + '" type="text" class="form-control form-control-sm font-monospace" data-action="field-checkbox-export-value" data-field-id="' + escapeHtml(field.id) + '" value="' + escapeHtml(String(field.checkboxExportValue || 'Yes')) + '">' +
+                            '</div>' +
+                            '<label class="form-check small mb-0 align-self-end">' +
+                                '<input class="form-check-input" type="checkbox" data-action="field-checkbox-border" data-field-id="' + escapeHtml(field.id) + '"' + (field.checkboxBorder ? ' checked' : '') + '>' +
+                                '<span class="form-check-label">Border</span>' +
+                            '</label>' +
+                            '<div>' +
+                                '<label class="form-label small text-muted mb-1" for="field-checkbox-border-width-' + escapeHtml(field.id) + '">Border width</label>' +
+                                '<select id="field-checkbox-border-width-' + escapeHtml(field.id) + '" class="form-select form-select-sm" data-action="field-checkbox-border-width" data-field-id="' + escapeHtml(field.id) + '"' + (field.checkboxBorder ? '' : ' disabled') + '>' +
+                                    '<option value="thin"' + ((field.checkboxBorderWidth || 'thin') === 'thin' ? ' selected' : '') + '>Thin</option>' +
+                                    '<option value="medium"' + (field.checkboxBorderWidth === 'medium' ? ' selected' : '') + '>Medium</option>' +
+                                    '<option value="thick"' + (field.checkboxBorderWidth === 'thick' ? ' selected' : '') + '>Thick</option>' +
+                                '</select>' +
                             '</div>' +
                         '</div>' +
                     '</div>'
@@ -3264,6 +3279,10 @@
                     previewDiv.style.fontSize = Math.max(8, boxPx * 0.8) + 'px';
                     previewDiv.style.lineHeight = '1';
                     previewDiv.style.color = '#000';
+                    if (field.checkboxBorder) {
+                        var borderWidths = { thin: 1, medium: 2, thick: 3 };
+                        previewDiv.style.border = (borderWidths[field.checkboxBorderWidth || 'thin'] || 1) + 'px solid #000';
+                    }
                 } else if (field.type === 'signature') {
                     previewDiv.classList.add('preview-signature');
                     if (_signatureDataUrl) {
@@ -3411,6 +3430,8 @@
                 autoSize: field.autoSize !== false,
                 checkboxStyle: field.checkboxStyle || undefined,
                 checkboxExportValue: field.checkboxExportValue || undefined,
+                checkboxBorder: !!field.checkboxBorder,
+                checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
                 allowScroll: field.allowScroll !== false,
                 backgroundColor: field.backgroundColor || undefined,
                 options: Array.isArray(field.options) ? field.options.slice() : undefined,
@@ -3462,7 +3483,10 @@
             font: getSessionDefault('font'),
             fontSize: getSessionDefault('fontSize'),
             autoSize: type === 'text' || type === 'multiline',
+            checkboxStyle: type === 'checkbox' ? (getSessionDefault('checkboxStyle') || 'cross') : undefined,
             checkboxExportValue: type === 'checkbox' ? getSessionDefault('checkboxExportValue') : undefined,
+            checkboxBorder: false,
+            checkboxBorderWidth: 'thin',
             options: OPTION_TYPES.has(type) ? DEFAULT_OPTION_LIST.slice() : undefined,
             nameSuggestions: nameSuggestions,
             tooltip: ''
@@ -3880,6 +3904,8 @@
             autoSize: field.autoSize !== false,
             checkboxStyle: field.checkboxStyle,
             checkboxExportValue: field.checkboxExportValue,
+            checkboxBorder: !!field.checkboxBorder,
+            checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
             allowScroll: field.allowScroll !== false,
             backgroundColor: field.backgroundColor,
             options: Array.isArray(field.options) ? field.options.slice() : undefined,
@@ -3956,6 +3982,8 @@
                 autoSize: field.autoSize !== false,
                 checkboxStyle: field.checkboxStyle,
                 checkboxExportValue: field.checkboxExportValue,
+                checkboxBorder: !!field.checkboxBorder,
+                checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
                 allowScroll: field.allowScroll !== false,
                 backgroundColor: field.backgroundColor,
                 options: Array.isArray(field.options) ? field.options.slice() : undefined,
@@ -5487,8 +5515,10 @@
                 delete field.options;
             }
             if (newType === 'checkbox') {
-                field.checkboxStyle = field.checkboxStyle || 'check';
+                field.checkboxStyle = field.checkboxStyle || (getSessionDefault('checkboxStyle') || 'cross');
                 field.checkboxExportValue = field.checkboxExportValue || 'Yes';
+                field.checkboxBorder = !!field.checkboxBorder;
+                field.checkboxBorderWidth = field.checkboxBorderWidth || 'thin';
             }
             if (!(newType === 'text' || newType === 'multiline')) {
                 field.autoSize = true;
@@ -5502,7 +5532,18 @@
             return;
         }
         if (target.dataset.action === 'field-checkbox-style') {
-            field.checkboxStyle = target.value || 'check';
+            field.checkboxStyle = target.value || 'cross';
+            markDirtyAndRender();
+            return;
+        }
+        if (target.dataset.action === 'field-checkbox-border') {
+            field.checkboxBorder = !!target.checked;
+            field.checkboxBorderWidth = field.checkboxBorderWidth || 'thin';
+            markDirtyAndRender();
+            return;
+        }
+        if (target.dataset.action === 'field-checkbox-border-width') {
+            field.checkboxBorderWidth = target.value || 'thin';
             markDirtyAndRender();
             return;
         }

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -651,6 +651,15 @@
                     <div class="repair-action-card border rounded p-3">
                         <div class="d-flex align-items-start justify-content-between gap-2">
                             <div>
+                                <h3 class="h6 fw-semibold mb-1">Restore Checkbox Appearances</h3>
+                                <p class="small text-muted mb-2">Add missing checkbox appearance streams without changing text field appearances.</p>
+                            </div>
+                            <button class="btn btn-outline-primary btn-sm flex-shrink-0 repair-run-btn" data-repair-action="restore_checkbox_appearances">Run</button>
+                        </div>
+                    </div>
+                    <div class="repair-action-card border rounded p-3">
+                        <div class="d-flex align-items-start justify-content-between gap-2">
+                            <div>
                                 <h3 class="h6 fw-semibold mb-1">Unlock PDF</h3>
                                 <p class="small text-muted mb-2">Remove encryption and permission restrictions.</p>
                                 <div class="mt-1">

--- a/docassemble/ALDashboard/docx_wrangling.py
+++ b/docassemble/ALDashboard/docx_wrangling.py
@@ -54,7 +54,7 @@ _IF_OPEN_PATTERN = re.compile(r"^(?:p\s+)?if\b", re.IGNORECASE)
 _IF_BRANCH_PATTERN = re.compile(r"^(?:p\s+)?(?:elif\b|else\b)", re.IGNORECASE)
 _IF_CLOSE_PATTERN = re.compile(r"^(?:p\s+)?endif\b", re.IGNORECASE)
 
-_XML_INVALID_CONTROL_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+_XML_INVALID_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
 
 
 def _sanitize_xml_text(text: str) -> str:
@@ -917,7 +917,9 @@ def apply_docx_label_renames(
         for paragraph in _collect_target_paragraphs(document):
             for run in paragraph.runs:
                 if original in run.text:
-                    run.text = _sanitize_xml_text(run.text.replace(original, replacement))
+                    run.text = _sanitize_xml_text(
+                        run.text.replace(original, replacement)
+                    )
                     rename_count += 1
 
     return rename_count

--- a/docassemble/ALDashboard/pdf_repair.py
+++ b/docassemble/ALDashboard/pdf_repair.py
@@ -414,9 +414,7 @@ def normalize_signature_fields(
     """
     import pikepdf
 
-    targets = {
-        str(name).strip() for name in signature_field_names if str(name).strip()
-    }
+    targets = {str(name).strip() for name in signature_field_names if str(name).strip()}
     if not targets:
         if input_pdf_path != output_pdf_path:
             shutil.copy2(input_pdf_path, output_pdf_path)

--- a/docassemble/ALDashboard/pdf_repair.py
+++ b/docassemble/ALDashboard/pdf_repair.py
@@ -465,7 +465,7 @@ def normalize_signature_fields(
 
             if converted and hasattr(pdf.Root, "AcroForm"):
                 try:
-                    existing_flags = int(pdf.Root.AcroForm.get("/SigFlags", 0) or 0)
+                    existing_flags = int(pdf.Root.AcroForm.get("/SigFlags") or 0)
                 except (TypeError, ValueError):
                     existing_flags = 0
                 pdf.Root.AcroForm["/SigFlags"] = existing_flags | 3

--- a/docassemble/ALDashboard/pdf_repair.py
+++ b/docassemble/ALDashboard/pdf_repair.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 
 class PDFRepairError(RuntimeError):
@@ -59,6 +59,435 @@ def _copy_if_same(src: str, dst: str) -> None:
     """If *src* == *dst* do nothing, otherwise copy."""
     if os.path.abspath(src) != os.path.abspath(dst):
         shutil.copy2(src, dst)
+
+
+def _get_pdf_field_parent(field_obj: Any) -> Optional[Any]:
+    """Return the nearest named field container for a widget annotation."""
+    if not hasattr(field_obj, "get"):
+        return None
+    if "/T" in field_obj:
+        return field_obj
+    parent = field_obj.get("/Parent")
+    if parent is None:
+        return None
+    try:
+        parent_obj = parent.resolve() if hasattr(parent, "resolve") else parent
+    except Exception:  # nosec B112
+        return None
+    return _get_pdf_field_parent(parent_obj)
+
+
+def _pdf_obj_value(obj: Any, key: str, default: Any = None) -> Any:
+    """Read a PDF dictionary key with a small guard against malformed objects."""
+    try:
+        if hasattr(obj, "get"):
+            return obj.get(key, default)
+    except Exception:  # nosec B112
+        return default
+    return default
+
+
+def _is_checkbox_like_button(widget: Any, parent: Optional[Any]) -> bool:
+    """Return True for checkbox-style button fields, excluding radio/push buttons."""
+    ft = _pdf_obj_value(widget, "/FT", _pdf_obj_value(parent, "/FT"))
+    if str(ft) != "/Btn":
+        return False
+
+    try:
+        flags = int(
+            _pdf_obj_value(widget, "/Ff", _pdf_obj_value(parent, "/Ff", 0)) or 0
+        )
+    except (TypeError, ValueError):
+        flags = 0
+
+    pushbutton_flag = 1 << 16
+    radio_flag = 1 << 15
+    return not bool(flags & (pushbutton_flag | radio_flag))
+
+
+def _normal_appearance_dict(widget: Any) -> Optional[Any]:
+    """Return a widget's normal appearance dictionary when it already has one."""
+    ap = _pdf_obj_value(widget, "/AP")
+    if ap is None or not hasattr(ap, "get"):
+        return None
+    normal = ap.get("/N")
+    if normal is None or not hasattr(normal, "keys"):
+        return None
+    return normal
+
+
+def _checkbox_checked_state(
+    widget: Any, parent: Optional[Any], pikepdf_module: Any
+) -> Any:
+    """Choose the checked export state that should have a matching appearance."""
+    for key in ("/AS", "/V", "/DV"):
+        value = _pdf_obj_value(widget, key, _pdf_obj_value(parent, key))
+        if value is not None and str(value) and str(value) != "/Off":
+            return pikepdf_module.Name(str(value))
+    return pikepdf_module.Name("/Yes")
+
+
+_CHECKBOX_CAPTION_TO_STYLE = {
+    "4": "check",
+    "5": "cross",
+    "l": "circle",
+    "N": "star",
+    "u": "diamond",
+}
+
+
+def _checkbox_mark_style(widget: Any, parent: Optional[Any]) -> str:
+    """Infer the checkbox mark style from reportlab/Acrobat button metadata."""
+    for obj in (widget, parent):
+        mk = _pdf_obj_value(obj, "/MK")
+        if mk is None or not hasattr(mk, "get"):
+            continue
+        caption = mk.get("/CA")
+        if caption is None:
+            continue
+        style = _CHECKBOX_CAPTION_TO_STYLE.get(str(caption))
+        if style:
+            return style
+    return "check"
+
+
+_CHECKBOX_BORDER_WIDTHS = {
+    "thin": 1.0,
+    "medium": 2.0,
+    "thick": 3.0,
+}
+
+
+def _checkbox_border_width(value: Any) -> float:
+    """Normalize a checkbox border-width option into points."""
+    if value is None or value is False:
+        return 0.0
+    if value is True:
+        return _CHECKBOX_BORDER_WIDTHS["thin"]
+    if isinstance(value, (int, float)):
+        return max(float(value), 0.0)
+    normalized = str(value or "").strip().lower()
+    if normalized in {"", "none", "off", "false", "0"}:
+        return 0.0
+    return _CHECKBOX_BORDER_WIDTHS.get(normalized, _CHECKBOX_BORDER_WIDTHS["thin"])
+
+
+def _checkbox_mark_ops(
+    style: str, width: float, height: float, border_width: float
+) -> str:
+    """Return PDF path operations for a borderless checkbox mark."""
+    inset = max(3.0, border_width + 2.0)
+    left = inset
+    right = max(width - inset, left)
+    bottom = inset
+    top = max(height - inset, bottom)
+    mid_x = width / 2.0
+    mid_y = height / 2.0
+    r_x = max((right - left) / 2.0, 1.0)
+    r_y = max((top - bottom) / 2.0, 1.0)
+
+    if style == "cross":
+        return (
+            f"{left:.3f} {bottom:.3f} m\n"
+            f"{right:.3f} {top:.3f} l\n"
+            f"{right:.3f} {bottom:.3f} m\n"
+            f"{left:.3f} {top:.3f} l\n"
+        )
+    if style == "circle":
+        c = 0.5522847498
+        return (
+            f"{mid_x + r_x:.3f} {mid_y:.3f} m\n"
+            f"{mid_x + r_x:.3f} {mid_y + c * r_y:.3f} "
+            f"{mid_x + c * r_x:.3f} {mid_y + r_y:.3f} "
+            f"{mid_x:.3f} {mid_y + r_y:.3f} c\n"
+            f"{mid_x - c * r_x:.3f} {mid_y + r_y:.3f} "
+            f"{mid_x - r_x:.3f} {mid_y + c * r_y:.3f} "
+            f"{mid_x - r_x:.3f} {mid_y:.3f} c\n"
+            f"{mid_x - r_x:.3f} {mid_y - c * r_y:.3f} "
+            f"{mid_x - c * r_x:.3f} {mid_y - r_y:.3f} "
+            f"{mid_x:.3f} {mid_y - r_y:.3f} c\n"
+            f"{mid_x + c * r_x:.3f} {mid_y - r_y:.3f} "
+            f"{mid_x + r_x:.3f} {mid_y - c * r_y:.3f} "
+            f"{mid_x + r_x:.3f} {mid_y:.3f} c\n"
+        )
+    if style == "diamond":
+        return (
+            f"{mid_x:.3f} {top:.3f} m\n"
+            f"{right:.3f} {mid_y:.3f} l\n"
+            f"{mid_x:.3f} {bottom:.3f} l\n"
+            f"{left:.3f} {mid_y:.3f} l\n"
+            "h\n"
+        )
+    if style == "star":
+        points = [
+            (0.50, 1.00),
+            (0.62, 0.62),
+            (1.00, 0.62),
+            (0.69, 0.40),
+            (0.81, 0.00),
+            (0.50, 0.25),
+            (0.19, 0.00),
+            (0.31, 0.40),
+            (0.00, 0.62),
+            (0.38, 0.62),
+        ]
+        ops = []
+        for index, (px, py) in enumerate(points):
+            x = left + px * (right - left)
+            y = bottom + py * (top - bottom)
+            ops.append(f"{x:.3f} {y:.3f} {'m' if index == 0 else 'l'}")
+        ops.append("h")
+        return "\n".join(ops) + "\n"
+    return (
+        f"{left:.3f} {mid_y:.3f} m\n"
+        f"{width * 0.42:.3f} {height * 0.20:.3f} l\n"
+        f"{right:.3f} {top:.3f} l\n"
+    )
+
+
+def _make_checkbox_appearance_streams(
+    pdf: Any,
+    width: float,
+    height: float,
+    *,
+    style: str = "check",
+    border_width: float = 0.0,
+) -> Dict[str, Any]:
+    """Create minimal Off/checked appearance XObjects for a checkbox widget."""
+    import pikepdf
+
+    border_ops = ""
+    if border_width > 0:
+        half = border_width / 2.0
+        box_width = max(width - border_width, 0.0)
+        box_height = max(height - border_width, 0.0)
+        border_ops = (
+            "0 0 0 RG\n"
+            f"{border_width:.3f} w\n"
+            f"{half:.3f} {half:.3f} {box_width:.3f} {box_height:.3f} re\n"
+            "S\n"
+        )
+
+    off_stream = pikepdf.Stream(pdf, f"q\n{border_ops}Q\n".encode("ascii"))
+    off_stream["/Type"] = pikepdf.Name("/XObject")
+    off_stream["/Subtype"] = pikepdf.Name("/Form")
+    off_stream["/FormType"] = 1
+    off_stream["/BBox"] = pikepdf.Array([0, 0, width, height])
+    off_stream["/Matrix"] = pikepdf.Array([1, 0, 0, 1, 0, 0])
+
+    checked_ops = (
+        "q\n"
+        f"{border_ops}"
+        "0 0 0 RG\n"
+        "1.8 w\n"
+        f"{_checkbox_mark_ops(style, width, height, border_width)}"
+        "S\n"
+        "Q\n"
+    ).encode("ascii")
+    checked_stream = pikepdf.Stream(pdf, checked_ops)
+    checked_stream["/Type"] = pikepdf.Name("/XObject")
+    checked_stream["/Subtype"] = pikepdf.Name("/Form")
+    checked_stream["/FormType"] = 1
+    checked_stream["/BBox"] = pikepdf.Array([0, 0, width, height])
+    checked_stream["/Matrix"] = pikepdf.Array([1, 0, 0, 1, 0, 0])
+    return {"off": off_stream, "checked": checked_stream}
+
+
+def restore_checkbox_appearances(
+    input_pdf_path: str,
+    output_pdf_path: str,
+    *,
+    checkbox_border_widths: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Restore missing checkbox appearance streams without touching text fields.
+
+    This repair is intentionally narrow: it only synthesizes normal appearances
+    for checkbox-like ``/Btn`` widget annotations that are missing ``/AP``.
+    Text-field appearances are left alone because deleting those streams is how
+    the labeler avoids reportlab's opaque blue backgrounds and thick borders.
+    """
+    import pikepdf
+
+    restored = 0
+    checked = 0
+    skipped_existing = 0
+    skipped_non_checkbox = 0
+    border_widths = {
+        str(name): _checkbox_border_width(value)
+        for name, value in (checkbox_border_widths or {}).items()
+        if str(name).strip()
+    }
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        with pikepdf.open(input_pdf_path) as pdf:
+            for page in pdf.pages:
+                annots = page.get("/Annots")
+                if annots is None:
+                    continue
+                for annot in annots:  # type: ignore[attr-defined]
+                    try:
+                        widget = annot.resolve() if hasattr(annot, "resolve") else annot
+                    except Exception:  # nosec B112
+                        continue
+                    try:
+                        if widget.get("/Subtype") != pikepdf.Name("/Widget"):
+                            continue
+                    except Exception:  # nosec B112
+                        continue
+
+                    parent = _get_pdf_field_parent(widget)
+                    if not _is_checkbox_like_button(widget, parent):
+                        skipped_non_checkbox += 1
+                        continue
+                    checked += 1
+
+                    normal_ap = _normal_appearance_dict(widget)
+                    if normal_ap is not None and "/Off" in normal_ap:
+                        skipped_existing += 1
+                        continue
+
+                    rect = widget.get("/Rect", [0, 0, 12, 12])
+                    try:
+                        width = max(float(rect[2]) - float(rect[0]), 1.0)
+                        height = max(float(rect[3]) - float(rect[1]), 1.0)
+                    except (TypeError, ValueError, IndexError):
+                        width = height = 12.0
+
+                    checked_state = _checkbox_checked_state(widget, parent, pikepdf)
+                    mark_style = _checkbox_mark_style(widget, parent)
+                    field_name_obj = _pdf_obj_value(
+                        parent, "/T", _pdf_obj_value(widget, "/T", "")
+                    )
+                    field_name = str(field_name_obj or "")
+                    border_width = border_widths.get(field_name, 0.0)
+                    streams = _make_checkbox_appearance_streams(
+                        pdf,
+                        width,
+                        height,
+                        style=mark_style,
+                        border_width=border_width,
+                    )
+                    normal_states = pikepdf.Dictionary(
+                        {"/Off": pdf.make_indirect(streams["off"])}
+                    )
+                    normal_states[str(checked_state)] = pdf.make_indirect(
+                        streams["checked"]
+                    )
+                    widget["/AP"] = pikepdf.Dictionary({"/N": normal_states})
+                    restored += 1
+
+            pdf.save(tmp_path)
+
+        _assert_pdf(tmp_path, label="restore checkbox appearances")
+        _copy_if_same(tmp_path, output_pdf_path)
+    except PDFRepairError:
+        raise
+    except Exception as exc:
+        raise PDFRepairError(f"Checkbox appearance repair failed: {exc}") from exc
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    return {
+        "action": "restore_checkbox_appearances",
+        "checkbox_fields_checked": checked,
+        "appearances_restored": restored,
+        "existing_appearances_skipped": skipped_existing,
+        "non_checkbox_widgets_skipped": skipped_non_checkbox,
+    }
+
+
+def normalize_signature_fields(
+    input_pdf_path: str,
+    output_pdf_path: str,
+    signature_field_names: Iterable[str],
+) -> Dict[str, Any]:
+    """Convert ReportLab-created text widgets into real signature fields.
+
+    FormFyxer currently asks ReportLab to draw signature fields as text fields
+    because ReportLab does not expose a signature widget API. The labeler still
+    needs exported PDFs to contain ``/FT /Sig`` so external PDF editors recognize
+    those widgets as signature fields.
+    """
+    import pikepdf
+
+    targets = {
+        str(name).strip() for name in signature_field_names if str(name).strip()
+    }
+    if not targets:
+        if input_pdf_path != output_pdf_path:
+            shutil.copy2(input_pdf_path, output_pdf_path)
+        return {"action": "normalize_signature_fields", "fields_converted": 0}
+
+    converted = 0
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    def _normalize_obj(obj: Any) -> bool:
+        nonlocal converted
+        if obj is None or not hasattr(obj, "get"):
+            return False
+        field_name = str(obj.get("/T", "") or "").strip()
+        if field_name not in targets:
+            return False
+        if str(obj.get("/FT", "")) != "/Sig":
+            converted += 1
+        obj["/FT"] = pikepdf.Name("/Sig")
+        for key in ("/V", "/DV", "/MaxLen", "/Q", "/DS", "/RV"):
+            if key in obj:
+                del obj[key]
+        return True
+
+    try:
+        with pikepdf.open(input_pdf_path) as pdf:
+            for page in pdf.pages:
+                annots = page.get("/Annots")
+                if annots is None:
+                    continue
+                for annot in annots:  # type: ignore[attr-defined]
+                    try:
+                        widget = annot.resolve() if hasattr(annot, "resolve") else annot
+                    except Exception:  # nosec B112
+                        continue
+                    try:
+                        if widget.get("/Subtype") != pikepdf.Name("/Widget"):
+                            continue
+                    except Exception:  # nosec B112
+                        continue
+                    parent = _get_pdf_field_parent(widget)
+                    if _normalize_obj(parent):
+                        if parent is not widget and hasattr(widget, "get"):
+                            widget["/FT"] = pikepdf.Name("/Sig")
+                    else:
+                        _normalize_obj(widget)
+
+            if converted and hasattr(pdf.Root, "AcroForm"):
+                try:
+                    existing_flags = int(pdf.Root.AcroForm.get("/SigFlags", 0) or 0)
+                except (TypeError, ValueError):
+                    existing_flags = 0
+                pdf.Root.AcroForm["/SigFlags"] = existing_flags | 3
+
+            pdf.save(tmp_path)
+
+        _assert_pdf(tmp_path, label="normalize signature fields")
+        _copy_if_same(tmp_path, output_pdf_path)
+    except PDFRepairError:
+        raise
+    except Exception as exc:
+        raise PDFRepairError(f"Signature field normalization failed: {exc}") from exc
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    return {
+        "action": "normalize_signature_fields",
+        "fields_converted": converted,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -630,6 +1059,7 @@ REPAIR_ACTIONS: Dict[str, Any] = {
     "auto": auto_repair,
     "ghostscript_reprint": ghostscript_reprint,
     "qpdf_repair": qpdf_repair,
+    "restore_checkbox_appearances": restore_checkbox_appearances,
     "unlock": unlock_pdf,
     "repair_metadata": repair_metadata,
     "ocr": ocr_pdf,
@@ -647,6 +1077,10 @@ REPAIR_ACTION_HELP = {
     "qpdf_repair": (
         "Run pikepdf/qpdf repair mode to fix cross-reference tables "
         "and rebuild the page tree."
+    ),
+    "restore_checkbox_appearances": (
+        "Restore missing checkbox appearance streams only for checkbox fields. "
+        "Leaves text field appearances unchanged."
     ),
     "unlock": (
         "Remove encryption and permission restrictions so the PDF "

--- a/docassemble/ALDashboard/pdf_repair.py
+++ b/docassemble/ALDashboard/pdf_repair.py
@@ -134,6 +134,9 @@ _CHECKBOX_CAPTION_TO_STYLE = {
     "N": "star",
     "u": "diamond",
 }
+_CHECKBOX_STYLE_TO_CAPTION = {
+    style: caption for caption, style in _CHECKBOX_CAPTION_TO_STYLE.items()
+}
 
 
 def _checkbox_mark_style(widget: Any, parent: Optional[Any]) -> str:
@@ -149,6 +152,23 @@ def _checkbox_mark_style(widget: Any, parent: Optional[Any]) -> str:
         if style:
             return style
     return "check"
+
+
+def _set_checkbox_mark_style(
+    widget: Any, parent: Optional[Any], style: str, pikepdf_module: Any
+) -> None:
+    """Write checkbox caption metadata that matches the synthesized mark style."""
+    caption = _CHECKBOX_STYLE_TO_CAPTION.get(style)
+    if not caption:
+        return
+    for obj in (widget, parent):
+        if obj is None or not hasattr(obj, "get"):
+            continue
+        mk = obj.get("/MK")
+        if not isinstance(mk, pikepdf_module.Dictionary):
+            mk = pikepdf_module.Dictionary()
+            obj["/MK"] = mk
+        mk["/CA"] = pikepdf_module.String(caption)
 
 
 _CHECKBOX_BORDER_WIDTHS = {
@@ -344,8 +364,13 @@ def restore_checkbox_appearances(
                         continue
                     checked += 1
 
+                    checked_state = _checkbox_checked_state(widget, parent, pikepdf)
                     normal_ap = _normal_appearance_dict(widget)
-                    if normal_ap is not None and "/Off" in normal_ap:
+                    if (
+                        normal_ap is not None
+                        and "/Off" in normal_ap
+                        and str(checked_state) in normal_ap
+                    ):
                         skipped_existing += 1
                         continue
 
@@ -356,7 +381,6 @@ def restore_checkbox_appearances(
                     except (TypeError, ValueError, IndexError):
                         width = height = 12.0
 
-                    checked_state = _checkbox_checked_state(widget, parent, pikepdf)
                     mark_style = _checkbox_mark_style(widget, parent)
                     field_name_obj = _pdf_obj_value(
                         parent, "/T", _pdf_obj_value(widget, "/T", "")
@@ -377,8 +401,12 @@ def restore_checkbox_appearances(
                         streams["checked"]
                     )
                     widget["/AP"] = pikepdf.Dictionary({"/N": normal_states})
+                    _set_checkbox_mark_style(widget, parent, mark_style, pikepdf)
                     restored += 1
 
+            acroform = pdf.Root.get("/AcroForm")
+            if isinstance(acroform, pikepdf.Dictionary) and "/NeedAppearances" in acroform:
+                del acroform["/NeedAppearances"]
             pdf.save(tmp_path)
 
         _assert_pdf(tmp_path, label="restore checkbox appearances")

--- a/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
+++ b/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
@@ -5,7 +5,8 @@ These tests verify that:
 - Red border color metadata (/MK[BC]) is removed from checkbox widgets.
 - With preserve_button_appearances=True the /AP stream is kept for /Btn fields.
 - Without the flag the old behavior is preserved (AP deleted for all widgets).
-- /AP is still removed from text (/Tx) widgets regardless of the flag.
+- Text fields get a regenerated standard /AP stream after cleanup.
+- /NeedAppearances is cleared so viewers keep the saved button appearance.
 """
 
 import os
@@ -89,7 +90,10 @@ class TestApplyPDFFieldVisualDefaultsButtonPreservation(unittest.TestCase):
     """_apply_pdf_field_visual_defaults: preserve_button_appearances behavior."""
 
     def _make_pdf_with_checkbox(
-        self, has_ap: bool = True, has_red_border: bool = True
+        self,
+        has_ap: bool = True,
+        has_red_border: bool = True,
+        has_need_appearances: bool = False,
     ) -> str:
         """Create a minimal PDF with a checkbox widget.  Returns the file path."""
         import pikepdf
@@ -124,7 +128,10 @@ class TestApplyPDFFieldVisualDefaultsButtonPreservation(unittest.TestCase):
 
         field = pdf.make_indirect(Dictionary(field_dict))
         page.obj["/Annots"] = Array([field])
-        pdf.Root["/AcroForm"] = Dictionary({"/Fields": Array([field])})
+        acroform = Dictionary({"/Fields": Array([field])})
+        if has_need_appearances:
+            acroform["/NeedAppearances"] = True
+        pdf.Root["/AcroForm"] = acroform
         pdf.save(pdf_path)
         pdf.close()
         return pdf_path
@@ -183,6 +190,13 @@ print("done")
 
         with pikepdf.open(pdf_path) as pdf:
             annot = pdf.pages[0]["/Annots"][0]
+            acroform = pdf.Root.get("/AcroForm")
+            ap_stream = ""
+            if "/AP" in annot and hasattr(annot.get("/AP"), "get") and "/N" in annot["/AP"]:
+                try:
+                    ap_stream = annot["/AP"]["/N"].read_bytes().decode("latin1")
+                except (AttributeError, pikepdf.PdfError):
+                    ap_stream = ""
             result = {
                 "has_ap": "/AP" in annot,
                 "has_mk_bc": (
@@ -190,6 +204,11 @@ print("done")
                     and isinstance(annot["/MK"], pikepdf.Dictionary)
                     and "/BC" in annot["/MK"]
                 ),
+                "has_need_appearances": (
+                    isinstance(acroform, pikepdf.Dictionary)
+                    and "/NeedAppearances" in acroform
+                ),
+                "ap_stream": ap_stream,
             }
         return result
 
@@ -222,6 +241,23 @@ print("done")
         finally:
             os.unlink(pdf_path)
 
+    def test_checkbox_need_appearances_cleared(self):
+        """The redraw flag is removed so viewers keep the saved checkbox /AP."""
+        pdf_path = self._make_pdf_with_checkbox(
+            has_ap=True,
+            has_red_border=True,
+            has_need_appearances=True,
+        )
+        try:
+            self._run_visual_defaults(pdf_path, preserve_button_appearances=True)
+            widget = self._read_first_widget(pdf_path)
+            self.assertFalse(
+                widget["has_need_appearances"],
+                "/NeedAppearances should be cleared for final output PDFs",
+            )
+        finally:
+            os.unlink(pdf_path)
+
     def test_checkbox_ap_deleted_without_flag(self):
         """Without the flag (old behavior), /AP is deleted for all widgets."""
         pdf_path = self._make_pdf_with_checkbox(has_ap=True, has_red_border=True)
@@ -235,16 +271,18 @@ print("done")
         finally:
             os.unlink(pdf_path)
 
-    def test_text_field_ap_always_deleted(self):
-        """/AP is removed from text (/Tx) widgets regardless of the flag."""
+    def test_text_field_ap_rebuilt_with_standard_stream(self):
+        """Text fields get a clean regenerated appearance stream."""
         pdf_path = self._make_pdf_with_text_field(has_ap=True)
         try:
             self._run_visual_defaults(pdf_path, preserve_button_appearances=True)
             widget = self._read_first_widget(pdf_path)
-            self.assertFalse(
+            self.assertTrue(
                 widget["has_ap"],
-                "/AP should be removed from text fields even with preserve_button_appearances=True",
+                "/AP should be regenerated for text fields",
             )
+            self.assertIn("/Helv", widget["ap_stream"])
+            self.assertIn("() Tj", widget["ap_stream"])
         finally:
             os.unlink(pdf_path)
 

--- a/docassemble/ALDashboard/test/test_pdf_export_utils.py
+++ b/docassemble/ALDashboard/test/test_pdf_export_utils.py
@@ -313,7 +313,6 @@ class TestPDFExportUtils(unittest.TestCase):
             ["same_name", "same_name__1", "other", "same_name__2"],
         )
 
-
     def test_bulk_normalize_keeps_auto_size_only_when_font_size_is_not_normalized(self):
         detected = [
             [

--- a/docassemble/ALDashboard/test/test_pdf_repair.py
+++ b/docassemble/ALDashboard/test/test_pdf_repair.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 import unittest
 from unittest import mock
+from typing import Any, Dict, List
 
 from docassemble.ALDashboard.pdf_repair import (
     PDFRepairError,
@@ -21,8 +22,10 @@ from docassemble.ALDashboard.pdf_repair import (
     ghostscript_reprint,
     list_repair_actions,
     ocr_pdf,
+    normalize_signature_fields,
     qpdf_repair,
     repair_metadata,
+    restore_checkbox_appearances,
     run_repair,
     unlock_pdf,
 )
@@ -116,6 +119,7 @@ class TestListRepairActions(unittest.TestCase):
                 "auto",
                 "ghostscript_reprint",
                 "qpdf_repair",
+                "restore_checkbox_appearances",
                 "unlock",
                 "repair_metadata",
                 "ocr",
@@ -275,6 +279,284 @@ class TestQpdfRepair(unittest.TestCase):
             self.assertEqual(result["original_page_count"], 1)
             self.assertEqual(result["repaired_page_count"], 1)
             self.assertTrue(os.path.isfile(out_path))
+        finally:
+            if os.path.exists(in_path):
+                os.remove(in_path)
+            if os.path.exists(out_path):
+                os.remove(out_path)
+
+
+class TestRestoreCheckboxAppearances(unittest.TestCase):
+    def _make_form_pdf(self, path: str, *, checkbox_has_ap: bool = False) -> None:
+        import pikepdf
+        from pikepdf import Array, Dictionary, Name, String
+
+        pdf = pikepdf.new()
+        page = pdf.add_blank_page(page_size=(612, 792))
+
+        checkbox = Dictionary(
+            {
+                "/FT": Name("/Btn"),
+                "/Ff": 0,
+                "/T": String("needs_appearance"),
+                "/V": Name("/Off"),
+                "/AS": Name("/Off"),
+                "/Type": Name("/Annot"),
+                "/Subtype": Name("/Widget"),
+                "/Rect": Array([10, 10, 30, 30]),
+                "/MK": Dictionary({"/CA": String("5")}),
+            }
+        )
+        if checkbox_has_ap:
+            checkbox["/AP"] = Dictionary(
+                {
+                    "/N": Dictionary(
+                        {
+                            "/Off": pikepdf.Stream(pdf, b"q Q"),
+                            "/Yes": pikepdf.Stream(pdf, b"q Q"),
+                        }
+                    )
+                }
+            )
+        checkbox_ref = pdf.make_indirect(checkbox)
+
+        text_field = pdf.make_indirect(
+            Dictionary(
+                {
+                    "/FT": Name("/Tx"),
+                    "/T": String("text_field"),
+                    "/Type": Name("/Annot"),
+                    "/Subtype": Name("/Widget"),
+                    "/Rect": Array([40, 10, 120, 30]),
+                }
+            )
+        )
+
+        radio = pdf.make_indirect(
+            Dictionary(
+                {
+                    "/FT": Name("/Btn"),
+                    "/Ff": 1 << 15,
+                    "/T": String("radio_field"),
+                    "/Type": Name("/Annot"),
+                    "/Subtype": Name("/Widget"),
+                    "/Rect": Array([130, 10, 150, 30]),
+                }
+            )
+        )
+
+        page.obj["/Annots"] = Array([checkbox_ref, text_field, radio])
+        pdf.Root["/AcroForm"] = Dictionary(
+            {"/Fields": Array([checkbox_ref, text_field, radio])}
+        )
+        pdf.save(path)
+        pdf.close()
+
+    def _read_widget_flags(self, path: str) -> List[Dict[str, Any]]:
+        import pikepdf
+
+        with pikepdf.open(path) as pdf:
+            widgets = []
+            annots: Any = pdf.pages[0]["/Annots"]
+            for annot in annots:
+                widgets.append(
+                    {
+                        "name": str(annot.get("/T", "")),
+                        "type": str(annot.get("/FT", "")),
+                        "flags": int(annot.get("/Ff", 0) or 0),
+                        "has_ap": "/AP" in annot,
+                        "normal_states": sorted(
+                            str(key)
+                            for key in (
+                                annot.get("/AP", {}).get("/N", {}).keys()
+                                if "/AP" in annot
+                                and hasattr(annot.get("/AP"), "get")
+                                and hasattr(annot.get("/AP").get("/N"), "keys")
+                                else []
+                            )
+                        ),
+                        "yes_stream": (
+                            annot["/AP"]["/N"]["/Yes"].read_bytes().decode("ascii")
+                            if "/AP" in annot
+                            and "/N" in annot["/AP"]
+                            and "/Yes" in annot["/AP"]["/N"]
+                            else ""
+                        ),
+                        "off_stream": (
+                            annot["/AP"]["/N"]["/Off"].read_bytes().decode("ascii")
+                            if "/AP" in annot
+                            and "/N" in annot["/AP"]
+                            and "/Off" in annot["/AP"]["/N"]
+                            else ""
+                        ),
+                    }
+                )
+        return widgets
+
+    def test_restores_only_missing_checkbox_appearances(self):
+        try:
+            import pikepdf  # noqa: F401
+        except ImportError:
+            self.skipTest("pikepdf not installed")
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as inp:
+            in_path = inp.name
+        out_path = in_path + ".appearances.pdf"
+        try:
+            self._make_form_pdf(in_path)
+            result = restore_checkbox_appearances(in_path, out_path)
+
+            self.assertEqual(result["action"], "restore_checkbox_appearances")
+            self.assertEqual(result["checkbox_fields_checked"], 1)
+            self.assertEqual(result["appearances_restored"], 1)
+
+            widgets = {item["name"]: item for item in self._read_widget_flags(out_path)}
+            self.assertTrue(widgets["needs_appearance"]["has_ap"])
+            self.assertEqual(
+                widgets["needs_appearance"]["normal_states"], ["/Off", "/Yes"]
+            )
+            self.assertIn("3.000 3.000 m", widgets["needs_appearance"]["yes_stream"])
+            self.assertIn("17.000 17.000 l", widgets["needs_appearance"]["yes_stream"])
+            self.assertIn("17.000 3.000 m", widgets["needs_appearance"]["yes_stream"])
+            self.assertIn("3.000 17.000 l", widgets["needs_appearance"]["yes_stream"])
+            self.assertNotIn(" re", widgets["needs_appearance"]["yes_stream"])
+            self.assertNotIn(" re", widgets["needs_appearance"]["off_stream"])
+            self.assertFalse(widgets["text_field"]["has_ap"])
+            self.assertFalse(widgets["radio_field"]["has_ap"])
+        finally:
+            if os.path.exists(in_path):
+                os.remove(in_path)
+            if os.path.exists(out_path):
+                os.remove(out_path)
+
+    def test_skips_checkbox_with_existing_appearances(self):
+        try:
+            import pikepdf  # noqa: F401
+        except ImportError:
+            self.skipTest("pikepdf not installed")
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as inp:
+            in_path = inp.name
+        out_path = in_path + ".appearances.pdf"
+        try:
+            self._make_form_pdf(in_path, checkbox_has_ap=True)
+            result = restore_checkbox_appearances(in_path, out_path)
+
+            self.assertEqual(result["checkbox_fields_checked"], 1)
+            self.assertEqual(result["appearances_restored"], 0)
+            self.assertEqual(result["existing_appearances_skipped"], 1)
+        finally:
+            if os.path.exists(in_path):
+                os.remove(in_path)
+            if os.path.exists(out_path):
+                os.remove(out_path)
+
+    def test_restores_opt_in_checkbox_border(self):
+        try:
+            import pikepdf  # noqa: F401
+        except ImportError:
+            self.skipTest("pikepdf not installed")
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as inp:
+            in_path = inp.name
+        out_path = in_path + ".appearances.pdf"
+        try:
+            self._make_form_pdf(in_path)
+            result = restore_checkbox_appearances(
+                in_path,
+                out_path,
+                checkbox_border_widths={"needs_appearance": "medium"},
+            )
+
+            self.assertEqual(result["appearances_restored"], 1)
+
+            widgets = {item["name"]: item for item in self._read_widget_flags(out_path)}
+            self.assertIn("2.000 w", widgets["needs_appearance"]["off_stream"])
+            self.assertIn(
+                "1.000 1.000 18.000 18.000 re",
+                widgets["needs_appearance"]["off_stream"],
+            )
+            self.assertIn("2.000 w", widgets["needs_appearance"]["yes_stream"])
+            self.assertIn(
+                "1.000 1.000 18.000 18.000 re",
+                widgets["needs_appearance"]["yes_stream"],
+            )
+        finally:
+            if os.path.exists(in_path):
+                os.remove(in_path)
+            if os.path.exists(out_path):
+                os.remove(out_path)
+
+
+class TestNormalizeSignatureFields(unittest.TestCase):
+    def _make_text_signature_pdf(self, path: str) -> None:
+        import pikepdf
+        from pikepdf import Array, Dictionary, Name, String
+
+        pdf = pikepdf.new()
+        page = pdf.add_blank_page(page_size=(612, 792))
+        signature_as_text = pdf.make_indirect(
+            Dictionary(
+                {
+                    "/FT": Name("/Tx"),
+                    "/T": String("users1_signature"),
+                    "/Type": Name("/Annot"),
+                    "/Subtype": Name("/Widget"),
+                    "/Rect": Array([72, 600, 220, 630]),
+                    "/V": String(""),
+                    "/DV": String(""),
+                    "/DA": String("/Helv 12 Tf 0 0 0 rg"),
+                }
+            )
+        )
+        ordinary_text = pdf.make_indirect(
+            Dictionary(
+                {
+                    "/FT": Name("/Tx"),
+                    "/T": String("users1_name"),
+                    "/Type": Name("/Annot"),
+                    "/Subtype": Name("/Widget"),
+                    "/Rect": Array([72, 560, 220, 580]),
+                    "/V": String(""),
+                }
+            )
+        )
+        page.obj["/Annots"] = Array([signature_as_text, ordinary_text])
+        pdf.Root["/AcroForm"] = Dictionary(
+            {"/Fields": Array([signature_as_text, ordinary_text])}
+        )
+        pdf.save(path)
+        pdf.close()
+
+    def test_converts_target_text_widget_to_signature_field(self):
+        try:
+            import pikepdf
+        except ImportError:
+            self.skipTest("pikepdf not installed")
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as inp:
+            in_path = inp.name
+        out_path = in_path + ".signature.pdf"
+        try:
+            self._make_text_signature_pdf(in_path)
+            result = normalize_signature_fields(
+                in_path,
+                out_path,
+                ["users1_signature"],
+            )
+
+            self.assertEqual(result["fields_converted"], 1)
+
+            with pikepdf.open(out_path) as pdf:
+                fields = {
+                    str(field.get("/T")): field for field in pdf.Root.AcroForm.Fields
+                }
+                self.assertEqual(str(fields["users1_signature"].get("/FT")), "/Sig")
+                self.assertNotIn("/V", fields["users1_signature"])
+                self.assertNotIn("/DV", fields["users1_signature"])
+                self.assertEqual(str(fields["users1_name"].get("/FT")), "/Tx")
+                self.assertIn("/V", fields["users1_name"])
+                self.assertEqual(int(pdf.Root.AcroForm.get("/SigFlags", 0)), 3)
         finally:
             if os.path.exists(in_path):
                 os.remove(in_path)

--- a/docassemble/ALDashboard/test/test_pdf_repair.py
+++ b/docassemble/ALDashboard/test/test_pdf_repair.py
@@ -287,7 +287,14 @@ class TestQpdfRepair(unittest.TestCase):
 
 
 class TestRestoreCheckboxAppearances(unittest.TestCase):
-    def _make_form_pdf(self, path: str, *, checkbox_has_ap: bool = False) -> None:
+    def _make_form_pdf(
+        self,
+        path: str,
+        *,
+        checkbox_has_ap: bool = False,
+        checkbox_has_partial_ap: bool = False,
+        has_need_appearances: bool = False,
+    ) -> None:
         import pikepdf
         from pikepdf import Array, Dictionary, Name, String
 
@@ -314,6 +321,16 @@ class TestRestoreCheckboxAppearances(unittest.TestCase):
                         {
                             "/Off": pikepdf.Stream(pdf, b"q Q"),
                             "/Yes": pikepdf.Stream(pdf, b"q Q"),
+                        }
+                    )
+                }
+            )
+        elif checkbox_has_partial_ap:
+            checkbox["/AP"] = Dictionary(
+                {
+                    "/N": Dictionary(
+                        {
+                            "/Off": pikepdf.Stream(pdf, b"q Q"),
                         }
                     )
                 }
@@ -346,9 +363,10 @@ class TestRestoreCheckboxAppearances(unittest.TestCase):
         )
 
         page.obj["/Annots"] = Array([checkbox_ref, text_field, radio])
-        pdf.Root["/AcroForm"] = Dictionary(
-            {"/Fields": Array([checkbox_ref, text_field, radio])}
-        )
+        acroform = Dictionary({"/Fields": Array([checkbox_ref, text_field, radio])})
+        if has_need_appearances:
+            acroform["/NeedAppearances"] = True
+        pdf.Root["/AcroForm"] = acroform
         pdf.save(path)
         pdf.close()
 
@@ -392,6 +410,13 @@ class TestRestoreCheckboxAppearances(unittest.TestCase):
                     }
                 )
         return widgets
+
+    def _has_need_appearances(self, path: str) -> bool:
+        import pikepdf
+
+        with pikepdf.open(path) as pdf:
+            acroform = pdf.Root.get("/AcroForm")
+            return isinstance(acroform, pikepdf.Dictionary) and "/NeedAppearances" in acroform
 
     def test_restores_only_missing_checkbox_appearances(self):
         try:
@@ -445,6 +470,59 @@ class TestRestoreCheckboxAppearances(unittest.TestCase):
             self.assertEqual(result["checkbox_fields_checked"], 1)
             self.assertEqual(result["appearances_restored"], 0)
             self.assertEqual(result["existing_appearances_skipped"], 1)
+        finally:
+            if os.path.exists(in_path):
+                os.remove(in_path)
+            if os.path.exists(out_path):
+                os.remove(out_path)
+
+    def test_repairs_partial_checkbox_appearances(self):
+        try:
+            import pikepdf  # noqa: F401
+        except ImportError:
+            self.skipTest("pikepdf not installed")
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as inp:
+            in_path = inp.name
+        out_path = in_path + ".appearances.pdf"
+        try:
+            self._make_form_pdf(in_path, checkbox_has_partial_ap=True)
+            result = restore_checkbox_appearances(in_path, out_path)
+
+            self.assertEqual(result["checkbox_fields_checked"], 1)
+            self.assertEqual(result["appearances_restored"], 1)
+            self.assertEqual(result["existing_appearances_skipped"], 0)
+
+            widgets = {item["name"]: item for item in self._read_widget_flags(out_path)}
+            self.assertEqual(
+                widgets["needs_appearance"]["normal_states"], ["/Off", "/Yes"]
+            )
+        finally:
+            if os.path.exists(in_path):
+                os.remove(in_path)
+            if os.path.exists(out_path):
+                os.remove(out_path)
+
+    def test_clears_need_appearances_after_checkbox_repair(self):
+        try:
+            import pikepdf  # noqa: F401
+        except ImportError:
+            self.skipTest("pikepdf not installed")
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as inp:
+            in_path = inp.name
+        out_path = in_path + ".appearances.pdf"
+        try:
+            self._make_form_pdf(
+                in_path,
+                checkbox_has_ap=True,
+                has_need_appearances=True,
+            )
+            result = restore_checkbox_appearances(in_path, out_path)
+
+            self.assertEqual(result["checkbox_fields_checked"], 1)
+            self.assertEqual(result["existing_appearances_skipped"], 1)
+            self.assertFalse(self._has_need_appearances(out_path))
         finally:
             if os.path.exists(in_path):
                 os.remove(in_path)


### PR DESCRIPTION
Fixes regression caused by #222 by creating a reasonable default appearance stream for a checkbox that is nicer than ReportLab's ugly red border.