### PR TITLE
Create a template for an interview that doesn't have one yet, based on questions in the interview (like review screen generator)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,9 +11,20 @@ stack.
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 import types
 from typing import Any, Callable
+
+
+def _isolate_external_llm_credentials() -> None:
+    """Prevent local dotenv credentials from changing deterministic tests."""
+    # docassemble may load the repository's .env while importing its config.
+    # Empty values are intentional: python-dotenv does not replace variables
+    # that are already present, and tests that need credentials can pass them
+    # explicitly or patch the environment in that test.
+    os.environ["OPENAI_API_KEY"] = ""
+    os.environ["OPENAI_BASE_URL"] = ""
 
 
 def _install_docassemble_webapp_stubs() -> None:
@@ -92,6 +103,7 @@ def _install_empty_docassemble_configuration() -> None:
         setattr(da_functions, "get_configuration", lambda: {})
 
 
+_isolate_external_llm_credentials()
 _install_docassemble_webapp_stubs()
 _install_empty_docassemble_configuration()
 _preimport_pikepdf()

--- a/conftest.py
+++ b/conftest.py
@@ -51,4 +51,23 @@ def _install_docassemble_webapp_stubs() -> None:
         pass
 
 
+def _preimport_pikepdf() -> None:
+    """Load pikepdf before any test patches ``sys.modules``.
+
+    ``unittest.mock.patch.dict("sys.modules", ...)`` restores the original
+    module dict on exit, dropping anything that was imported for the first
+    time inside the patched block. pikepdf cannot survive a second import in
+    the same process -- its ``@augments`` class patching raises
+    ``RuntimeError: ... both define the same non-abstract method`` -- so a test
+    that first pulls it in transitively (via ``docassemble.base.util``) while
+    ``sys.modules`` is patched would break every later pikepdf import.
+    Importing it up front keeps it in the dict that ``patch.dict`` restores.
+    """
+    try:
+        import pikepdf  # noqa: F401
+    except Exception:  # pragma: no cover - pikepdf is optional at import time
+        pass
+
+
 _install_docassemble_webapp_stubs()
+_preimport_pikepdf()

--- a/conftest.py
+++ b/conftest.py
@@ -69,5 +69,29 @@ def _preimport_pikepdf() -> None:
         pass
 
 
+def _install_empty_docassemble_configuration() -> None:
+    """Make ``get_config()`` usable without a running docassemble server.
+
+    docassemble 1.10 routes ``get_configuration()`` through a pluggy hook that
+    only the webapp registers. Outside a real server the hook has no
+    implementation and returns ``None``, so ``docassemble.base.functions``'s
+    ``get_config()`` dies with ``AttributeError: 'NoneType' object has no
+    attribute 'get'``. ALToolbox's ``llms`` module calls ``get_config`` at
+    import time, which breaks collection of every test that imports
+    ``docx_wrangling``. Fall back to an empty configuration, which is what
+    these tests want anyway.
+    """
+    try:
+        import docassemble.base.functions as da_functions
+    except Exception:
+        return
+
+    try:
+        da_functions.get_config("open ai")
+    except Exception:
+        setattr(da_functions, "get_configuration", lambda: {})
+
+
 _install_docassemble_webapp_stubs()
+_install_empty_docassemble_configuration()
 _preimport_pikepdf()

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -1016,7 +1016,7 @@ def delete_inactive_developer_accounts(
         }:
             raise
         # docassemble < 1.10 keeps these implementations in legacy modules.
-        from docassemble.webapp.server import user_interviews
+        from docassemble.webapp.server import user_interviews  # type: ignore[no-redef]
         from docassemble.webapp.backend import delete_user_data
 
     if requesting_user_id is None:

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -1016,8 +1016,8 @@ def delete_inactive_developer_accounts(
         }:
             raise
         # docassemble < 1.10 keeps these implementations in legacy modules.
-        from docassemble.webapp.server import user_interviews
-        from docassemble.webapp.backend import delete_user_data
+        from docassemble.webapp.server import user_interviews  # type: ignore[no-redef]
+        from docassemble.webapp.backend import delete_user_data  # type: ignore[no-redef]
 
     if requesting_user_id is None:
         requesting_user_id = _resolve_current_user_id()

--- a/docassemble/ALDashboard/api_dashboard.py
+++ b/docassemble/ALDashboard/api_dashboard.py
@@ -78,6 +78,7 @@ from .api_dashboard_utils import (
     translation_payload_from_request,
     validate_docx_payload_from_request,
     validate_translation_payload_from_request,
+    variable_report_payload_from_request,
     yaml_check_payload_from_request,
     yaml_reformat_payload_from_request,
     pdf_repair_payload_from_request,
@@ -108,6 +109,7 @@ if not in_celery:
         dashboard_yaml_check_task,
         dashboard_yaml_reformat_task,
         dashboard_pdf_repair_task,
+        dashboard_variable_report_task,
     )
 
 
@@ -550,6 +552,15 @@ def dashboard_interview_lint():
 @cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
 def dashboard_kiln_story():
     return _run_endpoint(alkiln_story_payload_from_request, dashboard_alkiln_story_task)
+
+
+@app.route(f"{DASHBOARD_API_BASE_PATH}/variable-report", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def dashboard_variable_report():
+    return _run_endpoint(
+        variable_report_payload_from_request, dashboard_variable_report_task
+    )
 
 
 @app.route(f"{DASHBOARD_API_BASE_PATH}/yaml/check", methods=["POST"])

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1939,6 +1939,69 @@ def alkiln_story_payload_from_options(
     return story_from_docassemble_json(docassemble_data, options=options)
 
 
+def variable_report_payload_from_request() -> Dict[str, Any]:
+    raw = merge_raw_options(_request_dict())
+    upload: Optional[Dict[str, Any]] = None
+    if "file" in request.files:
+        upload = _read_single_upload(field_name="file")
+    elif "files" in request.files:
+        uploads = _read_multi_uploads(field_name="files")
+        upload = uploads[0] if uploads else None
+    return variable_report_payload_from_options(raw, upload=upload)
+
+
+def variable_report_payload_from_options(
+    raw_options: Mapping[str, Any], *, upload: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    from .variable_report_generator import generate_variable_report
+
+    raw = merge_raw_options(raw_options)
+    yaml_text = raw.get("yaml_text") or raw.get("yaml_content")
+    playground_project = str(raw.get("playground_project") or "").strip()
+    playground_yaml_file = str(raw.get("playground_yaml_file") or "").strip()
+    source_token = str(raw.get("source_token") or "").strip()
+
+    if upload is None and raw.get("file_content_base64") is not None:
+        filename = str(raw.get("filename") or "upload.yml")
+        content = decode_base64_content(raw.get("file_content_base64"))
+        _validate_upload_size(content)
+        upload = {"filename": filename, "content": content}
+
+    if yaml_text is None and upload is not None:
+        upload_content = upload.get("content")
+        if isinstance(upload_content, (bytes, bytearray)):
+            yaml_text = bytes(upload_content).decode("utf-8", errors="replace")
+
+    if yaml_text is None and (playground_yaml_file or source_token):
+        token_to_use = playground_yaml_file or source_token
+        selected_source = _find_playground_yaml_source(
+            playground_project, token_to_use
+        )
+        with open(selected_source["path"], "r", encoding="utf-8") as f:
+            yaml_text = f.read()
+
+    if yaml_text is None:
+        raise DashboardAPIValidationError(
+            "Provide YAML as `yaml_text`, `file_content_base64`, multipart `file`, "
+            "or `playground_project` with `playground_yaml_file`."
+        )
+
+    report_title = str(raw.get("report_title") or "Interview Variable Report").strip()
+    infer_assemblyline = parse_bool(raw.get("infer_assemblyline"), default=True)
+
+    res = generate_variable_report(
+        [yaml_text],
+        report_title=report_title,
+        infer_assemblyline=infer_assemblyline,
+    )
+    return {
+        "mako_markdown": res["mako_markdown"],
+        "variables_count": res["variables_count"],
+        "list_count": res["list_count"],
+        "scalar_count": res["scalar_count"],
+    }
+
+
 def _prepare_pdf_upload(raw_options: Mapping[str, Any]) -> Dict[str, Any]:
     raw = merge_raw_options(raw_options)
     filename = str(raw.get("filename") or "upload.pdf")
@@ -2390,6 +2453,27 @@ def build_openapi_spec() -> Dict[str, Any]:
                     "description": (
                         "Formats embedded Python code blocks in YAML (for example `code` and "
                         "`validation code`) and returns `formatted_yaml` plus `changed`."
+                    ),
+                }
+            },
+            f"{DASHBOARD_API_BASE_PATH}/kiln/story": {
+                "post": {
+                    "summary": "Convert docassemble JSON, YAML, or a saved session to an ALKiln story",
+                    "description": (
+                        "Accepts docassemble JSON as `data`, `json_text`, or `variables`, "
+                        "a saved interview `session_id`, or interview YAML via `yaml_text`, "
+                        "upload, source token, or playground selection. YAML input uses "
+                        "heuristics to create table rows and detect the ending screen."
+                    ),
+                }
+            },
+            f"{DASHBOARD_API_BASE_PATH}/variable-report": {
+                "post": {
+                    "summary": "Generate interview variable report (Mako+Markdown and Jinja2 DOCX)",
+                    "description": (
+                        "Accepts interview YAML via `yaml_text`, upload, or playground selection, "
+                        "extracts all variables, infers AssemblyLine built-ins, and returns "
+                        "Mako+Markdown plain text and variable metrics."
                     ),
                 }
             },

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -651,12 +651,15 @@ def docx_labeler_suggest_payload_from_options(
             ),
             "judge_review_count": len(judge_review.get("reviews", []) or []),
         }
+        # Server-log priority on purpose: any other priority appends to
+        # `this_thread.message_log`, which docassemble 1.10 only populates
+        # inside an interview request, and these timings are not meant for
+        # the user's screen anyway.
         log(
             "ALDashboard: DOCX suggest-labels timings for "
             + repr(filename)
             + ": "
-            + json.dumps(timings, sort_keys=True),
-            "info",
+            + json.dumps(timings, sort_keys=True)
         )
 
         return {

--- a/docassemble/ALDashboard/api_dashboard_worker.py
+++ b/docassemble/ALDashboard/api_dashboard_worker.py
@@ -31,6 +31,7 @@ from .api_dashboard_utils import (
     translation_payload_from_options,
     validate_docx_payload_from_options,
     validate_translation_payload_from_options,
+    variable_report_payload_from_options,
     yaml_check_payload_from_options,
     yaml_reformat_payload_from_options,
 )
@@ -144,3 +145,10 @@ def dashboard_pdf_repair_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     """
     with bg_context():
         return pdf_repair_payload_from_options(payload)
+
+
+@workerapp.task
+def dashboard_variable_report_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    with bg_context():
+        return variable_report_payload_from_options(payload)
+

--- a/docassemble/ALDashboard/data/questions/menu.yml
+++ b/docassemble/ALDashboard/data/questions/menu.yml
@@ -108,6 +108,9 @@ data:
   - name: Generate an ALKiln story
     url: ${ interview_url(i=user_info().package + ":alkiln_story.yml", reset=1) }
     image: book
+  - name: Generate variable report
+    url: ${ interview_url(i=user_info().package + ":variable_report_generator.yml", reset=1) }
+    image: clipboard-list
   - name: Reformat YAML and Python
     url: ${ interview_url(i=user_info().package + ":yaml_formatter.yml", reset=1) }
     image: magic

--- a/docassemble/ALDashboard/data/questions/variable_report_generator.yml
+++ b/docassemble/ALDashboard/data/questions/variable_report_generator.yml
@@ -1,0 +1,222 @@
+---
+include:
+  - docassemble.ALToolbox:display_template.yml
+  - nav.yml
+---
+metadata:
+  title: |
+    Interview Intake Document Generator
+  temporary session: True
+  required privileges:
+    - admin
+    - developer
+---
+modules:
+  - .variable_report_generator
+  - .aldashboard
+---
+objects:
+  - markdown_download: DAFile
+  - docx_download: DAFile
+  - yaml_uploads: DAFileList
+---
+mandatory: True
+code: |
+  var_report_source
+  if var_report_source == "upload":
+    yaml_uploads
+    source_filenames = [f.filename for f in yaml_uploads]
+    report_yaml_texts = [f.slurp() for f in yaml_uploads]
+  elif var_report_source == "playground":
+    selected_playground_project
+    selected_playground_files
+    source_filenames = selected_playground_files.true_values()
+    report_yaml_texts = get_playground_yaml_texts(selected_playground_project, source_filenames)
+  else:
+    pasted_yaml
+    source_filenames = ["interview.yml"]
+    report_yaml_texts = [pasted_yaml]
+
+  meta_info = extract_interview_metadata_info(
+    report_yaml_texts,
+    primary_filename=source_filenames[0] if source_filenames else None,
+  )
+
+  options_screen
+  report_result
+  show_results
+---
+id: select variable report source
+question: |
+  Generate an Interview Intake Document Output
+subquestion: |
+  Select how you would like to provide the interview YAML files.
+fields:
+  - Source: var_report_source
+    datatype: radio
+    choices:
+      - Uploaded YAML file(s): upload
+      - YAML file(s) in playground: playground
+      - Pasted YAML text: pasted_yaml
+    default: playground
+---
+id: upload yaml for report
+question: |
+  Upload Interview YAML File(s)
+subquestion: |
+  Upload one or more YAML files containing the interview questions and objects block.
+fields:
+  - YAML File(s): yaml_uploads
+    datatype: files
+---
+id: select playground project for report
+question: |
+  Select Playground Project
+fields:
+  - Playground project: selected_playground_project
+    datatype: combobox
+    code: |
+      list_variable_report_playground_projects()
+---
+id: select playground files for report
+question: |
+  Select Playground YAML File(s)
+subquestion: |
+  Select one or more YAML files to combine into the document output.
+fields:
+  - YAML files: selected_playground_files
+    datatype: checkboxes
+    code: |
+      [
+        {"label": item["label"], "value": item["token"]}
+        for item in list_variable_report_playground_yaml_files(selected_playground_project)
+      ]
+validation code: |
+  if not selected_playground_files.true_values():
+    validation_error("Select at least one YAML file.")
+  allowed_files = {
+    item["token"]: item["label"]
+    for item in list_variable_report_playground_yaml_files(selected_playground_project)
+  }
+  for chosen in selected_playground_files.true_values():
+    if chosen not in allowed_files:
+      validation_error(
+        "Select valid YAML files from the chosen Playground project.",
+        field="selected_playground_files",
+      )
+---
+id: paste yaml for report
+question: |
+  Paste Interview YAML
+fields:
+  - Interview YAML: pasted_yaml
+    input type: area
+    rows: 12
+---
+continue button field: options_screen
+id: variable report options
+question: |
+  Output Options
+fields:
+  - Document Title: report_title
+    default: ${ meta_info["display_title"] }
+  - Show internal variable names in labels: show_variable_names
+    datatype: yesno
+    default: False
+  - Show variable data types in labels: show_variable_types
+    datatype: yesno
+    default: False
+  - Max table columns for lists before switching to vertical layout: max_list_cols
+    datatype: integer
+    default: 4
+    min: 1
+    max: 10
+  - Infer AssemblyLine built-in objects/lists: infer_assemblyline
+    datatype: yesno
+    default: True
+    help: |
+      Automatically infer built-in AssemblyLine objects (like `users`, `children`,
+      `plaintiff`, `trial_court`, etc.) if referenced in the interview.
+  - Save output files to playground: save_to_playground
+    datatype: yesno
+    default: False
+  - Save to project: save_playground_project
+    datatype: combobox
+    show if: save_to_playground
+    code: |
+      list_variable_report_playground_projects()
+  - Format(s) to save: save_format_choice
+    datatype: radio
+    show if: save_to_playground
+    choices:
+      - Both Markdown (.md) and Word DOCX (.docx): both
+      - Markdown (.md) text file only: markdown
+      - Word DOCX (.docx) template file only: docx
+    default: both
+  - Save Markdown as: md_filename
+    default: ${ meta_info["md_filename"] }
+    show if: save_to_playground
+  - Save DOCX as: docx_filename
+    default: ${ meta_info["docx_filename"] }
+    show if: save_to_playground
+---
+code: |
+  _save_to_pg = defined('save_to_playground') and bool(save_to_playground)
+  _save_proj = save_playground_project if _save_to_pg and defined('save_playground_project') else ""
+  _save_fmt = save_format_choice if _save_to_pg and defined('save_format_choice') else "both"
+  _md_name = md_filename if _save_to_pg and defined('md_filename') else meta_info["md_filename"]
+  _docx_name = docx_filename if _save_to_pg and defined('docx_filename') else meta_info["docx_filename"]
+
+  report_result = generate_variable_report(
+    report_yaml_texts,
+    report_title=report_title,
+    infer_assemblyline=infer_assemblyline,
+    show_variable_names=show_variable_names,
+    show_variable_types=show_variable_types,
+    max_list_cols=max_list_cols,
+  )
+
+  if _save_to_pg:
+    save_res = save_variable_report_to_playground(
+      mako_markdown=report_result["mako_markdown"],
+      docx_path=report_result["docx_path"],
+      selected_playground_project=_save_proj,
+      save_format_choice=_save_fmt,
+      md_filename=_md_name,
+      docx_filename=_docx_name,
+    )
+    report_result["saved"] = save_res["saved"]
+    report_result["saved_files"] = save_res["saved_files"]
+    report_result["save_error"] = save_res["error"]
+
+  markdown_download.initialize(filename=_md_name)
+  markdown_download.write(report_result["mako_markdown"])
+  markdown_download.commit()
+
+  docx_download.initialize(filename=_docx_name)
+  docx_download.copy_into(report_result["docx_path"])
+  docx_download.commit()
+imports:
+  - html
+---
+event: show_results
+id: variable report results
+question: |
+  ${ report_title }
+subquestion: |
+  Files combined: **${ len(source_filenames) }** | Interview screens & objects processed: **${ len(report_result["groups"]) }** | Total variables: **${ report_result["variables_count"] }**
+
+  ### Download Output Files
+  * **[Download Mako + Markdown Draft (${ _md_name })](${ markdown_download.url_for(attachment=True) })**
+  * **[Download DOCX Document Draft (${ _docx_name })](${ docx_download.url_for(attachment=True) })**
+
+  % if report_result.get("saved") and report_result.get("saved_files"):
+  * **Saved to Playground project `${ _save_proj }`:** ${ ", ".join(report_result.get("saved_files", [])) }
+  % endif
+
+  ---
+
+  <details class="mb-3 border p-3 rounded" open>
+    <summary style="cursor: pointer;" class="fw-bold text-primary h5 mb-3">Preview Plain Text Output (Mako + Markdown)</summary>
+    <pre style="white-space: pre-wrap; word-break: break-word; background-color: #f8f9fa; padding: 1rem; border: 1px solid #dee2e6; border-radius: 4px; font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; font-size: 0.875rem; line-height: 1.45; overflow-x: auto;"><code>${ html.escape(report_result["mako_markdown"]) }</code></pre>
+  </details>

--- a/docassemble/ALDashboard/data/questions/variable_report_generator.yml
+++ b/docassemble/ALDashboard/data/questions/variable_report_generator.yml
@@ -196,6 +196,7 @@ code: |
   docx_download.initialize(filename=_docx_name)
   docx_download.copy_into(report_result["docx_path"])
   docx_download.commit()
+---
 imports:
   - html
 ---

--- a/docassemble/ALDashboard/interview_linter.py
+++ b/docassemble/ALDashboard/interview_linter.py
@@ -550,7 +550,7 @@ def remove_mako(text: str) -> str:
     try:
         template = mako.template.Template(input_text)
         markdown_text = template.render()
-        html_text = docassemble.base.filter.markdown_to_html(markdown_text)
+        html_text = docassemble.base.filter.markdown_to_html(markdown_text)  # type: ignore[attr-defined]
         return docassemble.webapp.screenreader.to_text(html_text)
     except Exception:
         return input_text

--- a/docassemble/ALDashboard/interview_linter.py
+++ b/docassemble/ALDashboard/interview_linter.py
@@ -24,8 +24,15 @@ import ruamel.yaml
 import textstat
 from spellchecker import SpellChecker
 
-import docassemble.base.filter
 import docassemble.webapp.screenreader
+
+try:
+    from docassemble.base.filter.html import markdown_to_html
+except ImportError:
+    # docassemble < 1.10 keeps this in a flat `docassemble.base.filter` module.
+    from docassemble.base.filter import (  # type: ignore[no-redef,attr-defined]
+        markdown_to_html,
+    )
 
 try:
     from flask_login import current_user
@@ -550,7 +557,7 @@ def remove_mako(text: str) -> str:
     try:
         template = mako.template.Template(input_text)
         markdown_text = template.render()
-        html_text = docassemble.base.filter.markdown_to_html(markdown_text)
+        html_text = markdown_to_html(markdown_text)
         return docassemble.webapp.screenreader.to_text(html_text)
     except Exception:
         return input_text

--- a/docassemble/ALDashboard/pdf_field_labeler.py
+++ b/docassemble/ALDashboard/pdf_field_labeler.py
@@ -29,7 +29,13 @@ def log(message: str, level: str = "info") -> None:
         from docassemble.base.util import log as da_log
     except ImportError:
         return
-    da_log(message, level)
+    try:
+        da_log(message, level)
+    except Exception:
+        # Any level other than "log" is routed to `this_thread.message_log`,
+        # which docassemble 1.10 only populates inside a request. Diagnostics
+        # must never take down the labeling call that emitted them.
+        pass
 
 
 def _assert_valid_pdf_output(pdf_path: str, *, action_label: str) -> None:

--- a/docassemble/ALDashboard/test/test_inactive_developer_accounts.py
+++ b/docassemble/ALDashboard/test/test_inactive_developer_accounts.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import ast
 import calendar
 from datetime import datetime, timezone

--- a/docassemble/ALDashboard/test/test_variable_report_generator.py
+++ b/docassemble/ALDashboard/test/test_variable_report_generator.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import os
 import tempfile
 import unittest

--- a/docassemble/ALDashboard/test/test_variable_report_generator.py
+++ b/docassemble/ALDashboard/test/test_variable_report_generator.py
@@ -1,0 +1,161 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from docassemble.ALDashboard.variable_report_generator import (
+    extract_interview_metadata_info,
+    extract_interview_questions_and_variables,
+    generate_docx_report,
+    generate_mako_markdown_report,
+    generate_variable_report,
+    _load_assemblyline_baseline,
+    save_variable_report_to_playground,
+    generate_and_save_playground_variable_report,
+)
+from docassemble.ALDashboard.api_dashboard_utils import (
+    variable_report_payload_from_options,
+)
+
+
+class TestVariableReportGenerator(unittest.TestCase):
+    def test_extract_interview_metadata_info(self):
+        yaml_with_title = 'code:\n  interview_short_title = "Affidavit of Indigency"\n'
+        meta = extract_interview_metadata_info([yaml_with_title])
+        self.assertEqual(meta["short_title"], "Affidavit of Indigency")
+        self.assertEqual(meta["display_title"], "Affidavit of Indigency Draft")
+        self.assertEqual(meta["md_filename"], "affidavit_of_indigency_draft.md")
+        self.assertEqual(meta["docx_filename"], "affidavit_of_indigency_draft.docx")
+
+        meta_file = extract_interview_metadata_info(["question: | Start"], primary_filename="housing_code_checklist.yml")
+        self.assertEqual(meta_file["display_title"], "Housing Code Checklist Draft")
+        self.assertEqual(meta_file["md_filename"], "housing_code_checklist_draft.md")
+        self.assertEqual(meta_file["docx_filename"], "housing_code_checklist_draft.docx")
+
+    def test_assemblyline_baseline_inference(self):
+        baseline = _load_assemblyline_baseline()
+        self.assertIn("users", baseline)
+        self.assertTrue(baseline["users"].is_list)
+        self.assertEqual(baseline["users"].var_type, "ALPeopleList")
+        self.assertNotIn("al_form_type", baseline)
+
+    def test_extract_questions_and_variables_from_yaml(self):
+        yaml_content = """
+---
+objects:
+  - users: ALPeopleList
+---
+id: user screen
+question: |
+  What is your information?
+fields:
+  - User First Name: users[i].name.first
+  - User Birthdate: users[i].birthdate
+    datatype: date
+  - Case Number: case_number
+"""
+        groups, variables = extract_interview_questions_and_variables([yaml_content], infer_assemblyline=True)
+        self.assertIn("users", variables)
+        self.assertTrue(variables["users"].is_list)
+        self.assertIn("case_number", variables)
+        self.assertFalse(variables["case_number"].is_list)
+        self.assertEqual(groups[0].title, "What is your information?")
+
+    def test_generate_mako_markdown_report(self):
+        yaml_content = """
+---
+objects:
+  - users: ALPeopleList
+---
+id: user screen
+question: |
+  What is your information?
+fields:
+  - First Name: users[i].name.first
+  - Case Number: case_number
+"""
+        res = generate_variable_report([yaml_content], report_title="Test Report", infer_assemblyline=True)
+        mako_md = res["mako_markdown"]
+        self.assertIn("# Test Report", mako_md)
+        self.assertIn("## What is your information?", mako_md)
+        self.assertIn("% if showifdef('users'):", mako_md)
+        self.assertIn("${ showifdef(item.attr_name('name')) }", mako_md)
+        self.assertIn("${ showifdef('case_number') }", mako_md)
+
+    def test_vertical_list_layout_threshold(self):
+        yaml_content = """
+---
+objects:
+  - users: ALPeopleList
+---
+id: user screen
+question: |
+  User Info
+fields:
+  - FName: users[i].name.first
+  - LName: users[i].name.last
+  - BDate: users[i].birthdate
+  - Email: users[i].email
+  - Phone: users[i].phone_number
+"""
+        res = generate_variable_report(
+            [yaml_content],
+            report_title="Test Report",
+            infer_assemblyline=True,
+            max_list_cols=4,
+        )
+        mako_md = res["mako_markdown"]
+        self.assertIn("#### Person ${ i + 1 }", mako_md)
+
+    def test_generate_docx_report(self):
+        yaml_content = """
+---
+objects:
+  - users: ALPeopleList
+---
+question: |
+  User Info
+fields:
+  - First Name: users[i].name.first
+  - Case Number: case_number
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_docx = os.path.join(tmpdir, "report.docx")
+            res = generate_variable_report([yaml_content], output_docx_path=out_docx, infer_assemblyline=True)
+            self.assertTrue(os.path.exists(res["docx_path"]))
+            self.assertGreater(os.path.getsize(res["docx_path"]), 0)
+
+    def test_api_payload_from_options(self):
+        payload = variable_report_payload_from_options(
+            {
+                "yaml_text": "question:\n  User Info\nfields:\n  - Name: users[i].name.first\n",
+                "report_title": "Custom Title",
+            }
+        )
+        self.assertIn("Custom Title", payload["mako_markdown"])
+        self.assertGreater(payload["variables_count"], 0)
+
+    @patch("docassemble.ALDashboard.variable_report_generator._get_playground_storage")
+    def test_save_variable_report_to_playground(self, mock_storage):
+        mock_area = MagicMock()
+        mock_storage.return_value = (mock_area, "/tmp/fake_proj")
+
+        res = save_variable_report_to_playground(
+            mako_markdown="# Report",
+            selected_playground_project="default",
+            save_format_choice="markdown",
+            md_filename="test_report.md",
+        )
+        self.assertTrue(res["saved"])
+        self.assertIn("test_report.md", res["saved_files"])
+        mock_area.write_content.assert_called_once_with(
+            "# Report",
+            filename="test_report.md",
+            project="default",
+            save=False,
+        )
+        mock_area.finalize.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALDashboard/variable_report_generator.py
+++ b/docassemble/ALDashboard/variable_report_generator.py
@@ -13,7 +13,7 @@ try:
     from docx.enum.text import WD_ALIGN_PARAGRAPH
     from docx.shared import Inches, Pt, RGBColor
 except ImportError:
-    docx = None
+    docx = None  # type: ignore[assignment]
 
 # System variables to skip in user-facing intake outputs
 SKIP_SYSTEM_VARS: Set[str] = {
@@ -316,7 +316,7 @@ def extract_interview_questions_and_variables(
                 fields = doc.get("fields")
                 if isinstance(fields, list):
                     for f in fields:
-                        var_name = None
+                        var_name: Optional[str] = None
                         label = ""
                         datatype = "text"
                         if isinstance(f, str):

--- a/docassemble/ALDashboard/variable_report_generator.py
+++ b/docassemble/ALDashboard/variable_report_generator.py
@@ -316,17 +316,17 @@ def extract_interview_questions_and_variables(
                 fields = doc.get("fields")
                 if isinstance(fields, list):
                     for f in fields:
-                        var_name: Optional[str] = None
+                        field_var_name: Optional[str] = None
                         label = ""
                         datatype = "text"
                         if isinstance(f, str):
-                            var_name = f.strip()
+                            field_var_name = f.strip()
                         elif isinstance(f, Mapping):
                             if "note" in f and "field" not in f:
                                 continue
                             datatype = str(f.get("datatype") or "text").strip().lower()
                             if "field" in f and isinstance(f["field"], str):
-                                var_name = f["field"].strip()
+                                field_var_name = f["field"].strip()
                                 label = str(f.get("label") or f.get("note") or "").strip()
                             else:
                                 reserved_keys = {
@@ -339,21 +339,21 @@ def extract_interview_questions_and_variables(
                                     if str(k).strip().lower() in reserved_keys:
                                         continue
                                     if isinstance(v, str) and re.match(r"^[a-zA-Z_][a-zA-Z0-9_\[\]\.]*$", v.strip()):
-                                        var_name = v.strip()
+                                        field_var_name = v.strip()
                                         label = str(k).strip()
                                         break
                                     elif isinstance(k, str) and re.match(r"^[a-zA-Z_][a-zA-Z0-9_\[\]\.]*$", str(k).strip()) and (v is None or isinstance(v, (str, bool, int, float))):
-                                        var_name = str(k).strip()
+                                        field_var_name = str(k).strip()
                                         if isinstance(v, str):
                                             label = v.strip()
                                         break
 
-                        if var_name and var_name not in SKIP_SYSTEM_VARS:
-                            list_match = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)(?:\[.*?\]|\.(.+))?", var_name)
+                        if field_var_name and field_var_name not in SKIP_SYSTEM_VARS:
+                            list_match = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)(?:\[.*?\]|\.(.+))?", field_var_name)
                             if list_match:
                                 base_list = list_match.group(1)
                                 attr = list_match.group(2) or ""
-                                has_index_or_dot = "[" in var_name or "." in var_name
+                                has_index_or_dot = "[" in field_var_name or "." in field_var_name
 
                                 if has_index_or_dot:
                                     if attr and attr not in NOISE_LIST_ATTRS:
@@ -373,22 +373,22 @@ def extract_interview_questions_and_variables(
                                     else:
                                         variables[base_list].is_list = True
                                 else:
-                                    referenced_var_names.add(var_name)
-                                    if var_name not in variables:
-                                        variables[var_name] = VariableSpec(
-                                            name=var_name,
+                                    referenced_var_names.add(field_var_name)
+                                    if field_var_name not in variables:
+                                        variables[field_var_name] = VariableSpec(
+                                            name=field_var_name,
                                             var_type=datatype,
                                             is_list=False,
-                                            label=label or var_name.replace("_", " ").title(),
+                                            label=label or field_var_name.replace("_", " ").title(),
                                             source="yaml_fields",
                                         )
-                                    elif label and not variables[var_name].label:
-                                        variables[var_name].label = label
+                                    elif label and not variables[field_var_name].label:
+                                        variables[field_var_name].label = label
 
                                     group.fields.append(
                                         FieldSpec(
-                                            var_name=var_name,
-                                            label=label or var_name.replace("_", " ").title(),
+                                            var_name=field_var_name,
+                                            label=label or field_var_name.replace("_", " ").title(),
                                             datatype=datatype,
                                         )
                                     )

--- a/docassemble/ALDashboard/variable_report_generator.py
+++ b/docassemble/ALDashboard/variable_report_generator.py
@@ -1,0 +1,924 @@
+import html
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
+
+from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
+
+try:
+    import docx
+    from docx.enum.table import WD_ALIGN_VERTICAL, WD_TABLE_ALIGNMENT
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Inches, Pt, RGBColor
+except ImportError:
+    docx = None
+
+# System variables to skip in user-facing intake outputs
+SKIP_SYSTEM_VARS: Set[str] = {
+    "al_form_type",
+    "interview_short_title",
+    "al_intro_screen",
+    "acknowledged_information_use",
+    "interview_metadata",
+    "form_approved_for_email_filing",
+    "user_started_case",
+    "nav",
+    "menu_items",
+    "AL_ORGANIZATION_TITLE",
+    "session_local",
+    "device_local",
+    "user_local",
+    "url_args",
+    "cron_hourly",
+    "cron_daily",
+    "cron_weekly",
+    "cron_monthly",
+    "incoming_email",
+    "role_needed",
+    "speak_text",
+    "track_location",
+    "multi_user",
+    "allow_cron",
+    "basic_questions_intro_screen",
+}
+
+# Internal noise list attributes to filter out
+NOISE_LIST_ATTRS: Set[str] = {
+    "add_action",
+    "revisit",
+    "table",
+    "there_is_another",
+    "there_are_any",
+    "target_number",
+    "ask_number",
+    "gathered",
+    "auto_gather",
+    "complete",
+    "instanceName",
+    "elements",
+    "parent",
+    "attr_name",
+    "has_no_address",
+    "impounded",
+}
+
+# AssemblyLine built-in lists
+COMMON_AL_PEOPLE_LISTS: Set[str] = {
+    "users",
+    "children",
+    "plaintiff",
+    "defendants",
+    "other_parties",
+    "witnesses",
+    "caregivers",
+    "guardians_ad_litem",
+    "attorneys",
+    "translators",
+    "debt_collectors",
+    "creditors",
+    "spouses",
+    "parents",
+    "decedents",
+    "interested_parties",
+    "guardians",
+    "adoptees",
+}
+
+DEFAULT_INDIVIDUAL_ATTRIBUTES: List[Tuple[str, str, str]] = [
+    ("name", "text", "Full Name"),
+    ("address", "text", "Address"),
+    ("birthdate", "date", "Birthdate"),
+    ("email", "email", "Email Address"),
+    ("phone_number", "text", "Phone Number"),
+]
+
+
+@dataclass
+class AttributeSpec:
+    name: str
+    datatype: str = "text"
+    description: str = ""
+
+
+@dataclass
+class VariableSpec:
+    name: str
+    var_type: str = "unknown"
+    is_list: bool = False
+    label: str = ""
+    attributes: List[AttributeSpec] = field(default_factory=list)
+    source: str = "yaml"
+
+
+@dataclass
+class FieldSpec:
+    var_name: str
+    label: str
+    datatype: str = "text"
+    is_list: bool = False
+    list_name: str = ""
+    attr_name: str = ""
+
+
+@dataclass
+class QuestionGroupSpec:
+    question_id: str
+    title: str
+    fields: List[FieldSpec] = field(default_factory=list)
+    lists: List[VariableSpec] = field(default_factory=list)
+
+
+def list_variable_report_playground_projects() -> List[str]:
+    from .interview_linter import list_playground_projects
+
+    return list_playground_projects()
+
+
+def list_variable_report_playground_yaml_files(
+    project: str = "default",
+) -> List[Dict[str, str]]:
+    from .yaml_formatter import list_formatter_playground_yaml_files
+
+    return list_formatter_playground_yaml_files(project)
+
+
+def _get_playground_storage(project: str, section: str = "playground") -> Tuple[Any, str]:
+    from .docassemble_compat import SavedFile, directory_for
+    from .interview_linter import _resolve_current_user_id
+
+    current_user_id = _resolve_current_user_id()
+    if current_user_id is None:
+        raise ValueError("Could not determine current user for playground access.")
+
+    playground_area = SavedFile(current_user_id, fix=True, section=section)
+    project_root = directory_for(playground_area, project)
+    if not project_root:
+        raise ValueError("Could not locate selected playground project.")
+    os.makedirs(project_root, exist_ok=True)
+    return playground_area, os.path.realpath(project_root)
+
+
+def _load_yaml_documents(yaml_text: str) -> List[Dict[str, Any]]:
+    yaml = YAML(typ="safe", pure=True)
+    docs: List[Dict[str, Any]] = []
+
+    # First attempt full load_all
+    try:
+        for doc in yaml.load_all(StringIO(yaml_text)):
+            if isinstance(doc, dict):
+                docs.append(doc)
+        return docs
+    except Exception:
+        pass
+
+    # Resilient fallback: split by document separators and parse blocks individually
+    raw_blocks = re.split(r"^---\s*$", str(yaml_text or ""), flags=re.MULTILINE)
+    for block in raw_blocks:
+        if not block.strip():
+            continue
+        try:
+            doc = yaml.load(StringIO(block))
+            if isinstance(doc, dict):
+                docs.append(doc)
+        except Exception:
+            try:
+                # Replace tabs with spaces for YAML tab indentation syntax errors
+                cleaned_block = block.replace("\t", "    ")
+                doc = yaml.load(StringIO(cleaned_block))
+                if isinstance(doc, dict):
+                    docs.append(doc)
+            except Exception:
+                pass
+
+    return docs
+
+
+def _load_assemblyline_baseline() -> Dict[str, VariableSpec]:
+    baseline_specs: Dict[str, VariableSpec] = {}
+
+    for list_name in COMMON_AL_PEOPLE_LISTS:
+        attrs = [
+            AttributeSpec(name=attr_name, datatype=dtype, description=desc)
+            for attr_name, dtype, desc in DEFAULT_INDIVIDUAL_ATTRIBUTES
+        ]
+        baseline_specs[list_name] = VariableSpec(
+            name=list_name,
+            var_type="ALPeopleList",
+            is_list=True,
+            label=list_name.replace("_", " ").title(),
+            attributes=attrs,
+            source="inferred_assemblyline",
+        )
+
+    # Load ql_baseline.yml if present
+    baseline_path = os.path.expanduser(
+        "~/docassemble-AssemblyLine/docassemble/AssemblyLine/data/questions/ql_baseline.yml"
+    )
+    if os.path.exists(baseline_path):
+        try:
+            with open(baseline_path, "r", encoding="utf-8") as f:
+                docs = _load_yaml_documents(f.read())
+            for doc in docs:
+                objects = doc.get("objects")
+                if isinstance(objects, list):
+                    for item in objects:
+                        if isinstance(item, Mapping):
+                            for var_name, class_info in item.items():
+                                name_str = str(var_name).strip()
+                                class_str = str(class_info).strip()
+                                if name_str in SKIP_SYSTEM_VARS:
+                                    continue
+                                is_list = "ALPeopleList" in class_str or "DAList" in class_str or "List" in class_str
+                                if is_list and name_str not in baseline_specs:
+                                    attrs = (
+                                        [
+                                            AttributeSpec(name=a[0], datatype=a[1], description=a[2])
+                                            for a in DEFAULT_INDIVIDUAL_ATTRIBUTES
+                                        ]
+                                        if "ALPeopleList" in class_str
+                                        else [AttributeSpec(name="item", datatype="text", description="Item")]
+                                    )
+                                    baseline_specs[name_str] = VariableSpec(
+                                        name=name_str,
+                                        var_type=class_str,
+                                        is_list=True,
+                                        label=name_str.replace("_", " ").title(),
+                                        attributes=attrs,
+                                        source="inferred_assemblyline",
+                                    )
+        except Exception:
+            pass
+
+    return baseline_specs
+
+
+def _clean_var_name(name: str) -> str:
+    cleaned = re.sub(r"\[.*?\]", "", str(name or "")).strip()
+    return cleaned
+
+
+def _clean_title(raw: str) -> str:
+    title = str(raw or "").strip()
+    title = re.sub(r"\$\{.*?\}", "", title).strip()
+    title = title.strip("# \t\r\n:")
+    return title or "Interview Screen"
+
+
+def extract_interview_questions_and_variables(
+    yaml_texts: List[str],
+    infer_assemblyline: bool = True,
+) -> Tuple[List[QuestionGroupSpec], Dict[str, VariableSpec]]:
+    baseline_al = _load_assemblyline_baseline() if infer_assemblyline else {}
+    variables: Dict[str, VariableSpec] = {}
+    groups: List[QuestionGroupSpec] = []
+
+    list_attributes_found: Dict[str, Set[Tuple[str, str]]] = {}
+    referenced_var_names: Set[str] = set()
+
+    for yaml_text in yaml_texts:
+        docs = _load_yaml_documents(yaml_text)
+        for doc in docs:
+            # 1. Parse objects block
+            objects = doc.get("objects")
+            if isinstance(objects, list):
+                for obj_entry in objects:
+                    if isinstance(obj_entry, Mapping):
+                        for raw_var, class_info in obj_entry.items():
+                            var_name = _clean_var_name(str(raw_var))
+                            if var_name in SKIP_SYSTEM_VARS:
+                                continue
+                            class_str = str(class_info)
+                            is_list = any(
+                                k in class_str
+                                for k in ("ALPeopleList", "DAList", "ALList", "list", "DADict")
+                            )
+                            if var_name not in variables:
+                                variables[var_name] = VariableSpec(
+                                    name=var_name,
+                                    var_type=class_str,
+                                    is_list=is_list,
+                                    label=var_name.replace("_", " ").title(),
+                                    source="yaml_objects",
+                                )
+                            else:
+                                variables[var_name].var_type = class_str
+                                if is_list:
+                                    variables[var_name].is_list = True
+
+            # 2. Parse question screen
+            if "question" in doc or "fields" in doc or "id" in doc:
+                q_title = _clean_title(doc.get("question") or doc.get("id") or "Interview Screen")
+                q_id = str(doc.get("id") or "screen").strip()
+                group = QuestionGroupSpec(question_id=q_id, title=q_title)
+
+                fields = doc.get("fields")
+                if isinstance(fields, list):
+                    for f in fields:
+                        var_name = None
+                        label = ""
+                        datatype = "text"
+                        if isinstance(f, str):
+                            var_name = f.strip()
+                        elif isinstance(f, Mapping):
+                            if "note" in f and "field" not in f:
+                                continue
+                            datatype = str(f.get("datatype") or "text").strip().lower()
+                            if "field" in f and isinstance(f["field"], str):
+                                var_name = f["field"].strip()
+                                label = str(f.get("label") or f.get("note") or "").strip()
+                            else:
+                                reserved_keys = {
+                                    "datatype", "choices", "help", "hint", "note", "label",
+                                    "required", "default", "disable_others", "input type",
+                                    "show if", "hide if", "rows", "code", "validation code",
+                                    "address autocomplete", "js_show_if", "grid", "buttons"
+                                }
+                                for k, v in f.items():
+                                    if str(k).strip().lower() in reserved_keys:
+                                        continue
+                                    if isinstance(v, str) and re.match(r"^[a-zA-Z_][a-zA-Z0-9_\[\]\.]*$", v.strip()):
+                                        var_name = v.strip()
+                                        label = str(k).strip()
+                                        break
+                                    elif isinstance(k, str) and re.match(r"^[a-zA-Z_][a-zA-Z0-9_\[\]\.]*$", str(k).strip()) and (v is None or isinstance(v, (str, bool, int, float))):
+                                        var_name = str(k).strip()
+                                        if isinstance(v, str):
+                                            label = v.strip()
+                                        break
+
+                        if var_name and var_name not in SKIP_SYSTEM_VARS:
+                            list_match = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)(?:\[.*?\]|\.(.+))?", var_name)
+                            if list_match:
+                                base_list = list_match.group(1)
+                                attr = list_match.group(2) or ""
+                                has_index_or_dot = "[" in var_name or "." in var_name
+
+                                if has_index_or_dot:
+                                    if attr and attr not in NOISE_LIST_ATTRS:
+                                        referenced_var_names.add(base_list)
+                                        if base_list not in list_attributes_found:
+                                            list_attributes_found[base_list] = set()
+                                        list_attributes_found[base_list].add((attr, datatype))
+
+                                    if base_list not in variables:
+                                        variables[base_list] = VariableSpec(
+                                            name=base_list,
+                                            var_type="DAList",
+                                            is_list=True,
+                                            label=base_list.replace("_", " ").title(),
+                                            source="yaml_fields",
+                                        )
+                                    else:
+                                        variables[base_list].is_list = True
+                                else:
+                                    referenced_var_names.add(var_name)
+                                    if var_name not in variables:
+                                        variables[var_name] = VariableSpec(
+                                            name=var_name,
+                                            var_type=datatype,
+                                            is_list=False,
+                                            label=label or var_name.replace("_", " ").title(),
+                                            source="yaml_fields",
+                                        )
+                                    elif label and not variables[var_name].label:
+                                        variables[var_name].label = label
+
+                                    group.fields.append(
+                                        FieldSpec(
+                                            var_name=var_name,
+                                            label=label or var_name.replace("_", " ").title(),
+                                            datatype=datatype,
+                                        )
+                                    )
+
+                if group.fields:
+                    groups.append(group)
+
+            # 3. Find references in templates/code
+            doc_str = str(doc)
+            for var_match in re.finditer(r"\b([a-zA-Z_][a-zA-Z0-9_]*)(?:\[.*?\]|\.([a-zA-Z0-9_\.]+))?\b", doc_str):
+                b_name = var_match.group(1)
+                b_attr = var_match.group(2)
+                if b_name not in SKIP_SYSTEM_VARS and b_name not in ("True", "False", "None", "len", "str", "int", "dict", "list", "and", "or", "not", "if", "else", "endif", "for", "in", "endfor", "include", "fields", "question", "subquestion", "id", "mandatory", "code"):
+                    referenced_var_names.add(b_name)
+                    if b_attr and b_attr not in NOISE_LIST_ATTRS:
+                        if b_name not in list_attributes_found:
+                            list_attributes_found[b_name] = set()
+                        list_attributes_found[b_name].add((b_attr, "text"))
+
+    # Infer built-ins for referenced AL objects
+    if infer_assemblyline:
+        for ref in referenced_var_names:
+            if ref in baseline_al and ref not in SKIP_SYSTEM_VARS:
+                al_spec = baseline_al[ref]
+                if ref not in variables:
+                    variables[ref] = VariableSpec(
+                        name=al_spec.name,
+                        var_type=al_spec.var_type,
+                        is_list=al_spec.is_list,
+                        label=al_spec.label,
+                        attributes=list(al_spec.attributes),
+                        source="inferred_assemblyline",
+                    )
+                else:
+                    if variables[ref].var_type in ("unknown", "text", "DAList") and al_spec.var_type != "unknown":
+                        variables[ref].var_type = al_spec.var_type
+                    if al_spec.is_list:
+                        variables[ref].is_list = True
+                    if not variables[ref].attributes and al_spec.attributes:
+                        variables[ref].attributes = list(al_spec.attributes)
+
+    # Filter out internal list attributes and assign clean attributes
+    for var_name, spec in variables.items():
+        if spec.is_list:
+            filtered_attrs = [a for a in spec.attributes if a.name not in NOISE_LIST_ATTRS]
+            existing_attrs = {a.name for a in filtered_attrs}
+
+            if var_name in list_attributes_found:
+                for attr_name, dtype in sorted(list_attributes_found[var_name]):
+                    if attr_name not in NOISE_LIST_ATTRS and attr_name not in existing_attrs:
+                        filtered_attrs.append(
+                            AttributeSpec(
+                                name=attr_name,
+                                datatype=dtype,
+                                description=attr_name.replace("_", " ").replace(".", " ").title(),
+                            )
+                        )
+                        existing_attrs.add(attr_name)
+
+            if not filtered_attrs:
+                if "People" in spec.var_type or var_name in COMMON_AL_PEOPLE_LISTS:
+                    filtered_attrs = [
+                        AttributeSpec(name=a[0], datatype=a[1], description=a[2])
+                        for a in DEFAULT_INDIVIDUAL_ATTRIBUTES
+                    ]
+                else:
+                    filtered_attrs = [AttributeSpec(name="item", datatype="text", description="Item")]
+
+            spec.attributes = filtered_attrs
+
+    # Attach list variables to groups or to an Objects & Parties group
+    assigned_lists: Set[str] = set()
+    for g in groups:
+        for var_name, spec in variables.items():
+            if spec.is_list and var_name not in assigned_lists:
+                # Check if this list was referenced in this group's screen
+                if any(f.var_name.startswith(var_name) for f in g.fields) or var_name in g.title.lower():
+                    g.lists.append(spec)
+                    assigned_lists.add(var_name)
+
+    unassigned_lists = [v for k, v in variables.items() if v.is_list and k not in assigned_lists]
+    if unassigned_lists:
+        groups.append(
+            QuestionGroupSpec(
+                question_id="parties_objects",
+                title="Parties and Lists",
+                lists=unassigned_lists,
+            )
+        )
+
+    return groups, variables
+
+
+def generate_mako_markdown_report(
+    groups: List[QuestionGroupSpec],
+    variables: Dict[str, VariableSpec],
+    report_title: Optional[str] = None,
+    show_variable_names: bool = False,
+    show_variable_types: bool = False,
+    max_list_cols: int = 4,
+) -> str:
+    title = report_title or "Interview Document Draft"
+
+    lines: List[str] = []
+    lines.append(f"# {title}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for group in groups:
+        if not group.fields and not group.lists:
+            continue
+
+        lines.append(f"## {group.title}")
+        lines.append("")
+
+        if group.fields:
+            lines.append("| Field | Value |")
+            lines.append("| --- | --- |")
+            for fspec in group.fields:
+                disp_label = fspec.label
+                if show_variable_names:
+                    disp_label += f" (`{fspec.var_name}`)"
+                if show_variable_types:
+                    disp_label += f" [{fspec.datatype}]"
+
+                if fspec.datatype in ("yesno", "boolean"):
+                    val_expr = f"% if showifdef('{fspec.var_name}'): Yes % else: No % endif"
+                else:
+                    val_expr = f"${{ showifdef('{fspec.var_name}') }}"
+                lines.append(f"| {disp_label} | {val_expr} |")
+            lines.append("")
+
+        if group.lists:
+            for lvar in group.lists:
+                disp_title = lvar.label or lvar.name
+                if show_variable_names:
+                    disp_title += f" (`{lvar.name}`)"
+                if show_variable_types:
+                    disp_title += f" [{lvar.var_type}]"
+
+                lines.append(f"### {disp_title}")
+                lines.append("")
+
+                attrs = [a for a in lvar.attributes if a.name not in NOISE_LIST_ATTRS] or [AttributeSpec(name="item", datatype="text", description="Item")]
+
+                if len(attrs) <= max_list_cols:
+                    # Horizontal table format
+                    header_row = "| # | " + " | ".join([a.description or a.name for a in attrs]) + " |"
+                    sep_row = "| --- | " + " | ".join(["---"] * len(attrs)) + " |"
+                    lines.append(header_row)
+                    lines.append(sep_row)
+
+                    lines.append(f"% if showifdef('{lvar.name}'):")
+                    lines.append(f"% for i, item in enumerate({lvar.name}):")
+
+                    item_cells = []
+                    for a in attrs:
+                        if a.name == "item":
+                            item_cells.append(f"${{ showifdef(f'{lvar.name}[{{i}}]') }}")
+                        else:
+                            item_cells.append(f"${{ showifdef(item.attr_name('{a.name}')) }}")
+
+                    lines.append("| ${ i + 1 } | " + " | ".join(item_cells) + " |")
+                    lines.append("% endfor")
+                    lines.append("% else:")
+
+                    sample_cells = [f"Sample {a.description or a.name}" for a in attrs]
+                    lines.append("| 1 | " + " | ".join(sample_cells) + " |")
+                    lines.append("% endif")
+                    lines.append("")
+                else:
+                    # Vertical person-by-person format for wide lists
+                    lines.append(f"% if showifdef('{lvar.name}'):")
+                    lines.append(f"% for i, item in enumerate({lvar.name}):")
+                    lines.append(f"#### Person ${{ i + 1 }}")
+                    for a in attrs:
+                        desc = a.description or a.name
+                        if a.name == "item":
+                            expr = f"${{ showifdef(f'{lvar.name}[{{i}}]') }}"
+                        else:
+                            expr = f"${{ showifdef(item.attr_name('{a.name}')) }}"
+                        lines.append(f"- **{desc}:** {expr}")
+                    lines.append("")
+                    lines.append("% endfor")
+                    lines.append("% else:")
+                    lines.append("*No items listed.*")
+                    lines.append("% endif")
+                    lines.append("")
+
+        lines.append("---")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_docx_report(
+    groups: List[QuestionGroupSpec],
+    variables: Dict[str, VariableSpec],
+    report_title: Optional[str] = None,
+    output_path: Optional[str] = None,
+    show_variable_names: bool = False,
+    show_variable_types: bool = False,
+    max_list_cols: int = 4,
+) -> str:
+    if docx is None:
+        raise RuntimeError("python-docx is not installed in the python environment.")
+
+    title = report_title or "Interview Document Draft"
+    doc = docx.Document()
+
+    p_title = doc.add_heading(title, level=1)
+    p_title.alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+    for group in groups:
+        if not group.fields and not group.lists:
+            continue
+
+        doc.add_heading(group.title, level=2)
+
+        if group.fields:
+            table = doc.add_table(rows=1, cols=2)
+            table.alignment = WD_TABLE_ALIGNMENT.CENTER
+
+            hdr_cells = table.rows[0].cells
+            hdr_cells[0].text = "Field"
+            hdr_cells[1].text = "Value"
+
+            for fspec in group.fields:
+                row_cells = table.add_row().cells
+                disp_label = fspec.label
+                if show_variable_names:
+                    disp_label += f" ({fspec.var_name})"
+                if show_variable_types:
+                    disp_label += f" [{fspec.datatype}]"
+
+                row_cells[0].text = disp_label
+                if fspec.datatype in ("yesno", "boolean"):
+                    row_cells[1].text = f"{{% if showifdef('{fspec.var_name}') %}}Yes{{% else %}}No{{% endif %}}"
+                else:
+                    row_cells[1].text = f"{{{{ showifdef('{fspec.var_name}') }}}}"
+
+            doc.add_paragraph()
+
+        if group.lists:
+            for lvar in group.lists:
+                disp_title = lvar.label or lvar.name
+                if show_variable_names:
+                    disp_title += f" ({lvar.name})"
+                if show_variable_types:
+                    disp_title += f" [{lvar.var_type}]"
+
+                doc.add_heading(disp_title, level=3)
+
+                attrs = [a for a in lvar.attributes if a.name not in NOISE_LIST_ATTRS] or [AttributeSpec(name="item", datatype="text", description="Item")]
+
+                if len(attrs) <= max_list_cols:
+                    # Horizontal table format with standalone {%tr for %} and {%tr endfor %} rows
+                    cols_count = len(attrs) + 1
+                    table = doc.add_table(rows=4, cols=cols_count)
+                    table.alignment = WD_TABLE_ALIGNMENT.CENTER
+
+                    # Row 0: Headers
+                    hdr_cells = table.rows[0].cells
+                    hdr_cells[0].text = "#"
+                    for i, a in enumerate(attrs, start=1):
+                        hdr_cells[i].text = a.description or a.name
+
+                    # Row 1: Standalone Loop Start Row
+                    loop_start_cells = table.rows[1].cells
+                    loop_start_cells[0].text = f"{{%tr for item in showifdef('{lvar.name}') %}}"
+
+                    # Row 2: Data Row
+                    data_cells = table.rows[2].cells
+                    data_cells[0].text = "{{ loop.index }}"
+                    for i, a in enumerate(attrs, start=1):
+                        if a.name == "item":
+                            tag = "{{ item }}"
+                        else:
+                            tag = f"{{{{ showifdef(item.attr_name('{a.name}')) }}}}"
+                        data_cells[i].text = tag
+
+                    # Row 3: Standalone Loop End Row
+                    loop_end_cells = table.rows[3].cells
+                    loop_end_cells[0].text = "{%tr endfor %}"
+
+                    doc.add_paragraph()
+                else:
+                    # Vertical person-by-person format for wide lists
+                    p_loop_start = doc.add_paragraph(f"{{%p for item in showifdef('{lvar.name}') %}}")
+                    doc.add_heading("Person {{ loop.index }}", level=4)
+
+                    table = doc.add_table(rows=0, cols=2)
+                    table.alignment = WD_TABLE_ALIGNMENT.CENTER
+
+                    for a in attrs:
+                        row_cells = table.add_row().cells
+                        row_cells[0].text = a.description or a.name
+                        if a.name == "item":
+                            row_cells[1].text = "{{ item }}"
+                        else:
+                            row_cells[1].text = f"{{{{ showifdef(item.attr_name('{a.name}')) }}}}"
+
+                    doc.add_paragraph(f"{{%p endfor %}}")
+                    doc.add_paragraph()
+
+    if output_path:
+        doc.save(output_path)
+        return output_path
+    else:
+        temp_dir = os.path.join(os.getcwd(), "tmp")
+        os.makedirs(temp_dir, exist_ok=True)
+        out_file = os.path.join(temp_dir, "variable_report_draft.docx")
+        doc.save(out_file)
+        return out_file
+
+
+def generate_variable_report(
+    yaml_texts: List[str],
+    report_title: Optional[str] = None,
+    infer_assemblyline: bool = True,
+    show_variable_names: bool = False,
+    show_variable_types: bool = False,
+    max_list_cols: int = 4,
+    output_docx_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    groups, variables = extract_interview_questions_and_variables(
+        yaml_texts, infer_assemblyline=infer_assemblyline
+    )
+    mako_markdown = generate_mako_markdown_report(
+        groups,
+        variables,
+        report_title=report_title,
+        show_variable_names=show_variable_names,
+        show_variable_types=show_variable_types,
+        max_list_cols=max_list_cols,
+    )
+    docx_file_path = generate_docx_report(
+        groups,
+        variables,
+        report_title=report_title,
+        output_path=output_docx_path,
+        show_variable_names=show_variable_names,
+        show_variable_types=show_variable_types,
+        max_list_cols=max_list_cols,
+    )
+
+    list_count = sum(1 for v in variables.values() if v.is_list)
+    scalar_count = sum(1 for v in variables.values() if not v.is_list)
+
+    return {
+        "variables": variables,
+        "groups": groups,
+        "mako_markdown": mako_markdown,
+        "docx_path": docx_file_path,
+        "variables_count": len(variables),
+        "list_count": list_count,
+        "scalar_count": scalar_count,
+    }
+
+
+def save_variable_report_to_playground(
+    mako_markdown: Optional[str] = None,
+    docx_path: Optional[str] = None,
+    *,
+    selected_playground_project: str = "default",
+    save_format_choice: str = "both",
+    md_filename: str = "interview_document_draft.md",
+    docx_filename: str = "interview_document_draft.docx",
+    output_filename: Optional[str] = None,  # Backward compatibility
+) -> Dict[str, Any]:
+    project = str(selected_playground_project or "default")
+    if output_filename and not md_filename:
+        md_filename = output_filename
+
+    result: Dict[str, Any] = {
+        "saved_md": False,
+        "saved_docx": False,
+        "saved_files": [],
+        "saved": False,
+        "error": None,
+        "errors": [],
+    }
+
+    try:
+        # 1. Save Markdown (.md) to playground questions area (section="playground")
+        if save_format_choice in ("both", "markdown") and mako_markdown:
+            try:
+                playground_area, _ = _get_playground_storage(project, section="playground")
+                playground_area.write_content(
+                    str(mako_markdown or ""),
+                    filename=md_filename,
+                    project=project,
+                    save=False,
+                )
+                playground_area.finalize()
+                result["saved_md"] = True
+                result["saved_files"].append(md_filename)
+            except Exception as err:
+                result["errors"].append(f"Failed to save Markdown file '{md_filename}': {err}")
+
+        # 2. Save DOCX (.docx) to playground templates area (section="playgroundtemplate")
+        if save_format_choice in ("both", "docx") and docx_path and os.path.isfile(docx_path):
+            try:
+                template_area, the_directory = _get_playground_storage(project, section="playgroundtemplate")
+                filepath = os.path.join(the_directory, docx_filename)
+                with open(docx_path, "rb") as src, open(filepath, "wb") as dst:
+                    dst.write(src.read())
+                template_area.finalize()
+                result["saved_docx"] = True
+                result["saved_files"].append(docx_filename)
+            except Exception as err:
+                result["errors"].append(f"Failed to save DOCX file '{docx_filename}': {err}")
+
+        result["saved"] = result["saved_md"] or result["saved_docx"]
+        if result["errors"]:
+            result["error"] = "; ".join(result["errors"])
+
+    except Exception as err:
+        result["error"] = str(err)
+
+    return result
+
+
+def extract_interview_metadata_info(
+    yaml_texts: List[str],
+    primary_filename: Optional[str] = None,
+) -> Dict[str, str]:
+    short_title = None
+    for yaml_text in yaml_texts:
+        if not yaml_text:
+            continue
+        # 1. Match code block assignment: interview_short_title = "..."
+        m = re.search(r"interview_short_title\s*=\s*[\"']([^\"']+)[\"']", yaml_text)
+        if m:
+            short_title = m.group(1).strip()
+            break
+        # 2. Match YAML key: interview_short_title: ...
+        m2 = re.search(r"^interview_short_title:\s*([^\n#]+)", yaml_text, re.MULTILINE)
+        if m2:
+            short_title = m2.group(1).strip().strip("\"'")
+            break
+
+    def _slugify(text: str) -> str:
+        s = re.sub(r"[^\w\s-]", "", str(text or "")).strip().lower()
+        return re.sub(r"[-\s]+", "_", s)
+
+    if short_title:
+        base_name = _slugify(short_title)
+        display_title = f"{short_title} Draft"
+    elif primary_filename:
+        clean_file = primary_filename.split("/")[-1].rsplit(".", 1)[0]
+        base_name = _slugify(clean_file)
+        display_title = f"{clean_file.replace('_', ' ').replace('-', ' ').title()} Draft"
+    else:
+        base_name = "interview_document"
+        display_title = "Interview Document Draft"
+
+    return {
+        "short_title": short_title or "",
+        "display_title": display_title,
+        "md_filename": f"{base_name}_draft.md",
+        "docx_filename": f"{base_name}_draft.docx",
+    }
+
+
+def get_playground_yaml_texts(
+    selected_playground_project: str,
+    selected_filenames: Iterable[str],
+) -> List[str]:
+    project = str(selected_playground_project or "default")
+    filenames = [str(f) for f in selected_filenames]
+    if not filenames:
+        return []
+
+    _, project_root = _get_playground_storage(project, section="playground")
+    yaml_texts: List[str] = []
+    for filename in filenames:
+        source_path = os.path.realpath(os.path.join(project_root, filename))
+        if not source_path.startswith(project_root + os.sep):
+            raise ValueError("Refusing to read files outside selected playground project.")
+        with open(source_path, "r", encoding="utf-8") as f:
+            yaml_texts.append(f.read())
+    return yaml_texts
+
+
+def generate_and_save_playground_variable_report(
+    selected_filenames: Iterable[str],
+    *,
+    selected_playground_project: str,
+    save_to_playground: bool = False,
+    save_playground_project: str = "",
+    save_format_choice: str = "both",
+    md_filename: str = "interview_document_draft.md",
+    docx_filename: str = "interview_document_draft.docx",
+    output_filename: Optional[str] = None,
+    infer_assemblyline: bool = True,
+    show_variable_names: bool = False,
+    show_variable_types: bool = False,
+    max_list_cols: int = 4,
+    report_title: Optional[str] = None,
+) -> Dict[str, Any]:
+    project = str(selected_playground_project or "default")
+    filenames = [str(f) for f in selected_filenames]
+
+    if not filenames:
+        raise ValueError("Select at least one YAML file.")
+
+    yaml_texts = get_playground_yaml_texts(project, filenames)
+
+    res = generate_variable_report(
+        yaml_texts,
+        report_title=report_title,
+        infer_assemblyline=infer_assemblyline,
+        show_variable_names=show_variable_names,
+        show_variable_types=show_variable_types,
+        max_list_cols=max_list_cols,
+    )
+
+    if save_to_playground:
+        save_res = save_variable_report_to_playground(
+            mako_markdown=res["mako_markdown"],
+            docx_path=res["docx_path"],
+            selected_playground_project=save_playground_project or project,
+            save_format_choice=save_format_choice,
+            md_filename=output_filename or md_filename,
+            docx_filename=docx_filename,
+        )
+        res["saved"] = save_res["saved"]
+        res["saved_files"] = save_res["saved_files"]
+        res["save_error"] = save_res["error"]
+
+    return res


### PR DESCRIPTION
Sometimes (especially for an intake-type interview) an author might not have an existing form; in that case, they still might want an output document to go into a client file. This lets you create a draft template based on just the YAML.

It's built on the same theory as the review screen generator.

Fix #45 