### PR TITLE
Add filled, flattened PDF preview as option to PDF editor endpoint to help debug and test behavior of PDF editor

### DIFF
--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -69,6 +69,7 @@ from .api_dashboard_utils import (
 )
 from .pdf_export_utils import (
     build_normalized_pdf_field_definitions,
+    build_pdf_preview_fill_data,
     build_pdf_export_fields_per_page,
     deduplicate_fields_data_with_renames,
 )
@@ -3469,6 +3470,10 @@ def pdf_labeler_test_fill() -> Response:
                 if str(field.get("type", "")).lower() == "checkbox"
                 and str(field.get("checkboxExportValue", "")).strip()
             }
+            explicit_background_fields = _collect_fields_with_explicit_background(
+                fields_data
+            )
+            checkbox_border_widths = _collect_checkbox_border_widths(fields_data)
 
             fields_per_page = build_pdf_export_fields_per_page(
                 fields_data,
@@ -3482,33 +3487,46 @@ def pdf_labeler_test_fill() -> Response:
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_out:
                 output_path = tmp_out.name
 
+            signature_field_names = [
+                str(field.get("name", "")).strip()
+                for field in fields_data
+                if str(field.get("type", "")).lower() == "signature"
+                and str(field.get("name", "")).strip()
+            ]
+
             set_fields(input_path, output_path, fields_per_page, overwrite=True)
             _apply_checkbox_export_values(output_path, checkbox_export_values)
             from .pdf_repair import normalize_signature_fields
-            normalize_signature_fields(output_path)
-            _apply_pdf_field_visual_defaults(output_path)
+            normalize_signature_fields(output_path, output_path, signature_field_names)
+            _apply_pdf_field_visual_defaults(
+                output_path,
+                explicit_background_fields=explicit_background_fields,
+            )
+            from .pdf_repair import restore_checkbox_appearances
 
-            data_strings = []
-            images = []
-            sig_img_path = os.path.join(os.path.dirname(__file__), "data", "static", "placeholder_signature.png")
-            
+            restore_checkbox_appearances(
+                output_path,
+                output_path,
+                checkbox_border_widths=checkbox_border_widths,
+            )
+
             the_fields = read_fields(output_path)
-            for field, default, pageno, rect, field_type, export_value in the_fields:
-                field_type_str = str(field_type)
-                if field_type_str == "/Tx":
-                    data_strings.append((field, field))
-                elif field_type_str in ("/Btn", "/'Btn'"):
-                    data_strings.append((field, export_value or "Yes"))
-                elif field_type_str == "/Ch":
-                    data_strings.append((field, field))
-                elif field_type_str in ("/Sig", "/'Sig'"):
-                    images.append((field, {'fullpath': sig_img_path}))
+            signature_image_path = os.path.join(
+                os.path.dirname(__file__),
+                "data",
+                "static",
+                "placeholder_signature.png",
+            )
+            data_strings, images = build_pdf_preview_fill_data(
+                the_fields,
+                signature_image_path=signature_image_path,
+            )
                     
             filled_path = fill_template(
                 output_path,
                 data_strings=data_strings,
                 images=images,
-                editable=True
+                editable=False,
             )
 
             with open(filled_path, "rb") as f:

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -3425,6 +3425,117 @@ def pdf_labeler_apply_fields() -> Response:
         )
 
 
+@app.route("/pdf-labeler/api/test-fill", methods=["POST"])
+@app.route(f"{LABELER_BASE_PATH}/pdf-labeler/api/test-fill", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def pdf_labeler_test_fill() -> Response:
+    request_id = str(uuid.uuid4())
+    try:
+        import formfyxer  # type: ignore[import-not-found]
+        from formfyxer.pdf_wrangling import FormField, FieldType, set_fields
+        from reportlab.lib.colors import HexColor
+        from docassemble.base.pdftk import fill_template, read_fields
+        import pikepdf
+
+        filename, content, post_data = _read_pdf_labeler_file_request()
+        fields_raw = post_data.get("fields")
+        if isinstance(fields_raw, str):
+            fields_data = json.loads(fields_raw)
+        elif isinstance(fields_raw, list):
+            fields_data = fields_raw
+        else:
+            raise DashboardAPIValidationError("fields is required and must be a list.")
+            
+        deduplicate_field_names = parse_bool(
+            post_data.get("deduplicate_field_names"), default=False
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_in:
+            tmp_in.write(content)
+            input_path = tmp_in.name
+
+        output_path = None
+        try:
+            with pikepdf.open(input_path) as pdf:
+                page_count = len(pdf.pages)
+
+            if deduplicate_field_names:
+                fields_data, _ = deduplicate_fields_data_with_renames(fields_data)
+
+            checkbox_export_values = {
+                str(field.get("name", "")): str(field.get("checkboxExportValue", "")).strip()
+                for field in fields_data
+                if str(field.get("type", "")).lower() == "checkbox"
+                and str(field.get("checkboxExportValue", "")).strip()
+            }
+
+            fields_per_page = build_pdf_export_fields_per_page(
+                fields_data,
+                page_count=page_count,
+                form_field_cls=FormField,
+                field_type_enum=FieldType,
+                color_parser=HexColor,
+                deduplicate_field_names=False,
+            )
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_out:
+                output_path = tmp_out.name
+
+            set_fields(input_path, output_path, fields_per_page, overwrite=True)
+            _apply_checkbox_export_values(output_path, checkbox_export_values)
+            from .pdf_repair import normalize_signature_fields
+            normalize_signature_fields(output_path)
+            _apply_pdf_field_visual_defaults(output_path)
+
+            data_strings = []
+            images = []
+            sig_img_path = os.path.join(os.path.dirname(__file__), "data", "static", "placeholder_signature.png")
+            
+            the_fields = read_fields(output_path)
+            for field, default, pageno, rect, field_type, export_value in the_fields:
+                field_type_str = str(field_type)
+                if field_type_str == "/Tx":
+                    data_strings.append((field, field))
+                elif field_type_str in ("/Btn", "/'Btn'"):
+                    data_strings.append((field, export_value or "Yes"))
+                elif field_type_str == "/Ch":
+                    data_strings.append((field, field))
+                elif field_type_str in ("/Sig", "/'Sig'"):
+                    images.append((field, {'fullpath': sig_img_path}))
+                    
+            filled_path = fill_template(
+                output_path,
+                data_strings=data_strings,
+                images=images,
+                editable=True
+            )
+
+            with open(filled_path, "rb") as f:
+                output_bytes = f.read()
+
+            return jsonify({
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "filename": filename.replace(".pdf", "-test-filled.pdf"),
+                    "pdf_base64": base64.b64encode(output_bytes).decode("ascii"),
+                }
+            })
+        finally:
+            if os.path.exists(input_path):
+                os.remove(input_path)
+            if output_path and os.path.exists(output_path):
+                os.remove(output_path)
+            if 'filled_path' in locals() and os.path.exists(filled_path):
+                os.remove(filled_path)
+                
+    except DashboardAPIValidationError as exc:
+        return jsonify_with_status({"success": False, "request_id": request_id, "error": {"type": "validation_error", "message": exc.message}}, exc.status_code)
+    except Exception as exc:
+        return jsonify_with_status({"success": False, "request_id": request_id, "error": {"type": "server_error", "message": str(exc)}}, 500)
+
+
 @app.route("/pdf-labeler/api/attachment-block", methods=["POST"])
 @app.route(f"{LABELER_BASE_PATH}/pdf-labeler/api/attachment-block", methods=["POST"])
 @csrf.exempt

--- a/docassemble/ALDashboard/data/static/pdf_labeler.js
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.js
@@ -992,6 +992,7 @@
             document.getElementById('preview-icon-open').classList.remove('hidden');
             document.getElementById('preview-icon-closed').classList.add('hidden');
         }
+        updateDuplicateFieldWarning();
         updateZoomControls();
     }
 

--- a/docassemble/ALDashboard/data/static/pdf_labeler.js
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.js
@@ -276,6 +276,7 @@
     const exportDeduplicateFieldNamesInput = document.getElementById('export-deduplicate-field-names');
     const duplicateFieldWarning = document.getElementById('duplicate-field-warning');
     const exportBtn = document.getElementById('export-btn');
+    const testFillingBtn = document.getElementById('test-filling-btn');
     const normalizePassBtn = document.getElementById('normalize-pass-btn');
     const errorToast = document.getElementById('error-toast');
     const errorToastMessage = document.getElementById('error-toast-message');
@@ -970,8 +971,9 @@
         fieldsEmpty.classList.toggle('hidden', totalCount !== 0);
         fieldsList.classList.toggle('hidden', totalCount === 0);
         floatingToolPicker.classList.toggle('hidden', !state.pdfBytes);
+        autoDetectBtn.disabled = !state.pdfBytes;
         exportBtn.disabled = !state.pdfBytes || totalCount === 0;
-        updateDuplicateFieldWarning();
+        if (testFillingBtn) testFillingBtn.disabled = !state.pdfBytes || totalCount === 0;
         savePlaygroundBtn.disabled = !state.pdfBytes || totalCount === 0;
         normalizePassBtn.disabled = !state.pdfBytes || totalCount === 0;
         repairBtn.disabled = !state.pdfBytes;
@@ -3124,6 +3126,10 @@
                 '<div class="field-card-actions">' +
                     '<button type="button" class="btn btn-outline-secondary btn-sm" data-action="duplicate-field" data-field-id="' + escapeHtml(field.id) + '">Duplicate</button>' +
                     '<button type="button" class="btn btn-outline-danger btn-sm" data-action="delete-field" data-field-id="' + escapeHtml(field.id) + '">Delete</button>' +
+                    '<select class="form-select form-select-sm d-inline-block w-auto ms-1" data-action="move-field-page" data-field-id="' + escapeHtml(field.id) + '" aria-label="Move to page">' +
+                        '<option value="">Move to page...</option>' +
+                        Array.apply(null, Array(state.pageCount)).map(function (_, i) { return '<option value="' + i + '"' + (field.pageIndex === i ? ' disabled' : '') + '>Page ' + (i + 1) + '</option>'; }).join('') +
+                    '</select>' +
                 '</div>' +
             '</div>';
     }
@@ -5655,6 +5661,14 @@
             markDirtyAndRender();
             return;
         }
+        if (target.dataset.action === 'move-field-page') {
+            const newPage = parseInt(target.value, 10);
+            if (!isNaN(newPage) && newPage >= 0 && newPage < state.pageCount) {
+                field.pageIndex = newPage;
+                markDirtyAndRender();
+            }
+            return;
+        }
         if (target.dataset.action === 'field-checkbox-border') {
             field.checkboxBorder = !!target.checked;
             field.checkboxBorderWidth = field.checkboxBorderWidth || 'thin';
@@ -5706,6 +5720,57 @@
         sidebarRelabelBtn.addEventListener('click', relabelFields);
     }
     exportBtn.addEventListener('click', exportPdf);
+
+    if (testFillingBtn) {
+        testFillingBtn.addEventListener('click', async function () {
+            if (!state.pdfBytes) return;
+            const originalText = testFillingBtn.textContent;
+            testFillingBtn.textContent = 'Generating...';
+            testFillingBtn.disabled = true;
+            try {
+                const formData = new FormData();
+                formData.append('file', getPdfFileForRequests());
+                
+                const saveNameMap = buildExportNameMap({
+                    deduplicate: exportDeduplicateFieldNamesInput ? exportDeduplicateFieldNamesInput.checked : true
+                });
+                formData.append('fields', JSON.stringify(convertFieldsToAbsoluteCoordinates(saveNameMap)));
+                if (exportDeduplicateFieldNamesInput && exportDeduplicateFieldNamesInput.checked) {
+                    formData.append('deduplicate_field_names', 'true');
+                }
+
+                const response = await fetch(apiUrl('/pdf-labeler/api/test-fill'), {
+                    method: 'POST',
+                    headers: { 'Accept': 'application/json' },
+                    body: formData
+                });
+                const data = await parseApiResponse(response);
+                if (!data.success || !data.data || !data.data.pdf_base64) {
+                    throw new Error((data.error && data.error.message) || 'Test fill failed.');
+                }
+                const b64 = data.data.pdf_base64;
+                const binary = window.atob(b64);
+                const bytes = new Uint8Array(binary.length);
+                for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+                const blob = new Blob([bytes], { type: 'application/pdf' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = data.data.filename || 'test_fill.pdf';
+                document.body.appendChild(a);
+                a.click();
+                setTimeout(function () {
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+                }, 100);
+            } catch (err) {
+                showError('Error testing PDF fill: ' + err.message);
+            } finally {
+                testFillingBtn.textContent = originalText;
+                testFillingBtn.disabled = false;
+            }
+        });
+    }
 
     // Playground event listeners
     openPlaygroundBtn.addEventListener('click', openPlaygroundModal);

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -73,6 +73,7 @@
                         <span class="form-check-label">Deduplicate repeated names</span>
                     </label>
                     <button id="export-btn" class="btn btn-primary btn-sm" disabled>Export PDF</button>
+                    <button id="test-filling-btn" class="btn btn-outline-info btn-sm" disabled title="Generate a filled PDF preview">Test filling</button>
                     <button id="save-playground-btn" class="btn btn-outline-success btn-sm hidden" disabled title="Save this PDF back to the Playground templates folder">
                         <svg class="icon-16 me-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"></path></svg>
                         Save to Playground

--- a/docassemble/ALDashboard/pdf_export_utils.py
+++ b/docassemble/ALDashboard/pdf_export_utils.py
@@ -87,6 +87,41 @@ def deduplicate_pdf_field_names(
     return deduplicated, renames
 
 
+def build_pdf_preview_fill_data(
+    pdf_field_tuples: Iterable[Tuple[Any, ...]],
+    *,
+    signature_image_path: Optional[str] = None,
+) -> Tuple[List[Tuple[str, str]], List[Tuple[str, Dict[str, str]]]]:
+    """Build the placeholder values used by ALWeaver's flattened PDF previews.
+
+    This mirrors ``ALWeaver.interview_generator.reflect_fields`` while returning
+    the ``data_strings`` and ``images`` collections accepted by docassemble's
+    ``fill_template`` helper.
+    """
+    data_strings: List[Tuple[str, str]] = []
+    images: List[Tuple[str, Dict[str, str]]] = []
+    mapped_field_names: set[str] = set()
+
+    for field in pdf_field_tuples:
+        field_name = str(field[0])
+        field_type = str(field[4])
+        if field_type in {"/Btn", "/'Btn'"}:
+            export_value = str(field[5] if len(field) >= 6 and field[5] else "")
+            if export_value.lower() in {"yes", "on", "true", ""}:
+                data_strings.append((field_name, "Yes"))
+            elif field_name not in mapped_field_names:
+                data_strings.append((field_name, export_value))
+            mapped_field_names.add(field_name)
+        elif field_type in {"/Sig", "/'Sig'"} and signature_image_path:
+            images.append((field_name, {"fullpath": signature_image_path}))
+            mapped_field_names.add(field_name)
+        else:
+            data_strings.append((field_name, field_name))
+            mapped_field_names.add(field_name)
+
+    return data_strings, images
+
+
 def _looks_like_single_line_auto_size_field(field_name: Any) -> bool:
     return bool(
         re.search(

--- a/docassemble/ALDashboard/test/test_labeler_js_extraction.py
+++ b/docassemble/ALDashboard/test/test_labeler_js_extraction.py
@@ -194,6 +194,15 @@ class TestPdfLabelerJsExtraction(unittest.TestCase):
         self.assertIn("showFieldRenameSummary", self.js)
         self.assertIn("field-rename-summary-modal", self.html)
 
+    def test_field_count_refreshes_duplicate_warning(self):
+        match = re.search(
+            r"function updateFieldCount\(\) \{(?P<body>.*?)\n    \}",
+            self.js,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        self.assertIn("updateDuplicateFieldWarning();", match.group("body"))
+
     def test_pdf_attachment_block_utility_is_wired_into_ui(self):
         self.assertIn("/pdf-labeler/api/attachment-block", self.js)
         self.assertIn("util-attachment-generate", self.html)

--- a/docassemble/ALDashboard/test/test_pdf_export_utils.py
+++ b/docassemble/ALDashboard/test/test_pdf_export_utils.py
@@ -3,6 +3,7 @@ import unittest
 
 from docassemble.ALDashboard.pdf_export_utils import (
     build_normalized_pdf_field_definitions,
+    build_pdf_preview_fill_data,
     build_pdf_export_fields_per_page,
     deduplicate_fields_data,
     deduplicate_pdf_field_names,
@@ -30,6 +31,38 @@ class FakeFormField:
 
 
 class TestPDFExportUtils(unittest.TestCase):
+    def test_preview_fill_data_matches_alweaver_reflect_fields(self):
+        data_strings, images = build_pdf_preview_fill_data(
+            [
+                ("name", "", 1, (), "/Tx", None),
+                ("agrees", "", 1, (), "/Btn", "Yes"),
+                ("choice", "", 1, (), "/Btn", "First"),
+                ("choice", "", 1, (), "/Btn", "Second"),
+                ("signature", "", 1, (), "/Sig", None),
+                ("selection", "", 1, (), "/Ch", None),
+            ],
+            signature_image_path="/tmp/placeholder_signature.png",
+        )
+
+        self.assertEqual(
+            data_strings,
+            [
+                ("name", "name"),
+                ("agrees", "Yes"),
+                ("choice", "First"),
+                ("selection", "selection"),
+            ],
+        )
+        self.assertEqual(
+            images,
+            [
+                (
+                    "signature",
+                    {"fullpath": "/tmp/placeholder_signature.png"},
+                )
+            ],
+        )
+
     def test_deduplication_preserves_unique_double_underscore_suffixes(self):
         names, renames = deduplicate_pdf_field_names(
             ["users1_name", "users1_name", "users1_name__1", "users1_name__27"]

--- a/docassemble/ALDashboard/test/test_pdf_test_fill_appearances.py
+++ b/docassemble/ALDashboard/test/test_pdf_test_fill_appearances.py
@@ -1,0 +1,81 @@
+# do not pre-load
+"""Regression checks for the PDF labeler's test-fill appearance pipeline."""
+
+import ast
+import importlib.resources
+import unittest
+
+
+def _test_fill_function() -> ast.FunctionDef:
+    source = (
+        importlib.resources.files("docassemble.ALDashboard") / "api_labelers.py"
+    ).read_text(encoding="utf-8")
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "pdf_labeler_test_fill":
+            return node
+    raise AssertionError("pdf_labeler_test_fill was not found")
+
+
+def _calls(function: ast.FunctionDef) -> list[ast.Call]:
+    return [node for node in ast.walk(function) if isinstance(node, ast.Call)]
+
+
+def _call_name(call: ast.Call) -> str:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return ""
+
+
+class TestPdfTestFillAppearances(unittest.TestCase):
+    def test_collects_and_forwards_field_appearance_settings(self):
+        function = _test_fill_function()
+        calls = _calls(function)
+        call_names = [_call_name(call) for call in calls]
+
+        self.assertIn("_collect_fields_with_explicit_background", call_names)
+        self.assertIn("_collect_checkbox_border_widths", call_names)
+        self.assertIn("restore_checkbox_appearances", call_names)
+
+        visual_defaults = next(
+            call for call in calls if _call_name(call) == "_apply_pdf_field_visual_defaults"
+        )
+        self.assertIn(
+            "explicit_background_fields",
+            {keyword.arg for keyword in visual_defaults.keywords},
+        )
+
+        restore = next(
+            call for call in calls if _call_name(call) == "restore_checkbox_appearances"
+        )
+        self.assertIn(
+            "checkbox_border_widths",
+            {keyword.arg for keyword in restore.keywords},
+        )
+
+    def test_restores_checkbox_appearances_before_filling(self):
+        function = _test_fill_function()
+        calls_by_name = {_call_name(call): call for call in _calls(function)}
+        self.assertLess(
+            calls_by_name["restore_checkbox_appearances"].lineno,
+            calls_by_name["fill_template"].lineno,
+        )
+
+    def test_uses_docassemble_flattened_attachment_behavior(self):
+        function = _test_fill_function()
+        fill_call = next(
+            call for call in _calls(function) if _call_name(call) == "fill_template"
+        )
+        editable = next(
+            keyword.value
+            for keyword in fill_call.keywords
+            if keyword.arg == "editable"
+        )
+        self.assertIsInstance(editable, ast.Constant)
+        self.assertIs(editable.value, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This, as much as possible, re-uses the pathways Docassemble uses to render a flattened preview image of the PDF. This helps see what the end user would see for your template if the document is assembled by Docassemble.