### PR TITLE
[codex] Fix issue with copying PDF fields with manually set tab order

### DIFF
--- a/docassemble/ALDashboard/api_labelers.py
+++ b/docassemble/ALDashboard/api_labelers.py
@@ -407,6 +407,30 @@ def _apply_pdf_field_visual_defaults(
         pdf.save(pdf_path)
 
 
+def _copy_pdf_page_tab_order(source_pdf_path: str, output_pdf_path: str) -> None:
+    """Preserve per-page PDF tab order settings from one PDF in another."""
+    import pikepdf
+
+    with (
+        pikepdf.open(source_pdf_path) as source_pdf,
+        pikepdf.open(output_pdf_path, allow_overwriting_input=True) as output_pdf,
+    ):
+        source_page_count = len(source_pdf.pages)
+        for page_index, output_page in enumerate(output_pdf.pages):
+            if (
+                page_index < source_page_count
+                and "/Tabs" in source_pdf.pages[page_index]
+            ):
+                source_tabs = source_pdf.pages[page_index]["/Tabs"]
+                if getattr(source_tabs, "is_indirect", False):
+                    output_page["/Tabs"] = output_pdf.copy_foreign(source_tabs)
+                else:
+                    output_page["/Tabs"] = pikepdf.Name(str(source_tabs))
+            elif "/Tabs" in output_page:
+                del output_page["/Tabs"]  # type: ignore[operator]
+        output_pdf.save(output_pdf_path)
+
+
 def _normalize_provider_family(family_name: Optional[str]) -> str:
     """Normalize model provider aliases into the labeler provider keys.
 
@@ -3955,22 +3979,7 @@ def pdf_labeler_copy_fields() -> Response:
             # Preserve the source PDF's per-page tab order setting (/Tabs).
             # Without this, viewers fall back to visual row order even though
             # copy_pdf_fields already copied the Annots array in source order.
-            import pikepdf as _pikepdf
-
-            with (
-                _pikepdf.open(source_path) as _src_pdf,
-                _pikepdf.open(output_path, allow_overwriting_input=True) as _out_pdf,
-            ):
-                _src_page_count = len(_src_pdf.pages)
-                for _page_index, _out_page in enumerate(_out_pdf.pages):
-                    if (
-                        _page_index < _src_page_count
-                        and "/Tabs" in _src_pdf.pages[_page_index]
-                    ):
-                        _out_page["/Tabs"] = _src_pdf.pages[_page_index]["/Tabs"]
-                    elif "/Tabs" in _out_page:
-                        del _out_page["/Tabs"]  # type: ignore[operator]
-                _out_pdf.save(output_path)
+            _copy_pdf_page_tab_order(source_path, output_path)
 
             from .pdf_accessibility import (
                 apply_pdf_accessibility_settings,

--- a/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
+++ b/docassemble/ALDashboard/test/test_copy_fields_visual_defaults.py
@@ -10,6 +10,7 @@ These tests verify that:
 """
 
 import os
+import json
 import subprocess
 import sys
 import tempfile
@@ -68,6 +69,7 @@ _STUB_PREFIX = textwrap.dedent("""
 
     module = importlib.import_module("docassemble.ALDashboard.api_labelers")
     _apply_pdf_field_visual_defaults = module._apply_pdf_field_visual_defaults
+    _copy_pdf_page_tab_order = module._copy_pdf_page_tab_order
 """)
 
 
@@ -301,6 +303,54 @@ print("done")
             )
         finally:
             os.unlink(pdf_path)
+
+
+class TestCopyPDFPageTabOrder(unittest.TestCase):
+    """Regression tests for preserving copied-field tab order metadata."""
+
+    def test_direct_tabs_name_is_copied_into_output_pdf(self):
+        """A source-owned direct /Tabs name must not be assigned cross-PDF."""
+        probe = """
+import json
+import os
+import tempfile
+import pikepdf
+from pikepdf import Name
+
+source_path = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
+output_path = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False).name
+
+try:
+    source_pdf = pikepdf.new()
+    source_page_one = source_pdf.add_blank_page(page_size=(100, 100))
+    source_pdf.add_blank_page(page_size=(100, 100))
+    source_page_one.obj["/Tabs"] = Name("/S")
+    source_pdf.save(source_path)
+    source_pdf.close()
+
+    output_pdf = pikepdf.new()
+    output_pdf.add_blank_page(page_size=(100, 100))
+    output_page_two = output_pdf.add_blank_page(page_size=(100, 100))
+    output_page_two.obj["/Tabs"] = Name("/R")
+    output_pdf.save(output_path)
+    output_pdf.close()
+
+    _copy_pdf_page_tab_order(source_path, output_path)
+
+    with pikepdf.open(output_path) as output_pdf:
+        result = {
+            "page_one_tabs": str(output_pdf.pages[0].get("/Tabs")),
+            "page_two_has_tabs": "/Tabs" in output_pdf.pages[1],
+        }
+    print(json.dumps(result, sort_keys=True))
+finally:
+    for path in (source_path, output_path):
+        if os.path.exists(path):
+            os.unlink(path)
+"""
+        result = json.loads(_run_probe(probe))
+        self.assertEqual(result["page_one_tabs"], "/S")
+        self.assertFalse(result["page_two_has_tabs"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change fixes copying PDF fields when the source PDF uses a manually set tab order, and adds focused test coverage for that behavior.

Should fix issue shared by @vtskier on coding help channel