### PR TITLE
Make the review screen generator safe to re-run over a real interview

### DIFF
--- a/docassemble/ALDashboard/review_screen_generator.py
+++ b/docassemble/ALDashboard/review_screen_generator.py
@@ -6,6 +6,11 @@ from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, LiteralScalarString
 
+# Gathered by AssemblyLine's `basic_questions_signature_flow`, immediately
+# before the download screen, and therefore never something a review table's
+# "Edit" button should ask for.
+SIGNATURE_ATTRIBUTES = {"signature", "signature_date"}
+
 
 def list_review_playground_projects() -> List[str]:
     from .interview_linter import list_playground_projects
@@ -214,7 +219,18 @@ def generate_review_screen_yaml(
     *,
     build_revisit_blocks: bool = True,
     point_sections_to_review: bool = True,
+    review_id: str = "review screen",
+    review_event_name: str = "review_form",
+    review_question: str = "Review your answers",
 ) -> str:
+    """Draft a review screen for one or more interview YAML files.
+
+    ``review_id``, ``review_event_name`` and ``review_question`` name the block
+    that comes out. They matter when the draft is replacing a review screen an
+    interview already has: a generated interview's download screen links to its
+    own ``review_<label>`` event, so a draft that renamed the event to
+    ``review_form`` would quietly break the "Edit answers" button.
+    """
     docs = _load_yaml_documents(yaml_texts)
 
     objects_temp: List[Dict[str, str]] = []
@@ -251,23 +267,21 @@ def generate_review_screen_yaml(
                     except Exception:
                         continue
                     if ".name_fields(" in str(field["code"]):
-                        fields_temp.extend(
-                            [
-                                {"First": f"{object_name}.name.first"},
-                                {"Middle": f"{object_name}.name.middle"},
-                                {"Last": f"{object_name}.name.last"},
-                            ]
+                        # One "Name: Jane Q. Public" line rather than three
+                        # lines of first, middle and last: a review screen is
+                        # read, not filled in.
+                        fields_temp.append(
+                            {
+                                "Name": f"{object_name}.name.first",
+                                "display": f"{object_name}",
+                            }
                         )
                     elif ".address_fields(" in str(field["code"]):
-                        fields_temp.extend(
-                            [
-                                {"Address": f"{object_name}.address.address"},
-                                {"Apartment or Unit": f"{object_name}.address.unit"},
-                                {"City": f"{object_name}.address.city"},
-                                {"State": f"{object_name}.address.state"},
-                                {"Zip": f"{object_name}.address.zip"},
-                                {"Country": f"{object_name}.address.country"},
-                            ]
+                        fields_temp.append(
+                            {
+                                "Address": f"{object_name}.address.address",
+                                "display": f"{object_name}.address.block()",
+                            }
                         )
                     elif ".gender_fields(" in str(field["code"]):
                         fields_temp.append({"Gender": f"{object_name}.gender"})
@@ -318,7 +332,6 @@ def generate_review_screen_yaml(
     questions = questions_temp
     section_events = sections_temp
 
-    review_event_name = "review_form"
     review_fields_temp: List[Dict[str, str]] = []
     revisit_screens: List[Dict[str, str]] = []
     tables: List[Dict[str, Any]] = []
@@ -367,7 +380,7 @@ def generate_review_screen_yaml(
             )
             if obj_name in attributes_list:
                 columns = []
-                edits = []
+                edits: List[str] = []
                 for attribute in attributes_list[obj_name]:
                     attr_key = next(iter(attribute.keys()))
                     attr_value = next(iter(attribute.values()))
@@ -383,13 +396,21 @@ def generate_review_screen_yaml(
                             )
                         }
                     )
-                    edits.append(attr_name)
+                    # Docassemble seeks every variable named under `edit:`,
+                    # defining any the interview never asked. Sending someone
+                    # to a signature pad they did not ask for -- and that
+                    # AssemblyLine's signature flow overwrites moments later --
+                    # is not editing a row.
+                    if attr_name in SIGNATURE_ATTRIBUTES:
+                        continue
+                    if attr_name not in edits:
+                        edits.append(attr_name)
                 tables.append(
                     {
                         "table": f"{obj_name}.table",
                         "rows": obj_name,
                         "columns": columns,
-                        "edit": edits,
+                        "edit": edits if edits else True,
                     }
                 )
 
@@ -427,6 +448,8 @@ def generate_review_screen_yaml(
         "accept",
         "validate",
         "address autocomplete",
+        # Not a Docassemble key: how this generator wants the value shown.
+        "display",
     }
 
     for question in questions:
@@ -471,11 +494,25 @@ def generate_review_screen_yaml(
             if label != "no label":
                 review["button"] += f"{label}: "
 
+            # Whatever the datatype, an undefined variable has to render as
+            # empty. A review screen that sends the user back into the
+            # interview just for looking at their answers is a review screen
+            # with a bug, and `yesno('')` would confidently report "No" for a
+            # question nobody was ever asked.
             datatype = field.get("datatype")
-            if datatype in ["yesno", "yesnoradio", "yesnowide"]:
-                review["button"] += f"${{ word(yesno({value_ref})) }}\n"
+            display = field.get("display")
+            if display:
+                review[
+                    "button"
+                ] += f"${{ {display} if defined('{value_ref}') else '' }}\n"
+            elif datatype in ["yesno", "yesnoradio", "yesnowide"]:
+                review[
+                    "button"
+                ] += f"${{ word(yesno({value_ref})) if defined('{value_ref}') else '' }}\n"
             elif datatype == "currency":
-                review["button"] += f"${{ currency(showifdef('{value_ref}')) }}\n"
+                review[
+                    "button"
+                ] += f"${{ currency({value_ref}) if defined('{value_ref}') else '' }}\n"
             else:
                 review["button"] += f"${{ showifdef('{value_ref}') }}\n"
 
@@ -491,9 +528,11 @@ def generate_review_screen_yaml(
         sections
         + [
             {
-                "id": "review screen",
+                "id": review_id,
                 "event": review_event_name,
-                "question": "Review your answers",
+                "question": LiteralScalarString(
+                    str(review_question).rstrip("\n") + "\n"
+                ),
                 "review": review_fields_temp,
             }
         ]
@@ -503,6 +542,11 @@ def generate_review_screen_yaml(
 
     yaml = YAML()
     yaml.default_flow_style = False
+    # AssemblyLine's house style indents list items under their key, which is
+    # what every hand-written review screen in the ecosystem looks like. The
+    # draft has to be something an author can paste in without reformatting.
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.width = 4096
     stream = StringIO()
     yaml.dump_all(review_yaml, stream)
     return stream.getvalue()

--- a/docassemble/ALDashboard/test/test_review_screen_generator.py
+++ b/docassemble/ALDashboard/test/test_review_screen_generator.py
@@ -29,8 +29,11 @@ sections:
 """
         output = generate_review_screen_yaml([sample])
         self.assertIn("id: review screen", output)
-        self.assertIn("question: Review your answers", output)
+        self.assertIn("question: |\n  Review your answers", output)
         self.assertIn("First name", output)
+        # AssemblyLine's house style: list items indented under their key, the
+        # way every hand-written review screen in the ecosystem looks.
+        self.assertIn("\n  - Edit: ", output)
 
     def test_mapping_form_non_list_object_is_safely_skipped(self):
         sample = """
@@ -194,6 +197,91 @@ objects:
 
         self.assertNotIn("id: revisit user.jobs", output)
         self.assertNotIn("user.jobs.revisit", output)
+
+    def test_the_review_screen_can_take_the_interviews_own_names(self):
+        """A drafted screen has to keep the event the download screen links to."""
+        sample = """
+---
+question: What is your name?
+fields:
+  - First name: users[0].name.first
+"""
+        output = generate_review_screen_yaml(
+            [sample],
+            review_id="my form review screen",
+            review_event_name="review_my_form",
+            review_question="Look over your answers",
+        )
+
+        self.assertIn("id: my form review screen", output)
+        self.assertIn("event: review_my_form", output)
+        self.assertIn("question: |\n  Look over your answers", output)
+        self.assertNotIn("review_form", output)
+
+    def test_a_name_or_an_address_is_one_line_not_six(self):
+        sample = """
+---
+question: Your details
+fields:
+  - code: |
+      client.name_fields()
+  - code: |
+      client.address_fields()
+"""
+        output = generate_review_screen_yaml([sample])
+
+        self.assertIn(
+            "Name: ${ client if defined('client.name.first') else '' }", output
+        )
+        self.assertIn(
+            "Address: ${ client.address.block() "
+            "if defined('client.address.address') else '' }",
+            output,
+        )
+        self.assertNotIn("Middle:", output)
+        self.assertNotIn("Apartment or Unit:", output)
+
+    def test_no_value_on_the_screen_forces_a_variable_to_be_defined(self):
+        sample = """
+---
+question: Money and yes/no
+fields:
+  - Rent: rent_amount
+    datatype: currency
+  - Served: was_served
+    datatype: yesno
+  - Notes: notes
+"""
+        output = generate_review_screen_yaml([sample])
+
+        self.assertIn(
+            "${ currency(rent_amount) if defined('rent_amount') else '' }", output
+        )
+        self.assertIn(
+            "${ word(yesno(was_served)) if defined('was_served') else '' }", output
+        )
+        self.assertIn("${ showifdef('notes') }", output)
+
+    def test_a_review_table_never_asks_for_a_signature(self):
+        sample = """
+---
+objects:
+  - plaintiffs: ALPeopleList
+---
+question: Signatures
+fields:
+  - Signature: plaintiffs[i].signature
+    datatype: signature
+  - Phone: plaintiffs[i].phone_number
+"""
+        output = generate_review_screen_yaml([sample])
+        table = output.split("table: plaintiffs.table", 1)[1]
+        edits = table.split("edit:", 1)[1]
+
+        self.assertNotIn("- signature", edits)
+        self.assertIn("- phone_number", edits)
+        # It is still worth showing; it is just not something to demand.
+        self.assertIn("row_item.signature", table)
 
     def test_interview_uses_shared_generator_module(self):
         interview_path = PACKAGE_ROOT / "data/questions/review_screen_generator.yml"


### PR DESCRIPTION
ALWeaver wants to call this generator instead of keeping a second implementation of the same idea — both when it drafts a new interview and when an author re-syncs a review screen that has drifted from the questions (SuffolkLITLab/docassemble-ALWeaver#865, SuffolkLITLab/docassemble-ALWeaver#482, and the old SuffolkLITLab/docassemble-ALWeaver#400, which closed with "we integrated this into ALDashboard instead"). Four things stood in the way, and all four are worth fixing for the Dashboard's own tool.

### The block can take the interview's own names

A generated interview's download screen links to its own `review_<label>` event, so a draft that always named the block `review_form` quietly broke the "Edit answers" button. `review_id`, `review_event_name` and `review_question` now name the block, defaulting to exactly what they were, so nothing changes for existing callers.

### A name is one line, not three; an address is one line, not six

`name_fields()` came out as First / Middle / Last, and `address_fields()` as street, unit, city, state, zip and country. A review screen is read, not filled in. Both are now a single line showing the person and `address.block()`.

### Nothing on the screen forces a variable to be defined

Looking at your answers should never send you back into the interview. Plain values already used `showifdef()`, but `word(yesno(x))` and `currency(x)` did not — and `yesno('')` would confidently report "No" for a question nobody was asked. Both are guarded now.

### `edit:` never asks for a signature

Docassemble turns `edit:` into a follow-up list and defines every variable in it. Listing a signature sends the author's user to a signature pad they did not ask for, and that AssemblyLine's `basic_questions_signature_flow` overwrites moments later. Signatures stay out of `edit:` and remain visible as a column.

### Output style

The dump now uses AssemblyLine's indentation and a literal block for `question:`, so the draft is something an author can paste into an interview without reformatting it first:

```yaml
id: review screen
event: review_answers
question: |
  Review your answers
review:
  - Edit: client.name.first
    button: |
      **What is your name?**

      Name: ${ client if defined('client.name.first') else '' }
```

### Checking

Four new tests cover the new arguments, the collapsed name and address, the guarded values and the signature exclusion. The full suite passes (390 tests). I also ran the generator over the 50 interviews in the SuffolkLITLab packages that have a review screen: grouping puts 2.3–5.1 values behind each "Edit" link, where the hand-written screens sit at roughly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)