### PR TITLE
Fix issue where field can be missing /P annotation

### DIFF
--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -362,6 +362,10 @@ def _apply_pdf_field_visual_defaults(
                     if named_parent and hasattr(named_parent, "T"):
                         field_name = str(named_parent.T).strip()
 
+                    # Set the page reference explicitly so fields render on the correct page
+                    # rather than falling back to the first page.
+                    annot["/P"] = page.obj
+
                     _set_no_border(annot)
                     if named_parent and named_parent is not annot:
                         _set_no_border(named_parent)

--- a/test_pikepdf_copy.py
+++ b/test_pikepdf_copy.py
@@ -1,0 +1,13 @@
+import pikepdf
+from pikepdf import Pdf, Dictionary
+
+p1 = Pdf.new()
+p1.add_blank_page(page_size=(100, 100))
+p2 = Pdf.new()
+p2.add_blank_page(page_size=(100, 100))
+
+obj1 = Dictionary({"/A": 1})
+ref1 = p1.make_indirect(obj1)
+ref2 = p2.copy_foreign(ref1)
+ref3 = p2.copy_foreign(ref1)
+print("Are they the same?", ref2.objgen == ref3.objgen)


### PR DESCRIPTION
causing a bug when rendering signature field image in Docassemble

This is also fixed upstream in FormFyxer https://github.com/SuffolkLITLab/FormFyxer/pull/169