### PR TITLE
Review and improve pdf unique name handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# ALDashboard Agent Notes
+
+## PDF Labeler
+
+The browser editor is served at `/al/pdf-labeler`. Its main implementation is:
+
+- `docassemble/ALDashboard/api_labelers.py`: Flask endpoints.
+- `docassemble/ALDashboard/pdf_export_utils.py`: conversion and field-name rules.
+- `docassemble/ALDashboard/data/templates/pdf_labeler.html`: page and modal markup.
+- `docassemble/ALDashboard/data/static/pdf_labeler.js`: editor state and interactions.
+- `docassemble/ALDashboard/data/static/pdf_labeler.css`: labeler-specific styles.
+
+Keep the HTML template free of duplicated JavaScript. The labeler loads the
+packaged ES module from `data/static/pdf_labeler.js`.
+
+### Field-name contract
+
+PDF field names are opaque strings. Do not normalize, collapse underscores,
+renumber suffixes, or otherwise rewrite a unique field name during save or
+export.
+
+Deduplication means only this: no two fields in one output PDF may have exactly
+the same complete name. Keep the first occurrence and rename only later exact
+duplicates by appending an unused `__N` suffix.
+
+Names that already end in `__1`, `__2`, or any other digits after a double
+underscore are valid independent names. The digits do not need to be
+sequential. Reserve every original field name before generating a suffix so a
+generated name never displaces a later unique original name. Example:
+
+`["name", "name", "name__1"]` becomes
+`["name", "name__2", "name__1"]`.
+
+Whenever save or export changes names to enforce uniqueness, show an
+occurrence-level summary to the user with each old and new name.
+
+The executable contract and focused tests belong in
+`pdf_export_utils.py` and `test/test_pdf_export_utils.py`. Keep the browser
+implementation in `buildExportNameMap()` behaviorally identical.
+
+### Attachment blocks
+
+The Utilities modal generates a complete docassemble PDF `attachment:` block
+from the active PDF. It includes `name`, `filename`, `pdf template file`, and a
+list-form `fields` section. Match Weaver's quoted field-label style exactly:
+
+`- "users1_name__1": ${ users[0] }`
+
+Preserve the raw PDF field name on the left and use AssemblyLine display
+expressions on the right. Repeated-appearance suffixes are ignored only when
+deriving the expression. Do not remove that suffix from the actual PDF field
+name.
+
+### Verification
+
+Run the focused Python tests for export and attachment mapping, then the static
+labeler extraction tests. When changing browser behavior, also run a JavaScript
+syntax check.

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -70,7 +70,7 @@ from .api_dashboard_utils import (
 from .pdf_export_utils import (
     build_normalized_pdf_field_definitions,
     build_pdf_export_fields_per_page,
-    deduplicate_fields_data,
+    deduplicate_fields_data_with_renames,
 )
 
 __all__ = []
@@ -3243,8 +3243,11 @@ def pdf_labeler_apply_fields() -> Response:
             with pikepdf.open(input_path) as pdf:
                 page_count = len(pdf.pages)
 
+            renamed_fields: List[Dict[str, Any]] = []
             if deduplicate_field_names:
-                fields_data = deduplicate_fields_data(fields_data)
+                fields_data, renamed_fields = deduplicate_fields_data_with_renames(
+                    fields_data
+                )
 
             checkbox_export_values = {
                 str(field.get("name", "")): str(
@@ -3388,6 +3391,7 @@ def pdf_labeler_apply_fields() -> Response:
                     "data": {
                         "filename": output_filename,
                         "pdf_base64": base64.b64encode(output_bytes).decode("ascii"),
+                        "renamed_fields": renamed_fields,
                     },
                 }
             )
@@ -3414,6 +3418,50 @@ def pdf_labeler_apply_fields() -> Response:
                 "error": {"type": "server_error", "message": str(exc)},
             },
             500,
+        )
+
+
+@app.route("/pdf-labeler/api/attachment-block", methods=["POST"])
+@app.route(f"{LABELER_BASE_PATH}/pdf-labeler/api/attachment-block", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def pdf_labeler_attachment_block() -> Response:
+    """Generate an AssemblyLine-style attachment ``fields:`` block."""
+    request_id = str(uuid.uuid4())
+    try:
+        payload = request.get_json(silent=True) or {}
+        field_names = payload.get("field_names")
+        pdf_filename = payload.get("filename")
+        if not isinstance(field_names, list):
+            raise DashboardAPIValidationError(
+                "field_names is required and must be a list."
+            )
+        if not isinstance(pdf_filename, str) or not pdf_filename.strip():
+            raise DashboardAPIValidationError(
+                "filename is required and must be a PDF filename."
+            )
+        from .pdf_attachment_block import generate_attachment_block
+
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "attachment_block": generate_attachment_block(
+                        field_names,
+                        pdf_filename=pdf_filename,
+                    )
+                },
+            }
+        )
+    except DashboardAPIValidationError as exc:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": exc.message},
+            },
+            exc.status_code,
         )
 
 

--- a/docassemble/ALDashboard/data/static/pdf_labeler.js
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.js
@@ -313,6 +313,9 @@
     const a11yTagStructure = document.getElementById('a11y-tag-structure');
     const utilitiesModal = document.getElementById('utilities-modal');
     const utilitiesCloseBtn = document.getElementById('utilities-close');
+    const fieldRenameSummaryModal = document.getElementById('field-rename-summary-modal');
+    const fieldRenameSummaryContext = document.getElementById('field-rename-summary-context');
+    const fieldRenameSummaryList = document.getElementById('field-rename-summary-list');
     const pageManagerModal = document.getElementById('page-manager-modal');
     const closePageManagerBtn = document.getElementById('close-page-manager');
     const pageManagerStatus = document.getElementById('page-manager-status');
@@ -1295,8 +1298,10 @@
     function getDuplicateFieldNames() {
         const counts = new Map();
         state.fields.forEach(function (field) {
-            const normalized = normalizePdfFieldName(field.name || 'field') || 'field';
-            counts.set(normalized, (counts.get(normalized) || 0) + 1);
+            const name = field.name === null || field.name === undefined || field.name === ''
+                ? 'field'
+                : String(field.name);
+            counts.set(name, (counts.get(name) || 0) + 1);
         });
         const duplicates = [];
         counts.forEach(function (count, name) {
@@ -2148,6 +2153,7 @@
         try {
             // First export to get the latest PDF with field changes applied
             var pdfContent;
+            var saveRenamedFields = [];
             var saveDeduplicateFieldNames = document.getElementById('save-pg-deduplicate-field-names').checked;
             if (state.fields.length > 0 && (state.hasUnsavedChanges || saveDeduplicateFieldNames)) {
                 var formData = new FormData();
@@ -2155,6 +2161,7 @@
                 var saveNameMap = buildExportNameMap({
                     deduplicate: saveDeduplicateFieldNames
                 });
+                saveRenamedFields = getRenamedFields(saveNameMap);
                 formData.append('fields', JSON.stringify(convertFieldsToAbsoluteCoordinates(saveNameMap)));
                 formData.append('accessibility', JSON.stringify(buildAccessibilityPayload(saveNameMap)));
                 formData.append('deduplicate_field_names', saveDeduplicateFieldNames ? 'true' : 'false');
@@ -2185,6 +2192,10 @@
             setDirty(false);
             showPdfWorkspace();
             showSuccess((data.data && data.data.created ? 'Created' : 'Updated') + ' ' + filename + ' in Playground.');
+            showFieldRenameSummary(
+                saveRenamedFields,
+                'The PDF was saved after these exact duplicate field names were made unique.'
+            );
         } catch (error) {
             showPdfWorkspace();
             showError('Save to Playground failed: ' + (error.message || 'Unknown error.'));
@@ -2693,7 +2704,7 @@
         const rawName = String(field.name || '').trim();
         const normalized = normalizePdfFieldName(rawName);
         const duplicateExists = state.fields.some(function (candidate) {
-            return candidate.id !== field.id && normalizePdfFieldName(candidate.name) === normalized;
+            return candidate.id !== field.id && String(candidate.name || '') === String(field.name || '');
         });
 
         if (!rawName) {
@@ -3943,21 +3954,63 @@
     function buildExportNameMap(options) {
         const deduplicate = !!(options && options.deduplicate);
         const exportNameMap = new Map();
+        const originalNames = state.fields.map(function (field) {
+            return field.name === null || field.name === undefined || field.name === ''
+                ? 'field'
+                : String(field.name);
+        });
+        const reservedOriginalNames = new Set(originalNames);
         const used = new Set();
-        state.fields.forEach(function (field) {
-            const base = normalizePdfFieldName(field.name || 'field') || 'field';
+        const suffixByName = new Map();
+        state.fields.forEach(function (field, index) {
+            const base = originalNames[index];
             let candidate = base;
             if (deduplicate) {
-                let suffix = 1;
+                let suffix = suffixByName.get(base) || 0;
                 while (used.has(candidate)) {
-                    candidate = base + '__' + suffix;
                     suffix += 1;
+                    candidate = base + '__' + suffix;
+                    while (reservedOriginalNames.has(candidate) || used.has(candidate)) {
+                        suffix += 1;
+                        candidate = base + '__' + suffix;
+                    }
                 }
+                suffixByName.set(base, suffix);
             }
             used.add(candidate);
             exportNameMap.set(field.id, candidate);
         });
         return exportNameMap;
+    }
+
+    function getRenamedFields(exportNameMap) {
+        const renames = [];
+        state.fields.forEach(function (field, index) {
+            const oldName = field.name === null || field.name === undefined || field.name === ''
+                ? 'field'
+                : String(field.name);
+            const newName = exportNameMap.get(field.id) || oldName;
+            if (newName !== oldName) {
+                renames.push({
+                    index: index,
+                    old_name: oldName,
+                    new_name: newName
+                });
+            }
+        });
+        return renames;
+    }
+
+    function showFieldRenameSummary(renames, contextText) {
+        if (!Array.isArray(renames) || renames.length === 0) return;
+        fieldRenameSummaryContext.textContent = contextText || 'The following exact duplicate field names were renamed.';
+        fieldRenameSummaryList.innerHTML = renames.map(function (rename) {
+            return '<div class="border rounded p-2">' +
+                '<div class="small text-muted">Field ' + String(Number(rename.index) + 1) + '</div>' +
+                '<div><code>' + escapeHtml(rename.old_name) + '</code> &rarr; <code>' + escapeHtml(rename.new_name) + '</code></div>' +
+                '</div>';
+        }).join('');
+        fieldRenameSummaryModal.classList.remove('hidden');
     }
 
     function buildUniqueExportNameMap() {
@@ -3968,7 +4021,11 @@
         const nameMap = exportNameMap || buildUniqueExportNameMap();
         return state.fields.map(function (field) {
             const pageSize = state.pageSizes[field.pageIndex];
-            const safeName = nameMap.get(field.id) || normalizePdfFieldName(field.name || 'field');
+            const safeName = nameMap.get(field.id) || (
+                field.name === null || field.name === undefined || field.name === ''
+                    ? 'field'
+                    : String(field.name)
+            );
             return {
                 name: safeName,
                 type: field.type,
@@ -4184,6 +4241,7 @@
             formData.append('file', getPdfFileForRequests());
             const deduplicateFieldNames = !exportDeduplicateFieldNamesInput || exportDeduplicateFieldNamesInput.checked;
             const exportNameMap = buildExportNameMap({ deduplicate: deduplicateFieldNames });
+            const renamedFields = getRenamedFields(exportNameMap);
             formData.append('fields', JSON.stringify(convertFieldsToAbsoluteCoordinates(exportNameMap)));
             formData.append('accessibility', JSON.stringify(buildAccessibilityPayload(exportNameMap)));
             formData.append('deduplicate_field_names', deduplicateFieldNames ? 'true' : 'false');
@@ -4220,6 +4278,10 @@
             setDirty(false);
             showPdfWorkspace();
             showSuccess('PDF exported successfully.');
+            showFieldRenameSummary(
+                renamedFields,
+                'The exported PDF contains these renamed exact duplicate fields.'
+            );
         } catch (error) {
             console.error('Error exporting:', error);
             showPdfWorkspace();
@@ -4980,6 +5042,10 @@
         document.getElementById('util-bulk-status').classList.add('hidden');
         document.getElementById('util-bulk-size-warning').classList.add('hidden');
         document.getElementById('util-bulk-files').value = '';
+        document.getElementById('util-attachment-status').classList.add('hidden');
+        document.getElementById('util-attachment-output').value = '';
+        document.getElementById('util-attachment-generate').disabled = state.fields.length === 0;
+        document.getElementById('util-attachment-copy').disabled = true;
         bulkFiles = [];
         updateBulkState();
         updateUtilActiveButtons();
@@ -4988,6 +5054,59 @@
     });
     utilitiesCloseBtn.addEventListener('click', function () {
         utilitiesModal.classList.add('hidden');
+    });
+    [
+        document.getElementById('field-rename-summary-close'),
+        document.getElementById('field-rename-summary-done')
+    ].forEach(function (button) {
+        button.addEventListener('click', function () {
+            fieldRenameSummaryModal.classList.add('hidden');
+        });
+    });
+
+    document.getElementById('util-attachment-generate').addEventListener('click', function () {
+        var statusEl = document.getElementById('util-attachment-status');
+        var outputEl = document.getElementById('util-attachment-output');
+        var copyBtn = document.getElementById('util-attachment-copy');
+        statusEl.className = 'alert alert-info small mb-2';
+        statusEl.textContent = 'Generating attachment block...';
+        statusEl.classList.remove('hidden');
+        fetch(apiUrl('/pdf-labeler/api/attachment-block'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+            body: JSON.stringify({
+                field_names: state.fields.map(function (field) { return field.name; }),
+                filename: state.fileName || 'template.pdf'
+            })
+        })
+        .then(function (response) { return parseApiResponse(response); })
+        .then(function (data) {
+            if (!data.success || !data.data) {
+                throw new Error((data.error && data.error.message) || 'Generation failed.');
+            }
+            outputEl.value = data.data.attachment_block || 'fields:';
+            copyBtn.disabled = false;
+            statusEl.className = 'alert alert-success small mb-2';
+            statusEl.textContent = 'Attachment block generated.';
+        })
+        .catch(function (error) {
+            statusEl.className = 'alert alert-danger small mb-2';
+            statusEl.textContent = 'Error: ' + (error && error.message ? error.message : 'Unknown error.');
+        });
+    });
+    document.getElementById('util-attachment-copy').addEventListener('click', function () {
+        var outputEl = document.getElementById('util-attachment-output');
+        var copyPromise = navigator.clipboard && navigator.clipboard.writeText
+            ? navigator.clipboard.writeText(outputEl.value)
+            : Promise.reject(new Error('Clipboard API unavailable'));
+        copyPromise.then(function () {
+            showSuccess('Attachment fields block copied.');
+        }).catch(function () {
+            outputEl.focus();
+            outputEl.select();
+            document.execCommand('copy');
+            showSuccess('Attachment fields block copied.');
+        });
     });
 
     document.getElementById('util-copy-source-file').addEventListener('change', function (e) {

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -388,6 +388,22 @@
             </div>
         </div>
 
+        <div id="field-rename-summary-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1090;">
+            <div class="bg-white border shadow rounded p-4" style="width: 100%; max-width: 42rem; max-height: 85vh; overflow-y: auto;">
+                <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+                    <div>
+                        <h2 class="h5 fw-semibold mb-1">Field Names Changed</h2>
+                        <p id="field-rename-summary-context" class="small text-muted mb-0"></p>
+                    </div>
+                    <button id="field-rename-summary-close" class="btn-close" aria-label="Close"></button>
+                </div>
+                <div id="field-rename-summary-list" class="vstack gap-2"></div>
+                <div class="d-flex justify-content-end mt-3">
+                    <button id="field-rename-summary-done" class="btn btn-primary btn-sm">Done</button>
+                </div>
+            </div>
+        </div>
+
         <div id="accessibility-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 62rem; max-height: 92vh; overflow: auto;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
@@ -771,6 +787,16 @@
                         <label class="form-check-label small" for="util-copy-load-result">Load resulting PDF in the labeler</label>
                     </div>
                     <button id="util-copy-run" class="btn btn-primary btn-sm" disabled>Copy Fields</button>
+                </section>
+                <section class="border rounded p-3 mb-3">
+                    <h3 class="h6 fw-semibold mb-2">Attachment Block</h3>
+                    <p class="small text-muted mb-2">Generate a complete docassemble <code>attachment:</code> block for the active PDF. Field mappings use Weaver's quoted YAML list style, for example <code>- "users1_name__1": ${ users[0] }</code>.</p>
+                    <div id="util-attachment-status" class="hidden alert small mb-2"></div>
+                    <textarea id="util-attachment-output" class="form-control form-control-sm font-monospace mb-2" rows="9" readonly placeholder="Load a PDF, then generate the block."></textarea>
+                    <div class="d-flex gap-2">
+                        <button id="util-attachment-generate" class="btn btn-primary btn-sm" disabled>Generate Attachment Block</button>
+                        <button id="util-attachment-copy" class="btn btn-outline-secondary btn-sm" disabled>Copy</button>
+                    </div>
                 </section>
                 <section class="border rounded p-3 mb-3">
                     <h3 class="h6 fw-semibold mb-2">Bulk Upload &amp; Normalize PDFs</h3>

--- a/docassemble/ALDashboard/pdf_attachment_block.py
+++ b/docassemble/ALDashboard/pdf_attachment_block.py
@@ -1,0 +1,152 @@
+"""Generate docassemble PDF attachment mappings with AssemblyLine conventions."""
+
+import json
+import os
+import re
+from typing import Any, Iterable, List
+
+_PLURAL_PREFIXES = {
+    "user": "users",
+    "users": "users",
+    "other_party": "other_parties",
+    "other_parties": "other_parties",
+    "child": "children",
+    "children": "children",
+    "plaintiff": "plaintiffs",
+    "plaintiffs": "plaintiffs",
+    "defendant": "defendants",
+    "defendants": "defendants",
+    "petitioner": "petitioners",
+    "petitioners": "petitioners",
+    "respondent": "respondents",
+    "respondents": "respondents",
+    "spouse": "spouses",
+    "spouses": "spouses",
+    "parent": "parents",
+    "parents": "parents",
+    "guardian": "guardians",
+    "guardians": "guardians",
+    "attorney": "attorneys",
+    "attorneys": "attorneys",
+    "witness": "witnesses",
+    "witnesses": "witnesses",
+    "decedent": "decedents",
+    "decedents": "decedents",
+}
+
+_SUFFIXES = {
+    "_name": "",
+    "_name_full": "",
+    "_name_first": ".name.first",
+    "_name_middle": ".name.middle",
+    "_name_last": ".name.last",
+    "_name_suffix": ".name.suffix",
+    "_birthdate": ".birthdate.format()",
+    "_age": ".age_in_years()",
+    "_email": ".email",
+    "_phone": ".phone_number",
+    "_phone_number": ".phone_number",
+    "_mobile": ".mobile_number",
+    "_mobile_number": ".mobile_number",
+    "_signature": ".signature",
+    "_address_block": ".address.block()",
+    "_address_address": ".address.address",
+    "_address_street": ".address.address",
+    "_address_unit": ".address.unit",
+    "_address_street2": ".address.unit",
+    "_address_city": ".address.city",
+    "_address_state": ".address.state",
+    "_address_zip": ".address.zip",
+    "_address_county": ".address.county",
+    "_address_country": ".address.country",
+    "_address_on_one_line": ".address.on_one_line()",
+    "_mailing_address": ".mailing_address",
+    "_mailing_address_block": ".mailing_address.block()",
+    "_mailing_address_address": ".mailing_address.address",
+    "_mailing_address_street": ".mailing_address.address",
+    "_mailing_address_unit": ".mailing_address.unit",
+    "_mailing_address_street2": ".mailing_address.unit",
+    "_mailing_address_city": ".mailing_address.city",
+    "_mailing_address_state": ".mailing_address.state",
+    "_mailing_address_zip": ".mailing_address.zip",
+}
+
+
+def assembly_line_expression(field_name: Any) -> str:
+    """Map a PDF field name to an ALWeaver-style attachment expression."""
+    raw_name = str(field_name or "")
+    try:
+        from docassemble.ALWeaver.interview_generator import (
+            map_raw_to_final_display,
+        )
+
+        return str(map_raw_to_final_display(raw_name))
+    except ImportError:
+        # ALDashboard can be installed without ALWeaver. Keep the common
+        # AssemblyLine mappings available in that standalone deployment.
+        pass
+
+    normalized = re.sub(r"_{2,}\d+", "", raw_name)
+    normalized = re.sub(r"\s+", "_", normalized.strip())
+    normalized = re.sub(r"[^A-Za-z0-9_]", "", normalized)
+    normalized = re.sub(r"^[0-9]+", "", normalized)
+    if not normalized:
+        return "None"
+
+    for prefix in sorted(_PLURAL_PREFIXES, key=len, reverse=True):
+        match = re.fullmatch(rf"{re.escape(prefix)}(\d*)(.*)", normalized)
+        if not match:
+            continue
+        number_text, suffix = match.groups()
+        if suffix and suffix not in _SUFFIXES:
+            continue
+        index = max(int(number_text or "1") - 1, 0)
+        return f"{_PLURAL_PREFIXES[prefix]}[{index}]{_SUFFIXES.get(suffix, '')}"
+
+    return normalized
+
+
+def _double_quoted_yaml(value: Any) -> str:
+    """Return Weaver-style double-quoted YAML text."""
+    return json.dumps(str(value or ""), ensure_ascii=False)
+
+
+def _attachment_filename_parts(pdf_filename: Any) -> tuple[str, str, str]:
+    template_filename = os.path.basename(str(pdf_filename or "").strip())
+    if not template_filename:
+        template_filename = "template.pdf"
+    if not template_filename.lower().endswith(".pdf"):
+        template_filename += ".pdf"
+    output_filename = template_filename[:-4]
+    display_name = output_filename.replace("_", " ")
+    return display_name, output_filename, template_filename
+
+
+def generate_attachment_block(
+    field_names: Iterable[Any],
+    *,
+    pdf_filename: Any,
+) -> str:
+    """Return a complete Weaver-style PDF ``attachment`` YAML block."""
+    display_name, output_filename, template_filename = _attachment_filename_parts(
+        pdf_filename
+    )
+    lines: List[str] = [
+        "---",
+        "attachment:",
+        f"  name: {display_name}",
+        f"  filename: {output_filename}",
+        f"  pdf template file: {template_filename}",
+        "  fields:",
+    ]
+    seen: set[str] = set()
+    for raw_name in field_names:
+        field_name = str(raw_name or "")
+        if not field_name or field_name in seen:
+            continue
+        seen.add(field_name)
+        lines.append(
+            f"    - {_double_quoted_yaml(field_name)}: "
+            f"${{ {assembly_line_expression(field_name)} }}"
+        )
+    return "\n".join(lines)

--- a/docassemble/ALDashboard/pdf_export_utils.py
+++ b/docassemble/ALDashboard/pdf_export_utils.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from collections import Counter
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 
 def _parse_bool(value: Any, *, default: bool = False) -> bool:
@@ -30,15 +31,60 @@ def _parse_bool(value: Any, *, default: bool = False) -> bool:
     raise ValueError(f"Could not parse boolean value {value!r}.")
 
 
-def _dedupe_pdf_field_name(raw_name: Any, used_names: set[str]) -> str:
-    base_name = str(raw_name or "").strip() or "field"
-    candidate = base_name
-    suffix = 1
-    while candidate in used_names:
-        candidate = f"{base_name}__{suffix}"
-        suffix += 1
-    used_names.add(candidate)
-    return candidate
+def _pdf_field_name(raw_name: Any) -> str:
+    """Return the submitted field name without normalizing valid characters."""
+    if raw_name is None or raw_name == "":
+        return "field"
+    return str(raw_name)
+
+
+def deduplicate_pdf_field_names(
+    raw_names: Iterable[Any],
+) -> Tuple[List[str], List[Dict[str, Any]]]:
+    """Make only exactly repeated PDF field names unique.
+
+    This is the PDF labeler's deduplication contract:
+
+    * A duplicate is a complete, exact string match. Similar names are unrelated.
+    * Every unique submitted name stays byte-for-byte unchanged. In particular,
+      ``name__1`` and ``name__27`` are valid names, not suffixes to renumber.
+    * Keep the first occurrence of a repeated name. Rename only later occurrences
+      by appending ``__N`` for an available positive integer.
+    * Reserve all original names before generating names. Therefore
+      ``["name", "name", "name__1"]`` becomes
+      ``["name", "name__2", "name__1"]``; the unique ``name__1`` is untouched.
+
+    Empty or missing names use the existing ``field`` fallback because PDF field
+    objects require a usable name.
+    """
+    names = [_pdf_field_name(name) for name in raw_names]
+    original_names = set(names)
+    used_names: set[str] = set()
+    suffixes: Counter[str] = Counter()
+    deduplicated: List[str] = []
+    renames: List[Dict[str, Any]] = []
+
+    for index, original_name in enumerate(names):
+        if original_name not in used_names:
+            candidate = original_name
+        else:
+            suffix = suffixes[original_name] + 1
+            candidate = f"{original_name}__{suffix}"
+            while candidate in original_names or candidate in used_names:
+                suffix += 1
+                candidate = f"{original_name}__{suffix}"
+            suffixes[original_name] = suffix
+            renames.append(
+                {
+                    "index": index,
+                    "old_name": original_name,
+                    "new_name": candidate,
+                }
+            )
+        used_names.add(candidate)
+        deduplicated.append(candidate)
+
+    return deduplicated, renames
 
 
 def _looks_like_single_line_auto_size_field(field_name: Any) -> bool:
@@ -54,7 +100,7 @@ def _looks_like_single_line_auto_size_field(field_name: Any) -> bool:
 def deduplicate_fields_data(
     fields_data: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Return a copy of fields_data with duplicate field names suffixed.
+    """Return a copy of fields_data with only exact duplicate names suffixed.
 
     Applies the same ``__N`` suffix strategy used by
     :func:`build_pdf_export_fields_per_page` so that side-channel metadata
@@ -67,15 +113,34 @@ def deduplicate_fields_data(
     Returns:
         List[Dict[str, Any]]: New list with each field's ``name`` key uniquified.
     """
-    used_names: set[str] = set()
+    names, _renames = deduplicate_pdf_field_names(
+        field.get("name", "field") for field in fields_data
+    )
     result: List[Dict[str, Any]] = []
-    for field in fields_data:
-        raw_name = str(field.get("name", "field") or "").strip() or "field"
-        deduped_name = _dedupe_pdf_field_name(raw_name, used_names)
+    for field, deduped_name in zip(fields_data, names):
+        raw_name = _pdf_field_name(field.get("name", "field"))
         if deduped_name != raw_name:
             field = {**field, "name": deduped_name}
         result.append(field)
     return result
+
+
+def deduplicate_fields_data_with_renames(
+    fields_data: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Return deduplicated fields and an occurrence-level rename log."""
+    names, renames = deduplicate_pdf_field_names(
+        field.get("name", "field") for field in fields_data
+    )
+    result: List[Dict[str, Any]] = []
+    for field, deduplicated_name in zip(fields_data, names):
+        original_name = _pdf_field_name(field.get("name", "field"))
+        result.append(
+            {**field, "name": deduplicated_name}
+            if deduplicated_name != original_name
+            else field
+        )
+    return result, renames
 
 
 def _field_value(field: Any, key: str, default: Any = None) -> Any:
@@ -133,20 +198,28 @@ def build_normalized_pdf_field_definitions(
 ) -> List[Dict[str, Any]]:
     """Convert detected FormFyxer fields into normalized export definitions."""
     normalized_fields: List[Dict[str, Any]] = []
-    used_names: set[str] = set()
+    detected_pages = [
+        list(page_fields or []) for page_fields in detected_fields_per_page
+    ]
+    all_raw_names = [
+        _pdf_field_name(_field_value(field, "name", "field"))
+        for page_fields in detected_pages
+        for field in page_fields
+    ]
+    deduplicated_names, _renames = deduplicate_pdf_field_names(all_raw_names)
+    name_index = 0
 
-    for page_idx, page_fields in enumerate(detected_fields_per_page):
+    for page_idx, page_fields in enumerate(detected_pages):
         if page_idx < 0 or page_idx >= page_count:
             continue
         for field in page_fields or []:
-            raw_field_name = (
-                str(_field_value(field, "name", "field") or "").strip() or "field"
-            )
+            raw_field_name = _pdf_field_name(_field_value(field, "name", "field"))
             field_name = (
-                _dedupe_pdf_field_name(raw_field_name, used_names)
+                deduplicated_names[name_index]
                 if deduplicate_field_names
                 else raw_field_name
             )
+            name_index += 1
             field_type_str = _normalize_detected_field_type(
                 _field_value(field, "type", "text")
             )
@@ -213,9 +286,12 @@ def build_pdf_export_fields_per_page(
         List[List[Any]]: Form field objects grouped by page index.
     """
     fields_per_page: List[List[Any]] = [[] for _ in range(page_count)]
-    used_names: set[str] = set()
+    fields_list = list(fields_data)
+    deduplicated_names, _renames = deduplicate_pdf_field_names(
+        field_data.get("name", "field") for field_data in fields_list
+    )
 
-    for field_data in fields_data:
+    for field_index, field_data in enumerate(fields_list):
         page_idx = int(field_data.get("pageIndex", 0))
         if page_idx < 0 or page_idx >= page_count:
             continue
@@ -337,10 +413,10 @@ def build_pdf_export_fields_per_page(
             )
             field_configs["selected"] = False
 
-        raw_field_name = str(field_data.get("name", "field") or "").strip() or "field"
+        raw_field_name = _pdf_field_name(field_data.get("name", "field"))
         form_field = form_field_cls(
             field_name=(
-                _dedupe_pdf_field_name(raw_field_name, used_names)
+                deduplicated_names[field_index]
                 if deduplicate_field_names
                 else raw_field_name
             ),

--- a/docassemble/ALDashboard/test/test_labeler_js_extraction.py
+++ b/docassemble/ALDashboard/test/test_labeler_js_extraction.py
@@ -189,6 +189,15 @@ class TestPdfLabelerJsExtraction(unittest.TestCase):
     def test_js_references_JSZip_global(self):
         self.assertIn("JSZip", self.js)
 
+    def test_pdf_deduplication_contract_is_wired_into_ui(self):
+        self.assertIn("reservedOriginalNames", self.js)
+        self.assertIn("showFieldRenameSummary", self.js)
+        self.assertIn("field-rename-summary-modal", self.html)
+
+    def test_pdf_attachment_block_utility_is_wired_into_ui(self):
+        self.assertIn("/pdf-labeler/api/attachment-block", self.js)
+        self.assertIn("util-attachment-generate", self.html)
+
 
 class TestLabelerTemplateRendering(unittest.TestCase):
     """Verify that the template-reading helpers still work after refactoring."""

--- a/docassemble/ALDashboard/test/test_pdf_attachment_block.py
+++ b/docassemble/ALDashboard/test/test_pdf_attachment_block.py
@@ -1,0 +1,80 @@
+# do not pre-load
+import unittest
+
+from ruamel.yaml import YAML
+
+from docassemble.ALDashboard.pdf_attachment_block import (
+    assembly_line_expression,
+    generate_attachment_block,
+)
+
+
+class TestPDFAttachmentBlock(unittest.TestCase):
+    def test_repeated_appearance_suffix_is_only_removed_from_expression(self):
+        self.assertEqual(assembly_line_expression("users1_name__1"), "users[0]")
+        self.assertEqual(
+            generate_attachment_block(
+                ["users1_name__1"],
+                pdf_filename="motion_to_continue.pdf",
+            ),
+            "---\n"
+            "attachment:\n"
+            "  name: motion to continue\n"
+            "  filename: motion_to_continue\n"
+            "  pdf template file: motion_to_continue.pdf\n"
+            "  fields:\n"
+            '    - "users1_name__1": ${ users[0] }',
+        )
+
+    def test_maps_common_assembly_line_person_fields(self):
+        self.assertEqual(
+            assembly_line_expression("other_parties2_address_city__27"),
+            "other_parties[1].address.city",
+        )
+        self.assertEqual(
+            assembly_line_expression("children3_name_first"),
+            "children[2].name.first",
+        )
+
+    def test_preserves_order_and_skips_exact_duplicate_keys(self):
+        self.assertEqual(
+            generate_attachment_block(
+                ["docket_number", "docket_number", 'field "quoted"'],
+                pdf_filename="/tmp/my_form.pdf",
+            ),
+            "---\n"
+            "attachment:\n"
+            "  name: my form\n"
+            "  filename: my_form\n"
+            "  pdf template file: my_form.pdf\n"
+            "  fields:\n"
+            '    - "docket_number": ${ docket_number }\n'
+            '    - "field \\"quoted\\"": ${ field_quoted }',
+        )
+
+    def test_adds_pdf_extension_when_missing(self):
+        block = generate_attachment_block([], pdf_filename="court_form")
+        self.assertIn("pdf template file: court_form.pdf", block)
+        self.assertIn("filename: court_form", block)
+
+    def test_generated_attachment_is_valid_yaml_with_list_fields(self):
+        block = generate_attachment_block(
+            ["users1_name__1", "docket_number"],
+            pdf_filename="court_form.pdf",
+        )
+        parsed = YAML(typ="safe").load(block)
+
+        self.assertEqual(parsed["attachment"]["name"], "court form")
+        self.assertEqual(parsed["attachment"]["filename"], "court_form")
+        self.assertEqual(parsed["attachment"]["pdf template file"], "court_form.pdf")
+        self.assertEqual(
+            parsed["attachment"]["fields"],
+            [
+                {"users1_name__1": "${ users[0] }"},
+                {"docket_number": "${ docket_number }"},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALDashboard/test/test_pdf_export_utils.py
+++ b/docassemble/ALDashboard/test/test_pdf_export_utils.py
@@ -4,6 +4,8 @@ import unittest
 from docassemble.ALDashboard.pdf_export_utils import (
     build_normalized_pdf_field_definitions,
     build_pdf_export_fields_per_page,
+    deduplicate_fields_data,
+    deduplicate_pdf_field_names,
 )
 
 
@@ -28,6 +30,40 @@ class FakeFormField:
 
 
 class TestPDFExportUtils(unittest.TestCase):
+    def test_deduplication_preserves_unique_double_underscore_suffixes(self):
+        names, renames = deduplicate_pdf_field_names(
+            ["users1_name", "users1_name", "users1_name__1", "users1_name__27"]
+        )
+
+        self.assertEqual(
+            names,
+            ["users1_name", "users1_name__2", "users1_name__1", "users1_name__27"],
+        )
+        self.assertEqual(
+            renames,
+            [
+                {
+                    "index": 1,
+                    "old_name": "users1_name",
+                    "new_name": "users1_name__2",
+                }
+            ],
+        )
+
+    def test_deduplication_changes_only_later_exact_matches(self):
+        fields = [
+            {"name": "name"},
+            {"name": "name_1"},
+            {"name": "name__1"},
+            {"name": "name"},
+            {"name": "name__1"},
+        ]
+
+        self.assertEqual(
+            [field["name"] for field in deduplicate_fields_data(fields)],
+            ["name", "name_1", "name__1", "name__2", "name__1__1"],
+        )
+
     def test_renamed_text_field_export_keeps_name_and_auto_size(self):
         fields_per_page = build_pdf_export_fields_per_page(
             [


### PR DESCRIPTION
* Fix behavior for correctness  - only rename fields when there is an exact duplicate, enforce sequential names, do not remove `__` and replace with `_` in any circumstances.
* noisy renames
* attachment block generator to help with importing renamed fields into an existing YAML (and also gives a single place to preview all names without scrolling)