### PR TITLE
Fix CI on main under docassemble.base 1.10

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,4 +51,23 @@ def _install_docassemble_webapp_stubs() -> None:
         pass
 
 
+def _preimport_pikepdf() -> None:
+    """Load pikepdf before any test patches ``sys.modules``.
+
+    ``unittest.mock.patch.dict("sys.modules", ...)`` restores the original
+    module dict on exit, dropping anything that was imported for the first
+    time inside the patched block. pikepdf cannot survive a second import in
+    the same process -- its ``@augments`` class patching raises
+    ``RuntimeError: ... both define the same non-abstract method`` -- so a test
+    that first pulls it in transitively (via ``docassemble.base.util``) while
+    ``sys.modules`` is patched would break every later pikepdf import.
+    Importing it up front keeps it in the dict that ``patch.dict`` restores.
+    """
+    try:
+        import pikepdf  # noqa: F401
+    except Exception:  # pragma: no cover - pikepdf is optional at import time
+        pass
+
+
 _install_docassemble_webapp_stubs()
+_preimport_pikepdf()

--- a/conftest.py
+++ b/conftest.py
@@ -69,5 +69,29 @@ def _preimport_pikepdf() -> None:
         pass
 
 
+def _install_empty_docassemble_configuration() -> None:
+    """Make ``get_config()`` usable without a running docassemble server.
+
+    docassemble 1.10 routes ``get_configuration()`` through a pluggy hook that
+    only the webapp registers. Outside a real server the hook has no
+    implementation and returns ``None``, so ``docassemble.base.functions``'s
+    ``get_config()`` dies with ``AttributeError: 'NoneType' object has no
+    attribute 'get'``. ALToolbox's ``llms`` module calls ``get_config`` at
+    import time, which breaks collection of every test that imports
+    ``docx_wrangling``. Fall back to an empty configuration, which is what
+    these tests want anyway.
+    """
+    try:
+        import docassemble.base.functions as da_functions
+    except Exception:
+        return
+
+    try:
+        da_functions.get_config("open ai")
+    except Exception:
+        setattr(da_functions, "get_configuration", lambda: {})
+
+
 _install_docassemble_webapp_stubs()
+_install_empty_docassemble_configuration()
 _preimport_pikepdf()

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -1016,8 +1016,8 @@ def delete_inactive_developer_accounts(
         }:
             raise
         # docassemble < 1.10 keeps these implementations in legacy modules.
-        from docassemble.webapp.server import user_interviews
-        from docassemble.webapp.backend import delete_user_data
+        from docassemble.webapp.server import user_interviews  # type: ignore[no-redef]
+        from docassemble.webapp.backend import delete_user_data  # type: ignore[no-redef]
 
     if requesting_user_id is None:
         requesting_user_id = _resolve_current_user_id()

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -651,12 +651,15 @@ def docx_labeler_suggest_payload_from_options(
             ),
             "judge_review_count": len(judge_review.get("reviews", []) or []),
         }
+        # Server-log priority on purpose: any other priority appends to
+        # `this_thread.message_log`, which docassemble 1.10 only populates
+        # inside an interview request, and these timings are not meant for
+        # the user's screen anyway.
         log(
             "ALDashboard: DOCX suggest-labels timings for "
             + repr(filename)
             + ": "
-            + json.dumps(timings, sort_keys=True),
-            "info",
+            + json.dumps(timings, sort_keys=True)
         )
 
         return {

--- a/docassemble/ALDashboard/interview_linter.py
+++ b/docassemble/ALDashboard/interview_linter.py
@@ -24,8 +24,15 @@ import ruamel.yaml
 import textstat
 from spellchecker import SpellChecker
 
-import docassemble.base.filter
 import docassemble.webapp.screenreader
+
+try:
+    from docassemble.base.filter.html import markdown_to_html
+except ImportError:
+    # docassemble < 1.10 keeps this in a flat `docassemble.base.filter` module.
+    from docassemble.base.filter import (  # type: ignore[no-redef,attr-defined]
+        markdown_to_html,
+    )
 
 try:
     from flask_login import current_user
@@ -550,7 +557,7 @@ def remove_mako(text: str) -> str:
     try:
         template = mako.template.Template(input_text)
         markdown_text = template.render()
-        html_text = docassemble.base.filter.markdown_to_html(markdown_text)
+        html_text = markdown_to_html(markdown_text)
         return docassemble.webapp.screenreader.to_text(html_text)
     except Exception:
         return input_text

--- a/docassemble/ALDashboard/pdf_field_labeler.py
+++ b/docassemble/ALDashboard/pdf_field_labeler.py
@@ -29,7 +29,13 @@ def log(message: str, level: str = "info") -> None:
         from docassemble.base.util import log as da_log
     except ImportError:
         return
-    da_log(message, level)
+    try:
+        da_log(message, level)
+    except Exception:
+        # Any level other than "log" is routed to `this_thread.message_log`,
+        # which docassemble 1.10 only populates inside a request. Diagnostics
+        # must never take down the labeling call that emitted them.
+        pass
 
 
 def _assert_valid_pdf_output(pdf_path: str, *, action_label: str) -> None:


### PR DESCRIPTION
`main` has been red since docassemble.base 1.10 reached the CI resolver ([run on `d659d15`](https://github.com/SuffolkLITLab/docassemble-ALDashboard/actions/runs/30929182131)). Two mypy errors failed the job before the pytest step ever ran, so every branch built on top of `main` inherits a red check — and once mypy passed, three more 1.10 incompatibilities surfaced in pytest.

## mypy

**`interview_linter.py` — real runtime break.** In 1.10, `docassemble.base.filter` became a package and its `__init__.py` is empty; `markdown_to_html` now lives in `docassemble.base.filter.html`. `docassemble.base.filter.markdown_to_html` would raise `AttributeError` at runtime, not just under mypy. Imported from the new location with a fallback to the flat module for docassemble < 1.10.

**`aldashboard.py` — `no-redef`.** `docassemble.base.hooks` resolves for real in 1.10, so the legacy `docassemble.webapp.server` fallback import of `user_interviews` is now a genuine redefinition. Silenced with `# type: ignore[no-redef]`, matching how the other compatibility shims in this file are handled.

## pytest

**`get_configuration()` is now a pluggy hook** that only the webapp registers. Outside a real server it has no implementation and returns `None`, so `get_config()` dies with `AttributeError: 'NoneType' object has no attribute 'get'`. ALToolbox's `llms` module calls `get_config` at import time, which broke collection of both `docx_wrangling` test modules. conftest now falls back to an empty configuration.

**`log(msg, level)` with any level other than `"log"`** appends to `this_thread.message_log`, which 1.10 only populates inside an interview request. `pdf_field_labeler.log()` is a diagnostics helper, so it now swallows the failure rather than taking down the labeling call that emitted it. `api_dashboard_utils` logged its suggest-labels timings at `"info"` and hit the same path; those are server-log diagnostics, not messages for the user's screen, so they now use the default `"log"` priority.

> [!NOTE]
> `api_labelers.py` has ~40 more `log(..., "info")` call sites with the same shape. None are exercised by a test that reaches the real `docassemble.base.util.log` (the endpoint tests stub it), so they are left alone here — but they are worth a look as a follow-up, since under 1.10 they can raise outside an interview request.

**pikepdf pre-import** — separate, latent test-isolation bug found once pytest could actually run. Tests that patch `sys.modules` pull pikepdf in transitively for the first time inside the patched block, and `patch.dict` drops it again on exit. pikepdf cannot be imported twice in one process — its `@augments` class patching raises `RuntimeError: ... both define the same non-abstract method` — so every later pikepdf import in the session fails. Reproducible on `main` with `pytest docassemble/ALDashboard/test/test_pdf_field_labeler.py -k relabel_existing_with_ai`. Pre-importing keeps it in the dict `patch.dict` restores, and drops the full suite from ~137s to ~18s.

## Verification

Run locally against the exact versions CI resolves (docassemble.base 1.10.5, docassemble.ALToolbox 0.18.0, pikepdf 10.1.0):

```
mypy . --exclude '^build/' --explicit-package-bases   →  Success: no issues found in 59 source files
pytest                                                →  375 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
