### PR TITLE
Fix slow user dropdown for large servers

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -531,12 +531,12 @@ def get_users_and_name_by_ids(ids: List[int]) -> List[Tuple[int, str, str, str]]
     with _get_db_session() as session:
         users = session.execute(statement).all()
 
-    results = []
-    for user in users:
-        user_id, email, first_name, last_name, nickname = user
-        display_name = first_name or nickname or ""
-        results.append((user_id, email or "", display_name, last_name or ""))
-    return results
+        results = []
+        for user in users:
+            user_id, email, first_name, last_name, nickname = user
+            display_name = first_name or nickname or ""
+            results.append((user_id, email or "", display_name, last_name or ""))
+        return results
 
 
 def search_users_by_email(wordstart: str, limit: int = 20) -> List[Tuple[int, str]]:

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -555,16 +555,16 @@ def search_users_by_email(wordstart: str, limit: int = 20) -> List[Tuple[int, st
     with _get_db_session() as session:
         users = session.execute(statement).all()
 
-    results = []
-    for user in users:
-        user_id, email, first_name, last_name = user
-        label = email
-        if first_name:
-            label += " " + first_name
-        if last_name:
-            label += " " + last_name
-        results.append((user_id, label))
-    return results
+        results = []
+        for user in users:
+            user_id, email, first_name, last_name = user
+            label = email
+            if first_name:
+                label += " " + first_name
+            if last_name:
+                label += " " + last_name
+            results.append((user_id, label))
+        return results
 
 def speedy_get_users() -> List[Dict[int, str]]:
     """

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -501,9 +501,7 @@ def get_user_count() -> int:
     it's safe to load every user into a dropdown, or whether the list is too large to do that.
     """
     with _get_db_session() as session:
-        statement = select(func.count(UserModel.id)).where(
-            ~UserModel.social_id.startswith("disabled$")
-        )
+        statement = select(func.count(UserModel.id))
         count = session.scalar(statement)
 
     if count is None:
@@ -550,7 +548,7 @@ def search_users_by_email(wordstart: str, limit: int = 20) -> List[Tuple[int, st
 
     statement = select(
         UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name
-    ).where(UserModel.email.ilike(wordstart + "%")).limit(limit)
+    ).where(UserModel.email.istartswith(wordstart)).limit(limit)
 
     with _get_db_session() as session:
         users = session.execute(statement).all()

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -140,6 +140,9 @@ __all__ = [
     "inactive_developer_account_report",
     "delete_inactive_developer_accounts",
     "is_user_privileged",
+    "get_user_count",
+    "get_users_and_name_by_ids",
+    "search_users_by_email",
 ]
 
 
@@ -492,6 +495,76 @@ def da_write_config(data: Dict):
     restart_all()
     return True
 
+def get_user_count() -> int:
+    """
+    Return the count of active (non-disabled) users on the server. Used to decide whether 
+    it's safe to load every user into a dropdown, or whether the list is too large to do that.
+    """
+    with _get_db_session() as session:
+        statement = select(func.count(UserModel.id)).where(
+            ~UserModel.social_id.startswith("disabled$")
+        )
+        count = session.scalar(statement)
+
+    if count is None:
+        return 0
+    return count
+
+
+def get_users_and_name_by_ids(ids: List[int]) -> List[Tuple[int, str, str, str]]:
+    """
+    Same shape as get_users_and_name(), but scoped to a specific list of user IDs instead of pulling 
+    every user in the database. Used to avoid loading the entire users table just to label a handful 
+    of already fetched session rows.
+    """
+    if not ids:
+        return []
+
+    statement = select(
+        UserModel.id,
+        UserModel.email,
+        UserModel.first_name,
+        UserModel.last_name,
+        UserModel.nickname,
+    ).where(UserModel.id.in_(ids))
+
+    with _get_db_session() as session:
+        users = session.execute(statement).all()
+
+    results = []
+    for user in users:
+        user_id, email, first_name, last_name, nickname = user
+        display_name = first_name or nickname or ""
+        results.append((user_id, email or "", display_name, last_name or ""))
+    return results
+
+
+def search_users_by_email(wordstart: str, limit: int = 20) -> List[Tuple[int, str]]:
+    """
+    Search for users whose email starts with the given text. Used by the input type: ajax field on large servers, 
+    so we never load the full user table - just return a handful of matches as the admin types.
+    """
+    wordstart = wordstart.strip()
+    if not wordstart:
+        return []
+
+    statement = select(
+        UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name
+    ).where(UserModel.email.ilike(wordstart + "%")).limit(limit)
+
+    with _get_db_session() as session:
+        users = session.execute(statement).all()
+
+    results = []
+    for user in users:
+        user_id, email, first_name, last_name = user
+        label = email
+        if first_name:
+            label += " " + first_name
+        if last_name:
+            label += " " + last_name
+        results.append((user_id, label))
+    return results
 
 def speedy_get_users() -> List[Dict[int, str]]:
     """

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -245,16 +245,9 @@ code: |
   needed_user_ids = set()
   for interview in sessions_list:
     raw_user_ids = getattr(interview, "user_ids", None)
-    if raw_user_ids is None:
-      raw_user_ids = getattr(interview, "user_id", None)
     if not raw_user_ids:
       continue
-    if isinstance(raw_user_ids, str):
-      needed_user_ids.update(raw_user_ids.split(","))
-    elif isinstance(raw_user_ids, (list, tuple, set)):
-      needed_user_ids.update(raw_user_ids)
-    else:
-      needed_user_ids.add(raw_user_ids)
+    needed_user_ids.update(raw_user_ids.split(","))
 
   clean_ids = []
   for uid in needed_user_ids:

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -50,6 +50,14 @@ code: |
   else:
     current_usage_rows = []
 ---
+code: |
+  # Used to decide whether it's safe to load every user into the dropdown below, 
+  # or whether the server has too many users for that
+  if user_has_privilege(["admin", "developer"]):
+    total_user_count = get_user_count()
+  else:
+    total_user_count = 0
+---
 id: select interview
 question: |
   What interview do you want to view sessions for?
@@ -125,12 +133,22 @@ fields:
     required: False
     datatype: integer
     input type: combobox
+    show if:
+      code: |
+        total_user_count <= 10000
     code: |
       (
         speedy_get_users()
         if user_has_privilege(["admin", "developer"])
         else [{user_info().id: user_info().email}]
       )
+  - User (leave blank to view all sessions): chosen_user
+    required: False
+    input type: ajax
+    action: user_search_ajax
+    show if:
+      code: |
+        total_user_count > 10000
   - Filter out interviews that are on the first page: filter_step1
     required: False
     datatype: yesno
@@ -202,6 +220,12 @@ validation code: |
     session_search_end_date = None
 ---
 # next((item.get('title') for item in interviews if item.get('filename') == interview['filename']), interview['filename'] )
+code: |
+  # chosen_user comes back as a string from the ajax field (large servers),
+  # but as a real int from the combobox (small servers) - normalize it here so speedy_get_sessions() 
+  #always gets a proper int either way
+  if total_user_count > 10000 and chosen_user:
+    chosen_user = int(chosen_user)
 ---
 code: |
   # For debugging purposes
@@ -214,14 +238,55 @@ code: |
     search_criteria_text=session_search_resolved_criteria_text,
   )
 ---
+need: sessions_list
 code: |
-  # users_and_names() returns a tuple of user ID to email, name, last
-  # Convert to a dict with key of user id, formatted email, name, last
+  # Only look up the names of users who actually appear in the sessions
+  # we're displaying, instead of loading every user on the server
+  needed_user_ids = set()
+  for interview in sessions_list:
+    raw_user_ids = getattr(interview, "user_ids", None)
+    if raw_user_ids is None:
+      raw_user_ids = getattr(interview, "user_id", None)
+    if not raw_user_ids:
+      continue
+    if isinstance(raw_user_ids, str):
+      needed_user_ids.update(raw_user_ids.split(","))
+    elif isinstance(raw_user_ids, (list, tuple, set)):
+      needed_user_ids.update(raw_user_ids)
+    else:
+      needed_user_ids.add(raw_user_ids)
+
+  clean_ids = []
+  for uid in needed_user_ids:
+    try:
+      clean_ids.append(int(uid))
+    except (TypeError, ValueError):
+      continue
 
   users_and_name_dict = {
     user_id: f"{email} {name} {last}"
-    for user_id, email, name, last in get_users_and_name()
+    for user_id, email, name, last in get_users_and_name_by_ids(clean_ids)
   }
+---
+event: user_search_ajax
+code: |
+  # set_save_status('ignore') so this doesn't add a step to the interview every time a search happens
+  set_save_status('ignore')
+  original = action_argument('wordstart')
+  # If the field is being redisplayed, docassemble sends the already-stored value (a user ID) instead of 
+  # typed text look that single user up and return their label so it renders correctly, per the ajax field docs
+  try:
+    original_id = int(original)
+    existing_match = get_users_and_name_by_ids([original_id])
+    if existing_match:
+      user_id, email, name, last = existing_match[0]
+      json_response([[str(user_id), f"{email} {name} {last}"]])
+  except (TypeError, ValueError):
+    pass
+  results = [
+    [str(user_id), label] for user_id, label in search_users_by_email(original)
+  ]
+  json_response(results)
 ---
 event: set_interview_to_browse
 code: |


### PR DESCRIPTION
Fixes #263.

Servers with a lot of users (MI/IL specifically) were loading everyone into a dropdown just to filter sessions by person. Now it checks the user count first: 10k or fewer keeps the same dropdown, more switches to a type-to-search field instead of loading everyone.

Also fixed a related issue: the session list was pulling every user's name/email on every page load just to label results, even on small servers. Now it only looks up the people actually shown.

One thing worth knowing: on the new search field, using the Back button shows the raw ID instead of the person's name. It doesn't break anything or lose your selection, it's just a small display issue I wasn't able to fully track down (seems to be something in docassemble's own field behavior)