### PR TITLE
Expose the find_file_by_id function in the answers viewer

### DIFF
--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -160,7 +160,6 @@ __all__ = [
     "increment_index_value",
     "get_current_index_value",
     "get_latest_s3_folder",
-    "get_upload_details",
     "get_permitted_upload_details",
     "get_file_ids_associated_with_session",
     "get_files_associated_with_session",
@@ -1501,7 +1500,9 @@ def get_session_details(session_id: str) -> Dict[str, Any]:
 def get_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
     """Resolve a docassemble file number to its upload and owning session."""
     requested_file_id = str(file_id or "").strip()
-    if not requested_file_id.isdigit():
+    # `isdigit()` alone is True for non-decimal digits like "\u00b2", which `int()`
+    # rejects, so check for ASCII digits before converting.
+    if not (requested_file_id.isascii() and requested_file_id.isdigit()):
         return None
 
     query = text("""
@@ -1516,7 +1517,6 @@ def get_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
     if upload is None:
         return None
     return {
-        "indexno": int(upload.indexno),
         "file_id": int(upload.indexno),
         "key": upload.key,
         "yamlfile": upload.yamlfile,
@@ -1526,14 +1526,24 @@ def get_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
 
 def get_permitted_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
     """
-    Resolve a file number and return it only when its owning session is visible.
+    Resolve a file number and return it only when the current user may see it.
 
-    The owning interview and permission are resolved through the session record,
-    so callers cannot use upload metadata or action arguments to bypass the
-    interview-viewer allow-list.
+    Both the upload's interview and its owning session are resolved from the
+    database rather than trusted from the caller, so an action argument can't be
+    used to get around the interview-viewer allow-list.
     """
     upload = get_upload_details(file_id)
     if not upload or not upload.get("key"):
+        return None
+    # The upload's own interview has to be checked separately from the session's:
+    # one session key can have userdict rows for more than one interview, and
+    # `get_session_details()` only reports the most recently modified one.
+    allowed_filenames = get_allowed_interview_filenames()
+    if allowed_filenames is not None and upload.get("yamlfile") not in allowed_filenames:
+        log(
+            f"get_permitted_upload_details: user {user_info().id if user_logged_in() else 'anonymous'} "
+            f"is not allowed to view interview {upload.get('yamlfile')} for file {upload.get('file_id')}"
+        )
         return None
     session_details = get_permitted_session_details(upload["key"])
     if not session_details:
@@ -1759,7 +1769,9 @@ def get_session_file_for_download(
     resolved and verified it, so this serves exactly the files that were listed.
     """
     requested_file_id = str(file_id or "").strip()
-    if not requested_file_id.isdigit():
+    # `isdigit()` alone is True for non-decimal digits like "\u00b2", which `int()`
+    # rejects, so check for ASCII digits before converting.
+    if not (requested_file_id.isascii() and requested_file_id.isdigit()):
         return None
     for item in get_files_associated_with_session(
         session_id, yaml_filename=yaml_filename, privileged=privileged

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -160,6 +160,8 @@ __all__ = [
     "increment_index_value",
     "get_current_index_value",
     "get_latest_s3_folder",
+    "get_upload_details",
+    "get_permitted_upload_details",
     "get_file_ids_associated_with_session",
     "get_files_associated_with_session",
     "build_session_files_zip",
@@ -1494,6 +1496,49 @@ def get_session_details(session_id: str) -> Dict[str, Any]:
         "steps": session_details.steps,
         "progress": session_details.progress,
     }
+
+
+def get_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
+    """Resolve a docassemble file number to its upload and owning session."""
+    requested_file_id = str(file_id or "").strip()
+    if not requested_file_id.isdigit():
+        return None
+
+    query = text("""
+        SELECT indexno, key, yamlfile, filename
+        FROM uploads
+        WHERE indexno = :file_id
+        LIMIT 1
+    """)
+    with _get_db_session() as session:
+        upload = session.execute(query, {"file_id": int(requested_file_id)}).fetchone()
+
+    if upload is None:
+        return None
+    return {
+        "indexno": int(upload.indexno),
+        "file_id": int(upload.indexno),
+        "key": upload.key,
+        "yamlfile": upload.yamlfile,
+        "filename": upload.filename,
+    }
+
+
+def get_permitted_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
+    """
+    Resolve a file number and return it only when its owning session is visible.
+
+    The owning interview and permission are resolved through the session record,
+    so callers cannot use upload metadata or action arguments to bypass the
+    interview-viewer allow-list.
+    """
+    upload = get_upload_details(file_id)
+    if not upload or not upload.get("key"):
+        return None
+    session_details = get_permitted_session_details(upload["key"])
+    if not session_details:
+        return None
+    return {**upload, "session": session_details}
 
 
 def get_file_ids_associated_with_session(

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -1539,7 +1539,10 @@ def get_permitted_upload_details(file_id: Any) -> Optional[Dict[str, Any]]:
     # one session key can have userdict rows for more than one interview, and
     # `get_session_details()` only reports the most recently modified one.
     allowed_filenames = get_allowed_interview_filenames()
-    if allowed_filenames is not None and upload.get("yamlfile") not in allowed_filenames:
+    if (
+        allowed_filenames is not None
+        and upload.get("yamlfile") not in allowed_filenames
+    ):
         log(
             f"get_permitted_upload_details: user {user_info().id if user_logged_in() else 'anonymous'} "
             f"is not allowed to view interview {upload.get('yamlfile')} for file {upload.get('file_id')}"

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -23,6 +23,8 @@ code: |
     load_answer
   elif session_list_mode == "session_id":
     view_single_session
+  elif session_list_mode == "file_id":
+    view_file_by_id
 ---
 continue button field: playground_splash
 id: splash screen
@@ -112,11 +114,18 @@ fields:
       - Browse recent sessions: browse
       - Search answer values: search
       - Look up specific session ID: session_id
+      - Look up file number: file_id
     default: browse
   - Session ID: session_id
     required: False
     js show if: |
       val("session_list_mode") == "session_id"
+  - File number: file_id_lookup
+    datatype: integer
+    required: False
+    min: 1
+    js show if: |
+      val("session_list_mode") == "file_id"
   - Filename: filename
     required: False
     datatype: combobox
@@ -137,7 +146,7 @@ fields:
         ),
       )
     js show if: |
-      val("session_list_mode") != "session_id"
+      ["browse", "search"].includes(val("session_list_mode"))
     show if:
       code: |
         user_has_privilege(['admin', 'developer'])
@@ -159,7 +168,7 @@ fields:
         ),
       )
     js show if: |
-      val("session_list_mode") != "session_id"
+      ["browse", "search"].includes(val("session_list_mode"))
     show if:
       code: |
         not user_has_privilege(['admin', 'developer'])
@@ -168,7 +177,7 @@ fields:
     datatype: integer
     input type: combobox
     js show if: |
-      val("session_list_mode") != "session_id"
+      ["browse", "search"].includes(val("session_list_mode"))
     show if:
       code: |
         total_user_count <= 10000
@@ -183,7 +192,7 @@ fields:
     input type: ajax
     action: user_search_ajax
     js show if: |
-      val("session_list_mode") != "session_id"
+      ["browse", "search"].includes(val("session_list_mode"))
     show if:
       code: |
         total_user_count > 10000
@@ -192,7 +201,7 @@ fields:
     datatype: yesno
     default: True
     js show if: |
-      val("session_list_mode") != "session_id"
+      ["browse", "search"].includes(val("session_list_mode"))
   - Use advanced answer-variable filters: session_search_use_advanced_filters
     datatype: yesno
     default: False
@@ -234,6 +243,9 @@ validation code: |
   if session_list_mode == "session_id":
     if not str(session_id or "").strip():
       validation_error("Please enter a session ID.", field="session_id")
+  elif session_list_mode == "file_id":
+    if not str(file_id_lookup or "").strip():
+      validation_error("Please enter a file number.", field="file_id_lookup")
   elif session_list_mode == "search":
     if session_search_use_advanced_filters:
       session_search_resolved_criteria_text = build_session_search_criteria_text(
@@ -402,6 +414,46 @@ event: go_to_session_id_lookup
 code: |
   session_list_mode = "session_id"
   undefine("session_id")
+---
+reconsider: True
+code: |
+  current_file_id = str(action_argument('file_id') or file_id_lookup or "").strip()
+---
+reconsider: True
+code: |
+  # This returns None for both missing files and files whose owning interview
+  # the current user cannot inspect, to avoid exposing sequential file IDs.
+  permitted_upload_details = get_permitted_upload_details(current_file_id)
+---
+event: view_file_by_id
+id: view file by id
+question: |
+  % if permitted_upload_details:
+  File #${ permitted_upload_details.get('file_id') }
+  % else:
+  File #${ current_file_id } not found
+  % endif
+subquestion: |
+  % if permitted_upload_details:
+  <% file_session = permitted_upload_details['session'] %>
+  <table class="table">
+    <tbody>
+      <tr><th scope="row">Filename</th><td class="text-wrap text-break">${ permitted_upload_details.get('filename') or 'Unknown' }</td></tr>
+      <tr><th scope="row">Interview</th><td class="text-wrap text-break">${ file_session.get('filename') or permitted_upload_details.get('yamlfile') }</td></tr>
+      <tr><th scope="row">Session</th><td class="text-wrap text-break">${ permitted_upload_details.get('key') }</td></tr>
+      <tr><th scope="row">User</th><td>${ format_session_users(file_session, {}) }</td></tr>
+      <tr><th scope="row">Modified</th><td>${ format_date(file_session.get('modtime'), "MMM d YYYY") }</td></tr>
+    </tbody>
+  </table>
+
+  <a class="btn btn-primary" href="${ interview_url_action('download_file_number', file_id=permitted_upload_details.get('file_id')) }">
+    <i class="fa-solid fa-download"></i>&nbsp;Download</a>
+  <a class="btn btn-secondary" href="${ interview_url_action('view_single_session', session_id=permitted_upload_details.get('key')) }">
+    <i class="fa-solid fa-magnifying-glass"></i>&nbsp;View session</a>
+  % else:
+  <div class="alert alert-warning">No file found with number <code>${ current_file_id }</code>, or you do not have permission to view its session.</div>
+  % endif
+back button: True
 ---
 # Recomputed on every screen so that following a "Details" link for one session
 # doesn't redisplay the session that was looked at before it.
@@ -572,6 +624,24 @@ code: |
   if not file_to_download:
     response(response="File not found for this session.", response_code=404, content_type="text/plain; charset=utf-8")
   response(file=file_to_download)
+---
+event: download_file_number
+code: |
+  # Re-resolve both ownership and authorization instead of trusting values from
+  # the result page or serving a guessed file number directly.
+  upload_for_download = get_permitted_upload_details(action_argument('file_id'))
+  if not upload_for_download:
+    response(response="File not found.", response_code=404, content_type="text/plain; charset=utf-8")
+  owning_session = upload_for_download['session']
+  file_from_number = get_session_file_for_download(
+    upload_for_download['key'],
+    upload_for_download['file_id'],
+    yaml_filename=owning_session.get('filename'),
+    privileged=user_has_privilege(['admin', 'developer'])
+  )
+  if not file_from_number:
+    response(response="File not found.", response_code=404, content_type="text/plain; charset=utf-8")
+  response(file=file_from_number)
 ---
 event: download_all_session_files
 code: |

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -417,13 +417,9 @@ code: |
 ---
 reconsider: True
 code: |
-  current_file_id = str(action_argument('file_id') or file_id_lookup or "").strip()
----
-reconsider: True
-code: |
   # This returns None for both missing files and files whose owning interview
   # the current user cannot inspect, to avoid exposing sequential file IDs.
-  permitted_upload_details = get_permitted_upload_details(current_file_id)
+  permitted_upload_details = get_permitted_upload_details(file_id_lookup)
 ---
 event: view_file_by_id
 id: view file by id
@@ -431,7 +427,7 @@ question: |
   % if permitted_upload_details:
   File #${ permitted_upload_details.get('file_id') }
   % else:
-  File #${ current_file_id } not found
+  File #${ file_id_lookup } not found
   % endif
 subquestion: |
   % if permitted_upload_details:
@@ -439,10 +435,10 @@ subquestion: |
   <table class="table">
     <tbody>
       <tr><th scope="row">Filename</th><td class="text-wrap text-break">${ permitted_upload_details.get('filename') or 'Unknown' }</td></tr>
-      <tr><th scope="row">Interview</th><td class="text-wrap text-break">${ file_session.get('filename') or permitted_upload_details.get('yamlfile') }</td></tr>
+      <tr><th scope="row">Interview</th><td class="text-wrap text-break">${ permitted_upload_details.get('yamlfile') }</td></tr>
       <tr><th scope="row">Session</th><td class="text-wrap text-break">${ permitted_upload_details.get('key') }</td></tr>
       <tr><th scope="row">User</th><td>${ format_session_users(file_session, {}) }</td></tr>
-      <tr><th scope="row">Modified</th><td>${ format_date(file_session.get('modtime'), "MMM d YYYY") }</td></tr>
+      <tr><th scope="row">Session last modified</th><td>${ format_date(file_session.get('modtime'), "MMM d YYYY") }</td></tr>
     </tbody>
   </table>
 
@@ -451,7 +447,7 @@ subquestion: |
   <a class="btn btn-secondary" href="${ interview_url_action('view_single_session', session_id=permitted_upload_details.get('key')) }">
     <i class="fa-solid fa-magnifying-glass"></i>&nbsp;View session</a>
   % else:
-  <div class="alert alert-warning">No file found with number <code>${ current_file_id }</code>, or you do not have permission to view its session.</div>
+  <div class="alert alert-warning">No file found with number <code>${ file_id_lookup }</code>, or you do not have permission to view its session.</div>
   % endif
 back button: True
 ---
@@ -543,7 +539,7 @@ subquestion: |
         <td>${ f.get('file_id') }</td>
         <td class="text-wrap text-break">${ f.get('filename') }</td>
         <td>
-          <a href="${ interview_url_action('download_session_file', session_id=current_session_id, file_id=f.get('file_id')) }">
+          <a href="${ interview_url_action('download_file_number', file_id=f.get('file_id')) }">
             <i class="fa-solid fa-download"></i>&nbsp;Download</a>
         </td>
       </tr>
@@ -583,7 +579,7 @@ subquestion: |
         <td>${ f.get('file_id') }</td>
         <td class="text-wrap text-break">${ f.get('filename') }</td>
         <td>
-          <a href="${ interview_url_action('download_session_file', session_id=current_session_id, file_id=f.get('file_id')) }">
+          <a href="${ interview_url_action('download_file_number', file_id=f.get('file_id')) }">
             <i class="fa-solid fa-download"></i>&nbsp;Download</a>
         </td>
       </tr>
@@ -609,34 +605,20 @@ code: |
     )
   )
 ---
-event: download_session_file
-code: |
-  session_details_for_download = get_permitted_session_details(action_argument('session_id'))
-  if not session_details_for_download:
-    response(response="File not found for this session.", response_code=404, content_type="text/plain; charset=utf-8")
-  # Serving a DAFile rather than raw bytes gives the download its real filename.
-  file_to_download = get_session_file_for_download(
-    action_argument('session_id'),
-    action_argument('file_id'),
-    yaml_filename=session_details_for_download.get('filename'),
-    privileged=user_has_privilege(['admin', 'developer'])
-  )
-  if not file_to_download:
-    response(response="File not found for this session.", response_code=404, content_type="text/plain; charset=utf-8")
-  response(file=file_to_download)
----
 event: download_file_number
 code: |
-  # Re-resolve both ownership and authorization instead of trusting values from
-  # the result page or serving a guessed file number directly.
+  # Re-resolve both ownership and authorization from the file number instead of
+  # trusting values from the result page or serving a guessed number directly.
   upload_for_download = get_permitted_upload_details(action_argument('file_id'))
   if not upload_for_download:
     response(response="File not found.", response_code=404, content_type="text/plain; charset=utf-8")
-  owning_session = upload_for_download['session']
+  # Serving a DAFile rather than raw bytes gives the download its real filename.
+  # The yamlfile filter uses the upload's own interview rather than the session's
+  # most recently modified one: a session key can span more than one interview.
   file_from_number = get_session_file_for_download(
     upload_for_download['key'],
     upload_for_download['file_id'],
-    yaml_filename=owning_session.get('filename'),
+    yaml_filename=upload_for_download.get('yamlfile'),
     privileged=user_has_privilege(['admin', 'developer'])
   )
   if not file_from_number:

--- a/docassemble/ALDashboard/test/test_session_details_and_files.py
+++ b/docassemble/ALDashboard/test/test_session_details_and_files.py
@@ -33,6 +33,7 @@ def _load_session_detail_helpers():
         "get_permitted_upload_details",
         "get_file_ids_associated_with_session",
         "get_files_associated_with_session",
+        "get_session_file_for_download",
         "build_session_files_zip",
         "download_file_by_id",
         "format_session_users",
@@ -54,6 +55,7 @@ def _load_session_detail_helpers():
         "re": __import__("re"),
         "os": __import__("os"),
         "_get_db_session": None,
+        "DAFile": None,
         "get_info_from_file_number": lambda *args, **kwargs: {},
         "SavedFile": None,
         "get_ext_and_mimetype": lambda fn: (
@@ -94,6 +96,7 @@ get_upload_details = aldashboard.get_upload_details
 get_permitted_upload_details = aldashboard.get_permitted_upload_details
 get_file_ids_associated_with_session = aldashboard.get_file_ids_associated_with_session
 get_files_associated_with_session = aldashboard.get_files_associated_with_session
+get_session_file_for_download = aldashboard.get_session_file_for_download
 build_session_files_zip = aldashboard.build_session_files_zip
 download_file_by_id = aldashboard.download_file_by_id
 format_session_users = aldashboard.format_session_users
@@ -198,7 +201,6 @@ def test_get_upload_details_resolves_owning_session(monkeypatch):
     monkeypatch.setattr(aldashboard, "_get_db_session", FakeSession)
 
     assert get_upload_details(" 12345 ") == {
-        "indexno": 12345,
         "file_id": 12345,
         "key": "abc123",
         "yamlfile": "docassemble.Foo:data/questions/foo.yml",
@@ -221,6 +223,10 @@ def test_get_upload_details_returns_none_for_invalid_or_missing_ids(monkeypatch)
 
     assert get_upload_details("not-a-number") is None
     assert get_upload_details("99999") is None
+    # Non-decimal digits pass `str.isdigit()` but `int()` rejects them, so they
+    # have to be turned away before the conversion rather than raising.
+    assert get_upload_details("\u00b2") is None
+    assert get_session_file_for_download("session-abc", "\u00b2") is None
 
 
 def test_get_permitted_upload_details_rejects_unauthorized_interview(monkeypatch):
@@ -228,7 +234,6 @@ def test_get_permitted_upload_details_rejects_unauthorized_interview(monkeypatch
         aldashboard,
         "get_upload_details",
         lambda file_id: {
-            "indexno": 12345,
             "file_id": 12345,
             "key": "secret-session",
             "yamlfile": "docassemble.Secret:data/questions/secret.yml",
@@ -244,7 +249,6 @@ def test_get_permitted_upload_details_rejects_unauthorized_interview(monkeypatch
 
 def test_get_permitted_upload_details_includes_authorized_session(monkeypatch):
     upload = {
-        "indexno": 12345,
         "file_id": 12345,
         "key": "allowed-session",
         "yamlfile": "docassemble.Allowed:data/questions/allowed.yml",
@@ -255,6 +259,62 @@ def test_get_permitted_upload_details_includes_authorized_session(monkeypatch):
     monkeypatch.setattr(
         aldashboard, "get_permitted_session_details", lambda session_id: session
     )
+    monkeypatch.setattr(
+        aldashboard, "get_allowed_interview_filenames", lambda: {upload["yamlfile"]}
+    )
+
+    assert get_permitted_upload_details(12345) == {**upload, "session": session}
+
+
+def test_get_permitted_upload_details_rejects_upload_from_other_interview(monkeypatch):
+    """
+    A session key can have userdict rows for more than one interview, and
+    `get_session_details()` only reports the most recently modified one, so the
+    upload's own interview has to be checked against the allow-list too.
+    """
+    upload = {
+        "file_id": 12345,
+        "key": "shared-session",
+        "yamlfile": "docassemble.Secret:data/questions/secret.yml",
+        "filename": "secret.pdf",
+    }
+    # The session resolves to the permitted interview, but the file doesn't
+    # belong to it.
+    session = {
+        "key": "shared-session",
+        "filename": "docassemble.Allowed:data/questions/allowed.yml",
+    }
+    monkeypatch.setattr(aldashboard, "get_upload_details", lambda file_id: upload)
+    monkeypatch.setattr(
+        aldashboard, "get_permitted_session_details", lambda session_id: session
+    )
+    monkeypatch.setattr(
+        aldashboard,
+        "get_allowed_interview_filenames",
+        lambda: {"docassemble.Allowed:data/questions/allowed.yml"},
+    )
+
+    assert get_permitted_upload_details(12345) is None
+
+
+def test_get_permitted_upload_details_allows_any_interview_for_privileged_users(
+    monkeypatch,
+):
+    upload = {
+        "file_id": 12345,
+        "key": "shared-session",
+        "yamlfile": "docassemble.Other:data/questions/other.yml",
+        "filename": "other.pdf",
+    }
+    session = {
+        "key": "shared-session",
+        "filename": "docassemble.Allowed:data/questions/allowed.yml",
+    }
+    monkeypatch.setattr(aldashboard, "get_upload_details", lambda file_id: upload)
+    monkeypatch.setattr(
+        aldashboard, "get_permitted_session_details", lambda session_id: session
+    )
+    monkeypatch.setattr(aldashboard, "get_allowed_interview_filenames", lambda: None)
 
     assert get_permitted_upload_details(12345) == {**upload, "session": session}
 
@@ -267,13 +327,10 @@ def test_file_number_workflow_reauthorizes_download_by_file_id():
     assert "Look up file number: file_id" in source
     assert "event: view_file_by_id" in source
     assert "event: download_file_number" in source
-    assert (
-        "upload_for_download = "
-        "get_permitted_upload_details(action_argument('file_id'))"
-    ) in source
-    assert "upload_for_download['key']" in source
-    assert "upload_for_download['file_id']" in source
-    assert "session_id=permitted_upload_details.get('key')" in source
+    # Downloads must never take a session ID from the caller: the file number
+    # alone determines the owning session, and that is what gets authorized.
+    assert "download_session_file" not in source
+    assert "get_permitted_upload_details" in source
 
 
 def test_get_file_ids_associated_with_session(monkeypatch):

--- a/docassemble/ALDashboard/test/test_session_details_and_files.py
+++ b/docassemble/ALDashboard/test/test_session_details_and_files.py
@@ -29,6 +29,8 @@ def _load_session_detail_helpers():
     lines = source.splitlines(keepends=True)
     names = {
         "get_session_details",
+        "get_upload_details",
+        "get_permitted_upload_details",
         "get_file_ids_associated_with_session",
         "get_files_associated_with_session",
         "build_session_files_zip",
@@ -88,6 +90,8 @@ def _load_session_detail_helpers():
 
 aldashboard = _load_session_detail_helpers()
 get_session_details = aldashboard.get_session_details
+get_upload_details = aldashboard.get_upload_details
+get_permitted_upload_details = aldashboard.get_permitted_upload_details
 get_file_ids_associated_with_session = aldashboard.get_file_ids_associated_with_session
 get_files_associated_with_session = aldashboard.get_files_associated_with_session
 build_session_files_zip = aldashboard.build_session_files_zip
@@ -175,6 +179,103 @@ def test_get_session_details_empty_key():
         get_session_details("   ")
 
 
+def test_get_upload_details_resolves_owning_session(monkeypatch):
+    Row = namedtuple("Row", ["indexno", "key", "yamlfile", "filename"])
+    row = Row(12345, "abc123", "docassemble.Foo:data/questions/foo.yml", "motion.pdf")
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, query, params):
+            assert params == {"file_id": 12345}
+            assert "WHERE indexno = :file_id" in query
+            return namedtuple("Result", ["fetchone"])(lambda: row)
+
+    monkeypatch.setattr(aldashboard, "_get_db_session", FakeSession)
+
+    assert get_upload_details(" 12345 ") == {
+        "indexno": 12345,
+        "file_id": 12345,
+        "key": "abc123",
+        "yamlfile": "docassemble.Foo:data/questions/foo.yml",
+        "filename": "motion.pdf",
+    }
+
+
+def test_get_upload_details_returns_none_for_invalid_or_missing_ids(monkeypatch):
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, query, params):
+            return namedtuple("Result", ["fetchone"])(lambda: None)
+
+    monkeypatch.setattr(aldashboard, "_get_db_session", FakeSession)
+
+    assert get_upload_details("not-a-number") is None
+    assert get_upload_details("99999") is None
+
+
+def test_get_permitted_upload_details_rejects_unauthorized_interview(monkeypatch):
+    monkeypatch.setattr(
+        aldashboard,
+        "get_upload_details",
+        lambda file_id: {
+            "indexno": 12345,
+            "file_id": 12345,
+            "key": "secret-session",
+            "yamlfile": "docassemble.Secret:data/questions/secret.yml",
+            "filename": "secret.pdf",
+        },
+    )
+    monkeypatch.setattr(
+        aldashboard, "get_permitted_session_details", lambda session_id: None
+    )
+
+    assert get_permitted_upload_details(12345) is None
+
+
+def test_get_permitted_upload_details_includes_authorized_session(monkeypatch):
+    upload = {
+        "indexno": 12345,
+        "file_id": 12345,
+        "key": "allowed-session",
+        "yamlfile": "docassemble.Allowed:data/questions/allowed.yml",
+        "filename": "allowed.pdf",
+    }
+    session = {"key": "allowed-session", "filename": upload["yamlfile"]}
+    monkeypatch.setattr(aldashboard, "get_upload_details", lambda file_id: upload)
+    monkeypatch.setattr(
+        aldashboard, "get_permitted_session_details", lambda session_id: session
+    )
+
+    assert get_permitted_upload_details(12345) == {**upload, "session": session}
+
+
+def test_file_number_workflow_reauthorizes_download_by_file_id():
+    source = (PACKAGE_ROOT / "data" / "questions" / "list_sessions.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Look up file number: file_id" in source
+    assert "event: view_file_by_id" in source
+    assert "event: download_file_number" in source
+    assert (
+        "upload_for_download = "
+        "get_permitted_upload_details(action_argument('file_id'))"
+    ) in source
+    assert "upload_for_download['key']" in source
+    assert "upload_for_download['file_id']" in source
+    assert "session_id=permitted_upload_details.get('key')" in source
+
+
 def test_get_file_ids_associated_with_session(monkeypatch):
     Row = namedtuple("Row", ["indexno"])
     rows = [Row(101), Row(102), Row(103)]
@@ -248,6 +349,50 @@ def test_get_files_associated_with_session(monkeypatch, tmp_path):
     assert files[0]["extension"] == "pdf"
     assert files[1]["file_id"] == 202
     assert files[1]["filename"] == "data.docx"
+
+
+def test_get_files_associated_with_session_materializes_saved_file(
+    monkeypatch, tmp_path
+):
+    saved_path = tmp_path / "saved-file"
+    Row = namedtuple("Row", ["indexno", "filename"])
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, query, params):
+            return [Row(321, "cloud.pdf")]
+
+    class FakeSavedFile:
+        def __init__(self, file_id, extension=None, fix=False):
+            assert (file_id, extension, fix) == (321, "pdf", True)
+            self.path = str(saved_path)
+            # SavedFile(..., fix=True) retrieves an S3 object to this local path.
+            saved_path.with_suffix(".pdf").write_text("cloud content")
+
+    monkeypatch.setattr(aldashboard, "_get_db_session", FakeSession)
+    monkeypatch.setattr(
+        aldashboard,
+        "get_info_from_file_number",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    monkeypatch.setattr(aldashboard, "SavedFile", FakeSavedFile)
+
+    files = get_files_associated_with_session("cloud-session")
+    assert files == [
+        {
+            "file_id": 321,
+            "filename": "cloud.pdf",
+            "path": str(saved_path.with_suffix(".pdf")),
+            "fullpath": str(saved_path.with_suffix(".pdf")),
+            "mimetype": "application/octet-stream",
+            "extension": "pdf",
+        }
+    ]
 
 
 def test_build_session_files_zip(monkeypatch, tmp_path):


### PR DESCRIPTION
Fix #146 

Mostly this was exposing existing, hidden code.

<img width="1615" height="1347" alt="image" src="https://github.com/user-attachments/assets/c217b254-9eb2-478f-babb-95c6468258ae" />

<img width="1286" height="865" alt="image" src="https://github.com/user-attachments/assets/2d6084dc-c1d6-4df5-8511-1fd7c3f1c6a3" />
