### PR TITLE
Format and update code to match new yaml check rules

### DIFF
--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -44,6 +44,7 @@ code: |
     indent=2,
   )
 ---
+id: generate story from server
 question: |
   Generate an ALKiln story
 subquestion: |
@@ -79,6 +80,7 @@ code: |
       f"{interview_title} | {interview_filename}"
     )
 ---
+id: select interview
 question: |
   Select an interview
 subquestion: |
@@ -115,6 +117,7 @@ code: |
       f"{_story_progress_label(saved_session.progress, saved_session.num_keys)}"
     )
 ---
+id: select session
 question: |
   Select a session
 subquestion: |
@@ -140,6 +143,7 @@ validation code: |
       field="selected_session_id",
     )
 ---
+id: generate story from source
 question: |
   Generate an ALKiln story
 subquestion: |
@@ -149,12 +153,14 @@ fields:
     input type: area
     rows: 12
 ---
+id: upload interview yaml
 question: |
   Upload interview YAML
 fields:
   - YAML file: yaml_upload
     datatype: file
 ---
+id: select playground project
 question: |
   Select playground project
 fields:
@@ -163,6 +169,7 @@ fields:
     code: |
       list_playground_projects()
 ---
+id: select playground yaml
 question: |
   Select playground YAML
 fields:
@@ -186,6 +193,7 @@ validation code: |
       field="selected_playground_file",
     )
 ---
+id: paste interview yaml
 question: |
   Paste interview YAML
 fields:
@@ -193,6 +201,7 @@ fields:
     input type: area
     rows: 12
 ---
+id: story options
 question: |
   Story options
 fields:
@@ -310,6 +319,7 @@ code: |
   story_download.commit()
 ---
 event: show_results
+id: alkiln story result
 question: |
   ALKiln story
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/alkiln_story.yml
+++ b/docassemble/ALDashboard/data/questions/alkiln_story.yml
@@ -39,6 +39,7 @@ code: |
 ---
 code: |
   import json
+
   default_ignore_anywhere_text = json.dumps(
     sorted(DEFAULT_IGNORE_ANYWHERE_IN_VAR_NAME),
     indent=2,
@@ -66,9 +67,7 @@ code: |
   for interview_filename, interview_info in sorted(
     interviews.items(),
     key=lambda item: (
-      item[1].get("title") or item[0]
-      if isinstance(item[1], dict)
-      else item[0]
+      item[1].get("title") or item[0] if isinstance(item[1], dict) else item[0]
     ),
   ):
     interview_title = (
@@ -97,6 +96,7 @@ fields:
 code: |
   import json
 
+
   def _story_progress_label(progress, num_keys):
     if progress is not None and str(progress).strip():
       try:
@@ -104,6 +104,7 @@ code: |
       except Exception:
         return str(progress)
     return f"Step {num_keys}"
+
 
   story_session_choices = {}
   for saved_session in speedy_get_sessions(
@@ -259,6 +260,7 @@ code: |
 ---
 code: |
   import json
+
   if story_source == "session":
     story_data = {
       "i": selected_interview_filename,
@@ -306,14 +308,22 @@ code: |
   if story_input_type == "yaml":
     story_result = story_from_docassemble_yaml(
       story_yaml_text,
-      filename=story_default_yaml_file_name if story_source == "playground" else yaml_file_name,
+      filename=(
+        story_default_yaml_file_name
+        if story_source == "playground"
+        else yaml_file_name
+      ),
       source_path=selected_playground_file if story_source == "playground" else None,
       options=story_options,
     )
   else:
     story_result = story_from_docassemble_json(story_data, options=story_options)
   story_download.initialize(
-    filename=output_file_name if output_file_name.endswith(".feature") else output_file_name + ".feature"
+    filename=(
+      output_file_name
+      if output_file_name.endswith(".feature")
+      else output_file_name + ".feature"
+    )
   )
   story_download.write(story_result["feature_text"])
   story_download.commit()

--- a/docassemble/ALDashboard/data/questions/api_test.yml
+++ b/docassemble/ALDashboard/data/questions/api_test.yml
@@ -50,6 +50,7 @@ code: |
     chat_response = chat_completion("you are a helpful assistant", test_chat_message)
   api_results
 ---
+id: test api key
 question: |
   Test an API key
 subquestion: |
@@ -139,6 +140,7 @@ code: |
   a = 1 / 0
 ---
 event: api_results
+id: api test results
 question: |
   Results
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/compile_bootstrap.yml
+++ b/docassemble/ALDashboard/data/questions/compile_bootstrap.yml
@@ -152,6 +152,7 @@ content: |
   ${ output_file.slurp() }
 ---
 event: error_screen
+id: scss compilation error
 question: We weren't able to compile your SCSS
 subquestion: |
   Bootstrap returned this output when we tried to create your Bootstrap CSS file.

--- a/docassemble/ALDashboard/data/questions/compile_bootstrap.yml
+++ b/docassemble/ALDashboard/data/questions/compile_bootstrap.yml
@@ -173,9 +173,9 @@ subquestion: |
   **[Bootstrap CSS file](${output_file.url_for(attachment=True)})**
 
   % if upload_choice == "type_out":
-  **[:download: SCSS source file](${ output_scss.url_for(attachment=True) })**
+  **[:download: Generated SCSS source file](${ output_scss.url_for(attachment=True) })**
   % else:
-  **[:download: SCSS source file](${ uploaded_file.url_for(attachment=True) })**
+  **[:download: Uploaded SCSS source file](${ uploaded_file.url_for(attachment=True) })**
   % endif
 
   <br>

--- a/docassemble/ALDashboard/data/questions/file_index.yml
+++ b/docassemble/ALDashboard/data/questions/file_index.yml
@@ -19,6 +19,7 @@ code: |
 code: |
   latest_s3_folder = get_latest_s3_folder("files/")
 ---
+id: view file index status
 question: |
   View status of S3 /files vs latest index values
 subquestion: |
@@ -37,6 +38,7 @@ fields:
     default: 5000
 ---
 event: show_results
+id: file index update result
 question: |
   New value is ${ get_current_index_value() }
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/generate_translation.yml
+++ b/docassemble/ALDashboard/data/questions/generate_translation.yml
@@ -29,6 +29,7 @@ code: |
   the_task = background_action("translate_file")
 ---
 event: waiting_screen
+id: translation wait screen
 question: |
   Please wait while we translate your file
 subquestion: |
@@ -64,6 +65,7 @@ code: |
   translations = action_argument("translations")
   background_response()
 ---
+id: select file to translate
 question: |
   What file do you want to translate?
 fields:
@@ -111,6 +113,7 @@ fields:
         not gpt_is_available()
 ---
 event: show_translation_results
+id: translation results
 question: |
   Translation results
 subquestion: |
@@ -137,6 +140,7 @@ code: |
   background_response("handled_error")
 ---
 event: error_screen
+id: translation error
 question: |
   There was an error.
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/install_assembly_line.yml
+++ b/docassemble/ALDashboard/data/questions/install_assembly_line.yml
@@ -99,6 +99,7 @@ code: |
 code: |
   backup_file = da_get_config_as_file()
 ---
+id: enable answer sets
 question: |
   Do you want to enable answer sets?
 subquestion: |
@@ -125,6 +126,7 @@ fields:
     datatype: yesnoradio
     default: False
 ---
+id: custom interview list page
 question: |
   Use a custom interview list page?
 subquestion: |
@@ -1016,6 +1018,7 @@ code: |
     reset(pkgname)
   al_install_done = True
 ---
+id: select packages to install
 question: |
   What packages do you want to install or update?
 continue button label: Install Assembly Line
@@ -1102,6 +1105,7 @@ fields:
     all of the above: True
 ---
 event: end_screen
+id: installation complete
 question: |
   Installation complete
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/install_packages.yml
+++ b/docassemble/ALDashboard/data/questions/install_packages.yml
@@ -40,6 +40,8 @@ fields:
   - Short name or alias (no spaces): packages[i].alias
     validate: |
       lambda y: y.isidentifier()
+    validation messages:
+      invalid: Use only letters, numbers, and underscores, and start with a letter or underscore.
     show if: packages[i].add_alias
 ---
 code: |

--- a/docassemble/ALDashboard/data/questions/install_packages.yml
+++ b/docassemble/ALDashboard/data/questions/install_packages.yml
@@ -21,6 +21,7 @@ code: |
   else:
     waiting_screen
 ---
+id: select packages to install
 question: |
   What packages do you want to install?
 list collect: True
@@ -74,6 +75,7 @@ code: |
   background_response()
 ---  
 event: waiting_screen
+id: installation wait screen
 question: |
   Wait here while we start the installation process
 reload: True
@@ -84,6 +86,7 @@ code: |
   background_response()
 ---
 event: ending_screen
+id: installation complete
 question: |
   All done
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/install_packages.yml
+++ b/docassemble/ALDashboard/data/questions/install_packages.yml
@@ -39,9 +39,7 @@ fields:
     show if: packages[i].add_alias
   - Short name or alias (no spaces): packages[i].alias
     validate: |
-      lambda y: y.isidentifier()
-    validation messages:
-      invalid: Use only letters, numbers, and underscores, and start with a letter or underscore.
+      lambda y: y.isidentifier() or validation_error("Use only letters, numbers, and underscores, and start with a letter or underscore.")
     show if: packages[i].add_alias
 ---
 code: |

--- a/docassemble/ALDashboard/data/questions/interview_linter.yml
+++ b/docassemble/ALDashboard/data/questions/interview_linter.yml
@@ -146,6 +146,7 @@ code: |
 
   severity_rank = {"red": 0, "yellow": 1, "green": 2}
   severity_label = {"red": "Fix required", "yellow": "Warning", "green": "Advisory"}
+  severity_class = {"red": "required", "yellow": "warning", "green": "advisory"}
 
 
   def _safe_id(value, prefix="id"):
@@ -171,6 +172,14 @@ code: |
     return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "  ")
 
 
+  def _severity_class(value):
+    return severity_class.get(str(value or "").lower(), "warning")
+
+
+  def _severity_label(value):
+    return severity_label.get(str(value or "").lower(), "Warning")
+
+
   lint_reports_ui = []
   for report_idx, report in enumerate(lint_reports):
     name = str(report.get("name") or "unknown")
@@ -184,7 +193,7 @@ code: |
           "name": name,
           "file_anchor": file_anchor,
           "error": error or "Unknown error",
-          "counts": {"red": 0, "yellow": 0, "green": 0},
+          "counts": {"required": 0, "warning": 0, "advisory": 0},
           "priority_findings": [],
           "screens": [],
           "orphan_findings": [],
@@ -198,9 +207,9 @@ code: |
 
     findings = _sort_findings(result.get("findings", []))
     counts = {
-      "red": len(result.get("findings_by_severity", {}).get("red", [])),
-      "yellow": len(result.get("findings_by_severity", {}).get("yellow", [])),
-      "green": len(result.get("findings_by_severity", {}).get("green", [])),
+      "required": len(result.get("findings_by_severity", {}).get("red", [])),
+      "warning": len(result.get("findings_by_severity", {}).get("yellow", [])),
+      "advisory": len(result.get("findings_by_severity", {}).get("green", [])),
     }
     screen_catalog = result.get("screen_catalog", [])
     by_screen = {str(screen.get("screen_id") or ""): [] for screen in screen_catalog}
@@ -261,21 +270,21 @@ subquestion: |
       <details id="${ report['file_anchor'] }" open>
         <summary>
           ${ html.escape(report['name']) }
-          <span class="al-lint-badge red">Red ${ report['counts']['red'] }</span>
-          <span class="al-lint-badge yellow">Yellow ${ report['counts']['yellow'] }</span>
-          <span class="al-lint-badge green">Green ${ report['counts']['green'] }</span>
+          <span class="al-lint-badge required">Fix required ${ report['counts']['required'] }</span>
+          <span class="al-lint-badge warning">Warnings ${ report['counts']['warning'] }</span>
+          <span class="al-lint-badge advisory">Advisories ${ report['counts']['advisory'] }</span>
         </summary>
         <div class="al-lint-file-body">
           <div>
             % if report['error']:
-            <div class="al-lint-finding red">${ html.escape(report['error']) }</div>
+            <div class="al-lint-finding required">${ html.escape(report['error']) }</div>
             % else:
             <div class="al-lint-priority-inline">
               <strong>Priority:</strong>
               % if report['priority_findings']:
               % for finding in report['priority_findings']:
               <a class="al-lint-priority-item" href="#${ report['file_anchor'] }-screen-${ _safe_id(finding.get('screen_id'), prefix='screen') if finding.get('screen_id') else report['file_anchor'] }">
-                <span class="al-lint-badge ${ str(finding.get('severity') or 'yellow') }">${ html.escape(severity_label.get(str(finding.get('severity') or '').lower(), 'Warning')) }</span>
+                <span class="al-lint-badge ${ _severity_class(finding.get('severity')) }">${ html.escape(_severity_label(finding.get('severity'))) }</span>
                 % if finding.get('screen_id'):
                 <code>${ html.escape(str(finding.get('screen_id'))) }</code>
                 % else:
@@ -290,7 +299,7 @@ subquestion: |
             <div class="al-lint-meta-line">
               Readability: <strong>${ html.escape(str(report['readability'].get('consensus', 'N/A'))) }</strong>
               % if report['readability'].get('warning'):
-              <span class="al-lint-badge ${ report['readability'].get('severity') or 'yellow' }">${ html.escape(str(report['readability'].get('warning')))}</span>
+              <span class="al-lint-badge ${ _severity_class(report['readability'].get('severity')) }">${ html.escape(str(report['readability'].get('warning')))}</span>
               % endif
             </div>
             % if report['misspelled']:
@@ -305,14 +314,14 @@ subquestion: |
               </div>
 
               % for finding in screen['findings']:
-              <div class="al-lint-finding ${ str(finding.get('severity') or 'yellow') }">
-                <span class="al-lint-badge ${ str(finding.get('severity') or 'yellow') }">${ html.escape(severity_label.get(str(finding.get('severity') or '').lower(), 'Warning')) }</span>
+              <div class="al-lint-finding ${ _severity_class(finding.get('severity')) }">
+                <span class="al-lint-badge ${ _severity_class(finding.get('severity')) }">${ html.escape(_severity_label(finding.get('severity'))) }</span>
                 ${ "✨ " if finding.get("source") == "llm" else "" }${ html.escape(_display_text(finding.get('message'))) }
                 % if finding.get("confidence"):
                 <em>(confidence: ${ html.escape(str(finding.get("confidence"))) })</em>
                 % endif
                 % if finding.get("url"):
-                <a href="${ html.escape(str(finding.get('url'))) }" target="_blank" rel="noopener noreferrer">Reference</a>
+                <a href="${ html.escape(str(finding.get('url'))) }" target="_blank" rel="noopener noreferrer">Reference (opens in new tab)</a>
                 % endif
                 % if finding.get("problematic_text"):
                 <div class="al-lint-problem">${ html.escape(_display_text(finding.get("problematic_text"))) }</div>
@@ -336,11 +345,11 @@ subquestion: |
             <article class="al-lint-screen">
               <div class="al-lint-screen-header"><strong>General findings (no section id)</strong></div>
               % for finding in report['orphan_findings']:
-              <div class="al-lint-finding ${ str(finding.get('severity') or 'yellow') }">
-                <span class="al-lint-badge ${ str(finding.get('severity') or 'yellow') }">${ html.escape(severity_label.get(str(finding.get('severity') or '').lower(), 'Warning')) }</span>
+              <div class="al-lint-finding ${ _severity_class(finding.get('severity')) }">
+                <span class="al-lint-badge ${ _severity_class(finding.get('severity')) }">${ html.escape(_severity_label(finding.get('severity'))) }</span>
                 ${ html.escape(_display_text(finding.get('message'))) }
                 % if finding.get("url"):
-                <a href="${ html.escape(str(finding.get('url'))) }" target="_blank" rel="noopener noreferrer">Reference</a>
+                <a href="${ html.escape(str(finding.get('url'))) }" target="_blank" rel="noopener noreferrer">Reference (opens in new tab)</a>
                 % endif
                 % if finding.get("problematic_text"):
                 <div class="al-lint-problem">${ html.escape(_display_text(finding.get("problematic_text"))) }</div>
@@ -354,10 +363,10 @@ subquestion: |
             <article class="al-lint-screen">
               <div class="al-lint-screen-header"><strong>Additional warnings</strong></div>
               % for warning in report['headings_warnings']:
-              <div class="al-lint-finding yellow">${ html.escape(_display_text(warning)) }</div>
+              <div class="al-lint-finding warning">${ html.escape(_display_text(warning)) }</div>
               % endfor
               % for warning in report['style_warnings']:
-              <div class="al-lint-finding yellow">${ html.escape(_display_text(warning.get("message") or "")) } <a href="${ html.escape(str(warning.get('url') or '')) }" target="_blank" rel="noopener noreferrer">Read more</a></div>
+              <div class="al-lint-finding warning">${ html.escape(_display_text(warning.get("message") or "")) } <a href="${ html.escape(str(warning.get('url') or '')) }" target="_blank" rel="noopener noreferrer">Style guidance (opens in new tab)</a></div>
               % endfor
             </article>
             % endif

--- a/docassemble/ALDashboard/data/questions/interview_linter.yml
+++ b/docassemble/ALDashboard/data/questions/interview_linter.yml
@@ -34,6 +34,7 @@ code: |
   lint_reports
   show_results
 ---
+id: interview text linter
 question: |
   Interview text linter
 subquestion: |
@@ -68,6 +69,7 @@ code: |
   installed_package_map = list_question_files_in_docassemble_packages()
   installed_package_names = sorted(installed_package_map.keys())
 ---
+id: upload yaml files
 question: |
   Upload YAML files
 fields:
@@ -76,6 +78,7 @@ fields:
     accept: |
       ".yml,.yaml,text/yaml,text/x-yaml"
 ---
+id: select installed package
 question: |
   Select installed package
 fields:
@@ -83,6 +86,7 @@ fields:
     code: |
       installed_package_names
 ---
+id: select installed package files
 question: |
   Select installed package files to lint
 fields:
@@ -96,6 +100,7 @@ fields:
         if filename.lower().endswith((".yml", ".yaml"))
       ]
 ---
+id: select playground project
 question: |
   Select playground project
 fields:
@@ -103,6 +108,7 @@ fields:
     code: |
       list_playground_projects()
 ---
+id: select playground files
 question: |
   Select playground files to lint
 fields:
@@ -242,6 +248,7 @@ code: |
     )
 ---
 event: show_results
+id: interview suggestions
 question: |
   Interview Suggestions
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -18,6 +18,7 @@ modules:
 ---
 #mandatory: True # Use while developing in playground
 continue button field: playground_splash
+id: splash screen
 question: |
   Splash screen
 ---
@@ -49,6 +50,7 @@ code: |
   else:
     current_usage_rows = []
 ---
+id: select interview
 question: |
   What interview do you want to view sessions for?
 subquestion: |
@@ -176,6 +178,7 @@ code: |
 ---
 mandatory: True
 event: load_answer
+id: session list
 question: |
   % if filename:
   Recently started sessions for ${ nicer_interview_filename(interviews.get(filename, {"title": filename}).get('title', filename)) }

--- a/docassemble/ALDashboard/data/questions/manage_users.yml
+++ b/docassemble/ALDashboard/data/questions/manage_users.yml
@@ -204,6 +204,7 @@ code: |
   do_disable_mfa = True
 ---
 event: ending_screen
+id: task complete
 question: |
   Task is done
 subquestion: |
@@ -220,4 +221,3 @@ subquestion: |
   % endif
 buttons:
   - Restart: restart
-  

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -16,6 +16,7 @@ features:
   css: al_dashboard.css
 ---
 mandatory: True
+id: dashboard menu
 question: |
   ALDashboard 
 Subquestion: |

--- a/docassemble/ALDashboard/data/questions/package_scanner.yml
+++ b/docassemble/ALDashboard/data/questions/package_scanner.yml
@@ -169,6 +169,7 @@ buttons:
 attachments:
   - name: Package Scanner Report    
     docx template file: pkg_scanner_report.docx
+    tagged pdf: True
     valid formats:
       - pdf
 ---

--- a/docassemble/ALDashboard/data/questions/review_screen_generator.yml
+++ b/docassemble/ALDashboard/data/questions/review_screen_generator.yml
@@ -13,6 +13,7 @@ code: |
   yaml_file
   results
 ---
+id: generate review screen
 question: |
   Generate a review screen
 subquestion: |
@@ -348,4 +349,3 @@ css: |
     max-height: 2000px;
   }
   </style>
-  

--- a/docassemble/ALDashboard/data/questions/test_translate_fragments.yml
+++ b/docassemble/ALDashboard/data/questions/test_translate_fragments.yml
@@ -24,6 +24,7 @@ code: |
     ),
   )
 ---
+id: test translation
 question: |
   Click to test the translation
 subquestion: |
@@ -33,6 +34,7 @@ subquestion: |
 continue button field: intro_screen
 ---
 continue button field: show_results
+id: translation test results
 question: |
   Here are the results
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/update_packages.yml
+++ b/docassemble/ALDashboard/data/questions/update_packages.yml
@@ -28,6 +28,7 @@ code: |
   else:
     waiting_screen
 ---
+id: select packages to update
 question: |
   What packages do you want to update?
 fields:
@@ -73,6 +74,7 @@ code: |
   background_response()
 ---  
 event: waiting_screen
+id: update wait screen
 question: |
   Wait here while we start the installation process
 reload: True
@@ -83,6 +85,7 @@ code: |
   background_response()
 ---
 event: ending_screen
+id: package update started
 question: |
   Your packages are installing
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/validate_attachment.yml
+++ b/docassemble/ALDashboard/data/questions/validate_attachment.yml
@@ -5,6 +5,7 @@ include:
 modules:
   - .validate_attachment
 ---
+id: paste attachment block
 question: |
   Paste the contents of a long attachment block
   (beginning with the line `fields:`)
@@ -23,6 +24,7 @@ code: |
 need:
   - load_all_errors
 mandatory: True
+id: attachment validation results
 question: |
   % if len(errors):
   ${ len(errors) } potential errors found

--- a/docassemble/ALDashboard/data/questions/validate_translation.yml
+++ b/docassemble/ALDashboard/data/questions/validate_translation.yml
@@ -2,6 +2,7 @@
 include:
   - nav.yml
 ---
+id: upload translation file
 question: |
   Upload a translation file
 fields:
@@ -143,6 +144,7 @@ code: |
 need:
   - load_all_errors
 mandatory: True
+id: translation validation results
 question: |
   % if len(errors):
   ${ len(errors) } potential errors found
@@ -165,4 +167,3 @@ subquestion: |
   
   Rows ${ comma_and_list(empty_rows) } have untranslated text.
   % endif
-  

--- a/docassemble/ALDashboard/data/questions/yaml_formatter.yml
+++ b/docassemble/ALDashboard/data/questions/yaml_formatter.yml
@@ -40,7 +40,7 @@ subquestion: |
 
   % if black_release_status.get("update_available"):
   <div class="alert alert-warning" role="alert">
-    This server is using an older version of the Python formatter
+    This server is using an older version of <code>black</code>
     (${ black_release_status.get("installed_version") }).
     The current release is ${ black_release_status.get("latest_version") }, so formatting may
     differ from CI and block a PR.
@@ -59,7 +59,7 @@ fields:
       variable: format_mode
       is: playground
     help: |
-      If enabled, all Python modules in the selected playground project are formatted with the configured Python formatter
+      If enabled, all Python modules in the selected playground project are formatted with `black`
       except `__init__.py` and `setup.py`.
   - Max line length: line_length
     datatype: integer
@@ -94,7 +94,7 @@ question: |
 subquestion: |
   Only selected YAML files will be rewritten.
 
-  All Python modules in the selected project are formatted with the configured Python formatter
+  All Python modules in the selected project are formatted with `black`
   except `__init__.py` and `setup.py`.
 fields:
   - Files: selected_playground_files
@@ -164,10 +164,10 @@ subquestion: |
   Errors: **${ playground_result["error_count"] }**
 
   % if playground_result["black"].get("requested"):
-  #### Python module formatting
+  #### Black formatting (Python modules)
   Processed modules: **${ playground_result["black"].get("processed_count") or 0 }**  
   Rewritten modules: **${ playground_result["black"].get("changed_count") or 0 }**  
-  Python formatting errors: **${ playground_result["black"].get("error_count") or 0 }**
+  Black errors: **${ playground_result["black"].get("error_count") or 0 }**
   % endif
 
   % if playground_result["selected_count"] == 0:
@@ -197,7 +197,7 @@ subquestion: |
   % endif
 
   % if playground_result["black"].get("errors"):
-  #### Python formatting errors
+  #### Black errors
   % for item in playground_result["black"].get("errors"):
   - `${ item["name"] }`: error
     `${ item["error"] }`

--- a/docassemble/ALDashboard/data/questions/yaml_formatter.yml
+++ b/docassemble/ALDashboard/data/questions/yaml_formatter.yml
@@ -31,6 +31,7 @@ code: |
 code: |
   black_release_status = get_black_release_status()
 ---
+id: yaml formatter
 question: |
   Reformat YAML and playground Python
 subquestion: |
@@ -72,12 +73,14 @@ fields:
     help: |
       If enabled, code blocks indented with 4 spaces are converted to 2-space indentation.
 ---
+id: upload yaml file
 question: |
   Upload YAML file
 fields:
   - YAML file: uploaded_yaml_file
     datatype: file
 ---
+id: select playground project
 question: |
   Select playground project
 fields:
@@ -85,6 +88,7 @@ fields:
     code: |
       list_playground_projects()
 ---
+id: select playground files
 question: |
   Select playground files to reformat
 subquestion: |
@@ -131,6 +135,7 @@ code: |
   )
 ---
 event: show_results
+id: yaml formatter results
 question: |
   YAML formatter results
 subquestion: |

--- a/docassemble/ALDashboard/data/questions/yaml_formatter.yml
+++ b/docassemble/ALDashboard/data/questions/yaml_formatter.yml
@@ -40,7 +40,7 @@ subquestion: |
 
   % if black_release_status.get("update_available"):
   <div class="alert alert-warning" role="alert">
-    This server is using an older version of <code>black</code>
+    This server is using an older version of the Python formatter
     (${ black_release_status.get("installed_version") }).
     The current release is ${ black_release_status.get("latest_version") }, so formatting may
     differ from CI and block a PR.
@@ -59,7 +59,7 @@ fields:
       variable: format_mode
       is: playground
     help: |
-      If enabled, all Python modules in the selected playground project are formatted with `black`
+      If enabled, all Python modules in the selected playground project are formatted with the configured Python formatter
       except `__init__.py` and `setup.py`.
   - Max line length: line_length
     datatype: integer
@@ -94,7 +94,7 @@ question: |
 subquestion: |
   Only selected YAML files will be rewritten.
 
-  All Python modules in the selected project are formatted with `black`
+  All Python modules in the selected project are formatted with the configured Python formatter
   except `__init__.py` and `setup.py`.
 fields:
   - Files: selected_playground_files
@@ -164,10 +164,10 @@ subquestion: |
   Errors: **${ playground_result["error_count"] }**
 
   % if playground_result["black"].get("requested"):
-  #### Black formatting (Python modules)
+  #### Python module formatting
   Processed modules: **${ playground_result["black"].get("processed_count") or 0 }**  
   Rewritten modules: **${ playground_result["black"].get("changed_count") or 0 }**  
-  Black errors: **${ playground_result["black"].get("error_count") or 0 }**
+  Python formatting errors: **${ playground_result["black"].get("error_count") or 0 }**
   % endif
 
   % if playground_result["selected_count"] == 0:
@@ -197,7 +197,7 @@ subquestion: |
   % endif
 
   % if playground_result["black"].get("errors"):
-  #### Black errors
+  #### Python formatting errors
   % for item in playground_result["black"].get("errors"):
   - `${ item["name"] }`: error
     `${ item["error"] }`

--- a/docassemble/ALDashboard/data/static/interview_linter.css
+++ b/docassemble/ALDashboard/data/static/interview_linter.css
@@ -57,17 +57,17 @@
   font-weight: 600;
 }
 
-.al-lint-badge.red {
+.al-lint-badge.required {
   background: #fde2e2;
   color: #922;
 }
 
-.al-lint-badge.yellow {
+.al-lint-badge.warning {
   background: #fff3d6;
   color: #7a5700;
 }
 
-.al-lint-badge.green {
+.al-lint-badge.advisory {
   background: #e0f7ea;
   color: #165d33;
 }
@@ -115,17 +115,17 @@
   font-size: 0.92rem;
 }
 
-.al-lint-finding.red {
+.al-lint-finding.required {
   border-left-color: #c53030;
   background: #fff5f5;
 }
 
-.al-lint-finding.yellow {
+.al-lint-finding.warning {
   border-left-color: #b7791f;
   background: #fffbf0;
 }
 
-.al-lint-finding.green {
+.al-lint-finding.advisory {
   border-left-color: #2f855a;
   background: #f2fff7;
 }

--- a/docassemble/ALDashboard/pdf_repair.py
+++ b/docassemble/ALDashboard/pdf_repair.py
@@ -405,7 +405,10 @@ def restore_checkbox_appearances(
                     restored += 1
 
             acroform = pdf.Root.get("/AcroForm")
-            if isinstance(acroform, pikepdf.Dictionary) and "/NeedAppearances" in acroform:
+            if (
+                isinstance(acroform, pikepdf.Dictionary)
+                and "/NeedAppearances" in acroform
+            ):
                 del acroform["/NeedAppearances"]
             pdf.save(tmp_path)
 

--- a/docassemble/ALDashboard/test/api_review_input.yml
+++ b/docassemble/ALDashboard/test/api_review_input.yml
@@ -23,4 +23,6 @@ fields:
 ---
 id: ask_yesno
 question: Are you filing?
-yesno: is_filing
+fields:
+  - Are you filing?: is_filing
+    datatype: yesno

--- a/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
+++ b/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
@@ -192,7 +192,11 @@ print("done")
             annot = pdf.pages[0]["/Annots"][0]
             acroform = pdf.Root.get("/AcroForm")
             ap_stream = ""
-            if "/AP" in annot and hasattr(annot.get("/AP"), "get") and "/N" in annot["/AP"]:
+            if (
+                "/AP" in annot
+                and hasattr(annot.get("/AP"), "get")
+                and "/N" in annot["/AP"]
+            ):
                 try:
                     ap_stream = annot["/AP"]["/N"].read_bytes().decode("latin1")
                 except (AttributeError, pikepdf.PdfError):

--- a/docassemble/ALDashboard/test/test_pdf_repair.py
+++ b/docassemble/ALDashboard/test/test_pdf_repair.py
@@ -416,7 +416,10 @@ class TestRestoreCheckboxAppearances(unittest.TestCase):
 
         with pikepdf.open(path) as pdf:
             acroform = pdf.Root.get("/AcroForm")
-            return isinstance(acroform, pikepdf.Dictionary) and "/NeedAppearances" in acroform
+            return (
+                isinstance(acroform, pikepdf.Dictionary)
+                and "/NeedAppearances" in acroform
+            )
 
     def test_restores_only_missing_checkbox_appearances(self):
         try:


### PR DESCRIPTION
1. Add `id` to all question blocks
2. Use more accessible language (not dependent on color) in linter
3. Remove less accessible input types, such as `yesno` question type
4. Add validation message for validation rules
5. Use tagged PDFs

Ignoring:

* Missing courtforms online metadata
* `black` isn't used as a color, but as the name of a tool

This doesn't have any real substantive changes. Going to merge; @plocket this is triggering your review but there are no substantive changes in the Kiln fixture-generating code.