### PR TITLE
PDF editor consistency fixes

### DIFF
--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -44,7 +44,7 @@ def _format_pdf_fields_for_ui_payload(
                     "y": field.y,
                     "width": field.configs.get("width", 100),
                     "height": field.configs.get("height", 20),
-                    "fontSize": 12 if auto_size else (raw_font_size or 12),
+                    "fontSize": 10 if auto_size else (raw_font_size or 10),
                     "autoSize": auto_size,
                 }
             )

--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from urllib.parse import quote, urlsplit
 from typing import Any, Dict, List, Optional, Set
 
-from flask import Response, jsonify, request
+from flask import Response, jsonify, request, url_for
 
 try:
     from flask_cors import cross_origin
@@ -341,7 +341,7 @@ def _apply_pdf_field_visual_defaults(
         if str(obj.get("/FT", "")) not in {"/Tx", "/Ch"}:
             return
         if "/DA" not in obj:
-            obj["/DA"] = pikepdf.String("/Helv 12 Tf 0 g")
+            obj["/DA"] = pikepdf.String("/Helv 10 Tf 0 g")
 
     def _is_button_widget(named_parent: Optional[Any]) -> bool:
         if named_parent is None or not hasattr(named_parent, "get"):
@@ -498,6 +498,80 @@ def _labeler_session_identity() -> Dict[str, Any]:
     except Exception:  # nosec B110
         pass
     return {"is_authenticated": False, "email": None, "user_id": None}
+
+
+def _labeler_account_menu_items(logout_url: str) -> List[Dict[str, str]]:
+    """Return docassemble's standard account links for the current user."""
+    if not _labeler_session_identity().get("is_authenticated"):
+        return []
+
+    items: List[Dict[str, str]] = []
+
+    def add_item(
+        label: str, endpoint: Optional[str] = None, href: Optional[str] = None
+    ) -> None:
+        try:
+            target = href or (url_for(endpoint) if endpoint else "")
+        except Exception:  # nosec B110
+            return
+        if target:
+            items.append({"label": str(label), "url": str(target)})
+
+    def has_roles(*roles: str) -> bool:
+        try:
+            return bool(current_user.has_roles(list(roles)))
+        except Exception:
+            try:
+                return bool(current_user.has_role(*roles))
+            except Exception:
+                return False
+
+    if has_roles("admin", "advocate") and app.config.get("ENABLE_MONITOR"):
+        add_item("Monitor", "monitor")
+    if has_roles("admin", "developer", "trainer") and app.config.get("ENABLE_TRAINING"):
+        add_item("Train", "train")
+    if has_roles("admin", "developer"):
+        if app.config.get("ALLOW_UPDATES") and (
+            app.config.get("DEVELOPER_CAN_INSTALL") or has_roles("admin")
+        ):
+            add_item("Package Management", "update_package")
+        if app.config.get("ALLOW_LOG_VIEWING"):
+            add_item("Logs", "logs")
+        if app.config.get("ENABLE_PLAYGROUND"):
+            add_item("Playground", "playground_page")
+        add_item("Utilities", "utilities")
+    try:
+        can_access_users = bool(current_user.can_do("access_user_info"))
+    except Exception:
+        can_access_users = False
+    if has_roles("admin", "advocate") or can_access_users:
+        add_item("User List", "user_list")
+    if has_roles("admin") and app.config.get("ALLOW_CONFIGURATION_EDITING"):
+        add_item("Configuration", "config_page")
+    if app.config.get("SHOW_DISPATCH"):
+        add_item("Available Interviews", "interview_start")
+
+    for item in app.config.get("ADMIN_INTERVIEWS", []):
+        try:
+            if item.can_use():
+                add_item(
+                    item.get_title(docassemble.base.functions.get_language()),
+                    href=item.get_url(),
+                )
+        except Exception:  # nosec B112
+            continue
+
+    if app.config.get("SHOW_MY_INTERVIEWS") or has_roles("admin"):
+        add_item("My Interviews", "interview_list")
+    if app.config.get("SHOW_PROFILE") or has_roles("admin", "developer"):
+        add_item("Profile", "user_profile_page")
+    else:
+        social_id = str(getattr(current_user, "social_id", "") or "")
+        if social_id.startswith("local") and app.config.get("ALLOW_CHANGING_PASSWORD"):
+            add_item("Change Password", "user.change_password")
+
+    add_item("Sign Out", href=logout_url)
+    return items
 
 
 def _labeler_ai_auth_check() -> bool:
@@ -1908,6 +1982,7 @@ def labeler_auth_status() -> Response:
                 "login_url": login_url,
                 "logout_url": logout_url,
                 "ai_enabled": _labeler_ai_auth_check(),
+                "menu_items": _labeler_account_menu_items(logout_url),
             },
         }
     )

--- a/docassemble/ALDashboard/data/static/pdf_labeler.js
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.js
@@ -159,7 +159,8 @@
             email: '',
             loginUrl: '/user/sign-in',
             logoutUrl: '/user/sign-out',
-            aiEnabled: false
+            aiEnabled: false,
+            menuItems: []
         },
         playgroundSource: {
             project: '',
@@ -230,6 +231,10 @@
         const defaults = _loadSessionDefaults();
         defaults[key] = value;
         _saveSessionDefaults(defaults);
+    }
+
+    function looksLikeSingleLineAutoSizeField(fieldName) {
+        return /(name|address|street|city|state|zip|postal|phone|phone_number|email|cell)/i.test(String(fieldName || ''));
     }
 
     let draftState = null;
@@ -1749,10 +1754,15 @@
         if (!authControls) return;
         if (state.auth.isAuthenticated) {
             const emailText = state.auth.email || 'Account';
+            const menuItems = Array.isArray(state.auth.menuItems) && state.auth.menuItems.length
+                ? state.auth.menuItems
+                : [{ label: 'Sign Out', url: state.auth.logoutUrl || '/user/sign-out' }];
             authControls.innerHTML =
                 '<button id="auth-menu-btn" class="btn btn-outline-light btn-sm dropdown-toggle" type="button" aria-expanded="false">' + escapeHtml(emailText) + '</button>' +
                 '<div id="auth-menu" class="dropdown-menu dropdown-menu-end header-auth-menu">' +
-                    '<a class="dropdown-item" href="' + escapeHtml(state.auth.logoutUrl || '/user/sign-out') + '">Log out</a>' +
+                    menuItems.map(function (item) {
+                        return '<a class="dropdown-item" href="' + escapeHtml(item.url || '#') + '">' + escapeHtml(item.label || '') + '</a>';
+                    }).join('') +
                 '</div>';
             const menuBtn = document.getElementById('auth-menu-btn');
             const menu = document.getElementById('auth-menu');
@@ -1813,6 +1823,7 @@
                 state.auth.loginUrl = data.data.login_url || '/user/sign-in';
                 state.auth.logoutUrl = data.data.logout_url || '/user/sign-out';
                 state.auth.aiEnabled = !!data.data.ai_enabled;
+                state.auth.menuItems = Array.isArray(data.data.menu_items) ? data.data.menu_items : [];
             }
         } catch (_error) {
             state.auth = {
@@ -1820,7 +1831,8 @@
                 email: '',
                 loginUrl: '/user/sign-in',
                 logoutUrl: '/user/sign-out',
-                aiEnabled: false
+                aiEnabled: false,
+                menuItems: []
             };
         }
         renderAuthControls();
@@ -3331,8 +3343,8 @@
                         // Max font size based on field height (single-line text, ~15% padding)
                         var maxPxSize = fieldHeightPx * 0.85 / 1.15;  // Account for line-height
                         
-                        // Start with the smaller of declared size or height-based max
-                        pxSize = Math.min(pxSize, maxPxSize);
+                        // PDF auto-size derives its starting size from the widget height.
+                        pxSize = maxPxSize;
                         
                         // Now check if text width fits; scale down if needed
                         var fontStr = css.weight + ' ' + Math.round(pxSize) + 'px ' + css.family;
@@ -3500,7 +3512,9 @@
             height: rect.height,
             font: getSessionDefault('font'),
             fontSize: getSessionDefault('fontSize'),
-            autoSize: type === 'text' || type === 'multiline',
+            autoSize: type === 'text' && looksLikeSingleLineAutoSizeField(
+                nameSuggestions[0] ? nameSuggestions[0].name : getDefaultFieldName(type)
+            ),
             checkboxStyle: type === 'checkbox' ? (getSessionDefault('checkboxStyle') || 'cross') : undefined,
             checkboxExportValue: type === 'checkbox' ? getSessionDefault('checkboxExportValue') : undefined,
             checkboxBorder: false,

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -24,7 +24,6 @@
                     </div>
                 </div>
                 <div id="tools-container" class="d-flex align-items-center gap-2 flex-wrap">
-                    <div id="auth-controls" class="position-relative"></div>
                     <button id="settings-btn" class="btn btn-outline-light btn-sm">
                         <svg class="icon-16 me-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                         Settings
@@ -78,6 +77,7 @@
                         <svg class="icon-16 me-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"></path></svg>
                         Save to Playground
                     </button>
+                    <div id="auth-controls" class="position-relative ms-2"></div>
                 </div>
             </div>
             <div class="container-fluid mt-3 d-flex justify-content-end align-items-center flex-wrap gap-2">

--- a/docassemble/ALDashboard/pdf_export_utils.py
+++ b/docassemble/ALDashboard/pdf_export_utils.py
@@ -258,7 +258,7 @@ def build_normalized_pdf_field_definitions(
             field_type_str = _normalize_detected_field_type(
                 _field_value(field, "type", "text")
             )
-            raw_font_size = _field_value(field, "fontSize", 12)
+            raw_font_size = _field_value(field, "fontSize", 10)
             auto_size = raw_font_size == 0
             nf: Dict[str, Any] = {
                 "name": field_name,
@@ -274,7 +274,7 @@ def build_normalized_pdf_field_definitions(
                     else str(_field_value(field, "font", "Helvetica") or "Helvetica")
                 ),
                 "fontSize": (
-                    font_size_pt if normalize_font_size else int(raw_font_size or 12)
+                    font_size_pt if normalize_font_size else int(raw_font_size or 10)
                 ),
                 "autoSize": False if normalize_font_size else auto_size,
             }
@@ -359,7 +359,7 @@ def build_pdf_export_fields_per_page(
         auto_size = _parse_bool(field_data.get("autoSize"), default=False)
         allow_scroll = _parse_bool(field_data.get("allowScroll"), default=True)
         font_size_raw = field_data.get("fontSize")
-        font_size = 0 if auto_size else int(font_size_raw or 12)
+        font_size = 0 if auto_size else int(font_size_raw or 10)
         field_configs: Dict[str, Any] = {}
         field_flag_parts: List[str] = []
 
@@ -381,7 +381,7 @@ def build_pdf_export_fields_per_page(
             field_configs["fontName"] = font_name
         elif field_type in (field_type_enum.CHOICE, field_type_enum.LIST_BOX):
             field_configs["fontName"] = font_name
-            field_configs["fontSize"] = font_size or 12
+            field_configs["fontSize"] = font_size or 10
         elif field_type in (field_type_enum.CHECK_BOX, field_type_enum.RADIO):
             widget_size = max(1.0, min(width, height))
             x_position += max(0.0, (width - widget_size) / 2.0)

--- a/docassemble/ALDashboard/test/test_api_dashboard_utils.py
+++ b/docassemble/ALDashboard/test/test_api_dashboard_utils.py
@@ -40,7 +40,7 @@ class TestDashboardAPIUtils(unittest.TestCase):
         payload = _format_pdf_fields_for_ui_payload([[field]])
         self.assertEqual(len(payload), 1)
         self.assertTrue(payload[0]["autoSize"])
-        self.assertEqual(payload[0]["fontSize"], 12)
+        self.assertEqual(payload[0]["fontSize"], 10)
 
     def test_format_pdf_fields_sets_auto_size_false_for_fixed_font_size(self):
         field = SimpleNamespace(

--- a/docassemble/ALDashboard/test/test_labeler_js_extraction.py
+++ b/docassemble/ALDashboard/test/test_labeler_js_extraction.py
@@ -207,6 +207,31 @@ class TestPdfLabelerJsExtraction(unittest.TestCase):
         self.assertIn("/pdf-labeler/api/attachment-block", self.js)
         self.assertIn("util-attachment-generate", self.html)
 
+    def test_account_menu_uses_server_menu_items_and_is_rightmost(self):
+        self.assertIn("data.data.menu_items", self.js)
+        self.assertIn("state.auth.menuItems", self.js)
+        self.assertGreater(
+            self.html.index('id="auth-controls"'),
+            self.html.index('id="save-playground-btn"'),
+        )
+
+    def test_new_text_fields_only_auto_size_name_and_address_like_names(self):
+        self.assertIn("function looksLikeSingleLineAutoSizeField", self.js)
+        self.assertIn(
+            "autoSize: type === 'text' && looksLikeSingleLineAutoSizeField(",
+            self.js,
+        )
+
+    def test_auto_size_preview_starts_from_field_height(self):
+        self.assertIn("pxSize = maxPxSize;", self.js)
+        self.assertNotIn("pxSize = Math.min(pxSize, maxPxSize);", self.js)
+
+    def test_pdf_field_default_is_ten_point_helvetica(self):
+        self.assertIn(
+            "HARD_DEFAULTS = { font: 'Helvetica', fontSize: 10",
+            self.js,
+        )
+
 
 class TestLabelerTemplateRendering(unittest.TestCase):
     """Verify that the template-reading helpers still work after refactoring."""

--- a/docassemble/ALDashboard/test/test_pdf_export_utils.py
+++ b/docassemble/ALDashboard/test/test_pdf_export_utils.py
@@ -163,7 +163,7 @@ class TestPDFExportUtils(unittest.TestCase):
         self.assertEqual(field.type, FakeFieldType.CHECK_BOX)
         self.assertEqual(field.x, 16)
         self.assertEqual(field.y, 20)
-        self.assertEqual(field.font_size, 12)
+        self.assertEqual(field.font_size, 10)
         self.assertEqual(field.configs["size"], 18.0)
         self.assertEqual(field.configs["buttonStyle"], "cross")
         self.assertNotIn("width", field.configs)
@@ -412,7 +412,7 @@ class TestPDFExportUtils(unittest.TestCase):
 
         self.assertEqual(normalized_fixed[0]["fontSize"], 10)
         self.assertFalse(normalized_fixed[0]["autoSize"])
-        self.assertEqual(normalized_auto[0]["fontSize"], 12)
+        self.assertEqual(normalized_auto[0]["fontSize"], 10)
         self.assertTrue(normalized_auto[0]["autoSize"])
         self.assertEqual(normalized_auto[0]["height"], 14)
 


### PR DESCRIPTION
* Font size is actually defaulting to 10 pt;
* auto-size is not the default for newly created text fields
* preview auto-size correctly and default off; 
* move the menu to the right, and inherit default Docassemble menu items