### PR TITLE
Fix DOCX labeler initial template loading from query params

### DIFF
--- a/docassemble/ALDashboard/data/static/docx_labeler.js
+++ b/docassemble/ALDashboard/data/static/docx_labeler.js
@@ -1,4 +1,16 @@
     (function() {
+        function parseBootstrapJson() {
+            var bootstrapEl = document.getElementById('labeler-bootstrap');
+            if (!bootstrapEl) return {};
+            try {
+                return JSON.parse(bootstrapEl.textContent || '{}');
+            } catch (_e) {
+                return {};
+            }
+        }
+
+        const LABELER_BOOTSTRAP = parseBootstrapJson();
+        const INITIAL_PLAYGROUND_SOURCE = LABELER_BOOTSTRAP.initialPlaygroundSource || {};
         const DOCX_LABELER_CONFIG = (typeof window !== 'undefined' && window.DOCX_LABELER_CONFIG)
             ? window.DOCX_LABELER_CONFIG
             : {};
@@ -164,6 +176,11 @@
             fileContent: null,
             originalHtml: '',
             playgroundSource: null,
+            initialPlaygroundSource: {
+                project: INITIAL_PLAYGROUND_SOURCE.project || '',
+                filename: INITIAL_PLAYGROUND_SOURCE.filename || '',
+                attempted: false
+            },
             runs: [],          // original runs from extract-runs endpoint
             existingLabels: [],
             suggestions: [],
@@ -1241,7 +1258,11 @@
             }
             renderAuthControls();
             updateAiUiState();
-            if (!shouldHideInterviewPicker()) {
+            if (state.auth.isAuthenticated) {
+                await fetchPlaygroundProjects();
+                await maybeOpenInitialPlaygroundTemplate();
+                await fetchInstalledPackages();
+            } else if (!shouldHideInterviewPicker()) {
                 await fetchPlaygroundProjects();
                 await fetchInstalledPackages();
             }
@@ -3009,6 +3030,22 @@
             }
         }
 
+        async function maybeOpenInitialPlaygroundTemplate() {
+            if (!state.auth.isAuthenticated) return;
+            if (state.initialPlaygroundSource.attempted) return;
+            var project = state.initialPlaygroundSource.project;
+            var filename = state.initialPlaygroundSource.filename;
+            if (!project || !filename) {
+                state.initialPlaygroundSource.attempted = true;
+                return;
+            }
+            state.initialPlaygroundSource.attempted = true;
+            if (state.playground.projects.indexOf(project) === -1) return;
+            state.playground.selectedProject = project;
+            renderInterviewPicker();
+            await openDocxTemplateFromPlayground(project, filename, { showSuccess: false });
+        }
+
         async function confirmOpenFromPlayground() {
             var openPgProject = document.getElementById('open-pg-project');
             var openPgTemplate = document.getElementById('open-pg-template');
@@ -3016,6 +3053,11 @@
             var filename = openPgTemplate.value;
             if (!filename) { showError('Select a template file.'); return; }
             openPlaygroundModalEl.classList.add('hidden');
+            await openDocxTemplateFromPlayground(project, filename);
+        }
+
+        async function openDocxTemplateFromPlayground(project, filename, options) {
+            options = options || {};
             showLoading('Loading ' + filename + ' from Playground...');
             try {
                 var data = await fetchJsonOrThrow(

--- a/docassemble/ALDashboard/data/templates/docx_labeler.html
+++ b/docassemble/ALDashboard/data/templates/docx_labeler.html
@@ -495,6 +495,7 @@
         </div>
     </div>
 
+    <script id="labeler-bootstrap" type="application/json">__LABELER_BOOTSTRAP_JSON__</script>
     <script src="/packagestatic/docassemble.ALDashboard/docx_labeler_preview_utils.js"></script>
     <script src="/packagestatic/docassemble.ALDashboard/docx_labeler.js"></script>
 </body>

--- a/docassemble/ALDashboard/test/test_labeler_js_extraction.py
+++ b/docassemble/ALDashboard/test/test_labeler_js_extraction.py
@@ -35,11 +35,25 @@ class TestDocxLabelerJsExtraction(unittest.TestCase):
         )
 
     def test_html_has_no_inline_application_js(self):
-        """The only <script> tags should be CDN libs or the static JS src."""
-        script_tags = re.findall(r"<script[^>]*>", self.html)
-        for tag in script_tags:
-            # Every script tag must have a src attribute (no inline JS)
-            self.assertIn("src=", tag, f"Found inline <script> tag: {tag}")
+        """Only CDN scripts, bootstrap JSON data, and static JS src tags."""
+        script_tags = re.findall(r"<script([^>]*)>(.*?)</script>", self.html, re.DOTALL)
+        for attrs, body in script_tags:
+            body_stripped = body.strip()
+            if not body_stripped:
+                # Empty body = external src, fine
+                continue
+            if 'type="application/json"' in attrs:
+                # Bootstrap JSON data block, not executable JS
+                continue
+            self.fail(
+                f"Found inline <script> with executable JS:\n"
+                f"  attrs: {attrs}\n"
+                f"  body (first 120 chars): {body_stripped[:120]}"
+            )
+
+    def test_html_preserves_bootstrap_json_placeholder(self):
+        self.assertIn("__LABELER_BOOTSTRAP_JSON__", self.html)
+        self.assertIn('id="labeler-bootstrap"', self.html)
 
     def test_html_still_loads_mammoth_cdn(self):
         self.assertIn("mammoth", self.html)
@@ -87,6 +101,12 @@ class TestDocxLabelerJsExtraction(unittest.TestCase):
     def test_js_contains_api_calls(self):
         """Verify API endpoint references are present in the JS."""
         self.assertIn("/docx-labeler/api/", self.js)
+
+    def test_js_reads_bootstrap_json(self):
+        """JS must read bootstrap config injected by the server."""
+        self.assertIn("parseBootstrapJson", self.js)
+        self.assertIn("labeler-bootstrap", self.js)
+        self.assertIn("LABELER_BOOTSTRAP", self.js)
 
     def test_js_references_mammoth(self):
         """The JS should reference the mammoth library loaded from the CDN."""
@@ -251,6 +271,19 @@ class TestLabelerTemplateRendering(unittest.TestCase):
         self.assertIn("</head>", html)
         self.assertIn("<body", html)
         self.assertIn("</body>", html)
+
+    def test_docx_bootstrap_json_injection(self):
+        """Simulate the server-side bootstrap JSON injection for docx."""
+        html = _read_package_file("data", "templates", "docx_labeler.html")
+        rendered = html.replace(
+            "__LABELER_BOOTSTRAP_JSON__",
+            '{"apiBasePath":"/al","initialPlaygroundSource":{"project":"demo-project","filename":"test.docx"}}',
+        )
+        self.assertNotIn("__LABELER_BOOTSTRAP_JSON__", rendered)
+        self.assertIn(
+            '{"apiBasePath":"/al","initialPlaygroundSource":{"project":"demo-project","filename":"test.docx"}}',
+            rendered,
+        )
 
     def test_pdf_bootstrap_json_injection(self):
         """Simulate the server-side bootstrap JSON injection."""


### PR DESCRIPTION
## Description
When opening the DOCX labeler from ALWeaver (or via query parameters like `/al/docx-labeler?project=demo&filename=test.docx`), the editor was not loading the requested DOCX template.

### Root Cause
While `api_labelers.py` parsed query parameters and passed `initialPlaygroundSource` into the bootstrap data dictionary:
1. `docx_labeler.html` lacked the `<script id="labeler-bootstrap" type="application/json">__LABELER_BOOTSTRAP_JSON__</script>` tag, so the bootstrap data was never injected into the DOM.
2. `docx_labeler.js` did not parse the bootstrap JSON element, did not store `initialPlaygroundSource` in state, and did not invoke `maybeOpenInitialPlaygroundTemplate()` upon authentication.

### Changes
- In [docx_labeler.html](file:///home/quinten/docassemble-ALDashboard/docassemble/ALDashboard/data/templates/docx_labeler.html): Added the `#labeler-bootstrap` JSON script tag.
- In [docx_labeler.js](file:///home/quinten/docassemble-ALDashboard/docassemble/ALDashboard/data/static/docx_labeler.js): Added `parseBootstrapJson()`, saved `initialPlaygroundSource` in state, factored out `openDocxTemplateFromPlayground()`, and added `maybeOpenInitialPlaygroundTemplate()` to automatically load the initial template upon authentication.
- In [test_labeler_js_extraction.py](file:///home/quinten/docassemble-ALDashboard/docassemble/ALDashboard/test/test_labeler_js_extraction.py): Added tests for bootstrap placeholder presence, server injection, and static JS bootstrap extraction.