### PR TITLE
Add JS static checks and accessibility fixes for the DOCX/PDF labelers

### DIFF
--- a/.github/scripts/labeler_a11y.js
+++ b/.github/scripts/labeler_a11y.js
@@ -1,0 +1,291 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { chromium } = require("playwright");
+const AxeBuilder = require("@axe-core/playwright").default;
+
+const serverUrl = String(process.env.SERVER_URL || "").replace(/\/$/, "");
+const email = process.env.EDITOR_EMAIL;
+const password = process.env.EDITOR_PASSWORD;
+
+if (!serverUrl || !email || !password) {
+  throw new Error("SERVER_URL, EDITOR_EMAIL, and EDITOR_PASSWORD are required");
+}
+
+const pageErrors = [];
+const blockingViolations = [];
+
+async function signInIfNeeded(page, endpoint) {
+  await page.goto(`${serverUrl}${endpoint}`, { waitUntil: "domcontentloaded" });
+
+  if (new URL(page.url()).pathname === endpoint) return;
+
+  const emailInput = page
+    .locator('input[type="email"], input[name="email"], input[name="username"]')
+    .first();
+  await emailInput.fill(email);
+  await page.locator('input[type="password"]').first().fill(password);
+  await page
+    .getByRole("button", { name: /sign in|log in/i })
+    .first()
+    .click();
+  await page.waitForURL((url) => url.pathname === endpoint, {
+    timeout: 30_000,
+  });
+}
+
+// The Bootstrap theme transitions button color/background/border over
+// 150ms on hover, focus and active-state changes. Scanning immediately
+// after a click can catch axe mid-transition and report a transient,
+// non-representative color as a contrast violation. Settling briefly
+// before each scan avoids that false positive.
+async function settle(page) {
+  await page.waitForTimeout(250);
+}
+
+async function audit(page, label, scope) {
+  await settle(page);
+  const builder = new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]);
+  if (scope) builder.include(scope);
+  const result = await builder.analyze();
+
+  console.log(`${label}: ${result.violations.length} axe violation(s)`);
+  for (const violation of result.violations) {
+    console.log(
+      JSON.stringify({
+        id: violation.id,
+        impact: violation.impact,
+        help: violation.help,
+        helpUrl: violation.helpUrl,
+        targets: violation.nodes.map((node) => node.target),
+      }),
+    );
+    blockingViolations.push({ label, violation });
+  }
+}
+
+const IMPACT_ORDER = ["critical", "serious", "moderate", "minor"];
+
+function impactRank(impact) {
+  const index = IMPACT_ORDER.indexOf(String(impact));
+  return index === -1 ? IMPACT_ORDER.length : index;
+}
+
+function writeReport() {
+  const findings = blockingViolations.map(({ label, violation }) => ({
+    label,
+    id: violation.id,
+    impact: violation.impact,
+    help: violation.help,
+    helpUrl: violation.helpUrl,
+    targets: violation.nodes.map((node) => node.target),
+  }));
+  findings.sort(
+    (a, b) =>
+      impactRank(a.impact) - impactRank(b.impact) ||
+      a.label.localeCompare(b.label) ||
+      a.id.localeCompare(b.id),
+  );
+
+  fs.writeFileSync(
+    "axe-results.json",
+    JSON.stringify({ pageErrors, findings }, null, 2),
+  );
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const lines = ["## Flask labeler accessibility", ""];
+  if (!findings.length && !pageErrors.length) {
+    lines.push("No axe violations and no browser page errors.");
+  }
+  if (findings.length) {
+    lines.push(
+      `${findings.length} axe violation occurrence(s), most severe first.`,
+      "",
+      "| Impact | Rule | Where | Nodes |",
+      "| --- | --- | --- | --- |",
+    );
+    for (const finding of findings) {
+      lines.push(
+        `| ${finding.impact || "unknown"} | [${finding.id}](${finding.helpUrl}) |` +
+          ` ${finding.label} | ${finding.targets.length} |`,
+      );
+    }
+    lines.push(
+      "",
+      "Full detail, including selectors, is in the `axe-results` artifact.",
+    );
+  }
+  if (pageErrors.length) {
+    lines.push("", "### Browser page errors", "");
+    for (const error of pageErrors) lines.push(`- \`${error}\``);
+  }
+  fs.appendFileSync(summaryPath, lines.join("\n") + "\n");
+}
+
+async function auditVisibleModal(page, label, openAction, modalSelector) {
+  await openAction();
+  const modal = page.locator(modalSelector);
+  await modal.waitFor({ state: "visible", timeout: 10_000 });
+  await audit(page, label, modalSelector);
+  const closeButton = modal
+    .locator('.btn-close, button[id*="close"], button[id*="cancel"]')
+    .first();
+  await closeButton.click();
+  await modal.waitFor({ state: "hidden", timeout: 10_000 });
+}
+
+async function checkDocxLabeler(page) {
+  const endpoint = "/al/docx-labeler";
+  await signInIfNeeded(page, endpoint);
+  await audit(page, "DOCX labeler empty state");
+
+  await auditVisibleModal(
+    page,
+    "DOCX labeler settings modal",
+    () => page.locator("#settings-btn").click(),
+    "#settings-modal",
+  );
+  await auditVisibleModal(
+    page,
+    "DOCX labeler utilities modal",
+    () => page.locator("#utilities-btn").click(),
+    "#utilities-modal",
+  );
+  await auditVisibleModal(
+    page,
+    "DOCX labeler repair modal",
+    () => page.locator("#repair-btn").click(),
+    "#repair-modal",
+  );
+
+  await page
+    .locator("#file-input")
+    .setInputFiles(
+      path.join(process.cwd(), "docassemble/ALDashboard/test/condo_deed.docx"),
+    );
+  await page
+    .locator("#main-panel")
+    .waitFor({ state: "visible", timeout: 30_000 });
+  await audit(page, "DOCX labeler loaded document");
+
+  await page.locator("#tab-suggestions").click();
+  await audit(page, "DOCX labeler suggestions tab");
+  await page.locator("#tab-existing").click();
+
+  await auditVisibleModal(
+    page,
+    "DOCX labeler bulk replace modal",
+    () => page.locator("#bulk-replace-btn").click(),
+    "#bulk-replace-modal",
+  );
+
+  // The edit-label dialog only opens from a label in the tree, so it was
+  // invisible to earlier runs of this script -- and its close button was
+  // missing an accessible name as a result. Audit it whenever the fixture
+  // document yields at least one label.
+  const firstLabel = page.locator("#existing-labels-tree .tree-item").first();
+  if ((await firstLabel.count()) > 0) {
+    await auditVisibleModal(
+      page,
+      "DOCX labeler edit label modal",
+      () => firstLabel.click(),
+      "#edit-label-modal",
+    );
+  } else {
+    console.log("DOCX labeler edit label modal: no labels in fixture, skipped");
+  }
+}
+
+async function checkPdfLabeler(page) {
+  const endpoint = "/al/pdf-labeler";
+  await signInIfNeeded(page, endpoint);
+  await audit(page, "PDF labeler empty state");
+
+  await page
+    .locator("#file-input")
+    .setInputFiles(
+      path.join(
+        process.cwd(),
+        "docassemble/ALDashboard/test/civil_docketing_statement_polished_repaired.pdf",
+      ),
+    );
+  await page
+    .locator("#pdf-pages")
+    .waitFor({ state: "visible", timeout: 30_000 });
+  await audit(page, "PDF labeler loaded document");
+
+  for (const [label, button, modal] of [
+    ["PDF labeler settings modal", "#settings-btn", "#settings-modal"],
+    [
+      "PDF labeler accessibility modal",
+      "#accessibility-btn",
+      "#accessibility-modal",
+    ],
+    [
+      "PDF labeler normalization modal",
+      "#normalize-pass-btn",
+      "#normalization-modal",
+    ],
+    ["PDF labeler repair modal", "#repair-btn", "#repair-modal"],
+    ["PDF labeler utilities modal", "#utilities-btn", "#utilities-modal"],
+    [
+      "PDF labeler page manager modal",
+      "#manage-pages-btn",
+      "#page-manager-modal",
+    ],
+  ]) {
+    const buttonLocator = page.locator(button);
+    if ((await buttonLocator.count()) === 0) {
+      throw new Error(`Expected ${button} on ${endpoint}`);
+    }
+    await auditVisibleModal(
+      page,
+      label,
+      () => buttonLocator.first().click(),
+      modal,
+    );
+  }
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1200 },
+  });
+  const page = await context.newPage();
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+
+  try {
+    await checkDocxLabeler(page);
+    await checkPdfLabeler(page);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  writeReport();
+
+  if (pageErrors.length) {
+    console.error("Browser page errors:");
+    for (const error of pageErrors) console.error(error);
+    process.exitCode = 1;
+  }
+  if (blockingViolations.length) {
+    console.error(
+      `Found ${blockingViolations.length} axe violation occurrence(s).`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  // Still emit whatever was collected before the run broke, so the artifact
+  // and job summary are useful when a selector or the server goes missing.
+  try {
+    writeReport();
+  } catch {}
+  process.exitCode = 1;
+});

--- a/.github/workflows/browser_accessibility.yml
+++ b/.github/workflows/browser_accessibility.yml
@@ -1,0 +1,60 @@
+name: Flask browser accessibility
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: browser-accessibility-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-accessibility:
+    name: Check Flask labelers with axe
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Start an isolated temporary docassemble server
+        id: github_server
+        uses: suffolkLITLab/ALKiln/action_for_github_server@v5
+        with:
+          DOCASSEMBLECLI_VERSION: '0.0.25'
+
+      - name: Install this checkout on the temporary server
+        uses: SuffolkLITLab/ALActions/da_package@main
+        with:
+          SERVER_URL: ${{ steps.github_server.outputs.SERVER_URL }}
+          DOCASSEMBLE_DEVELOPER_API_KEY: ${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install browser test dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Check dialog keyboard behaviour
+        run: npm run test:dialogs
+
+      - name: Check Flask labeler accessibility
+        env:
+          SERVER_URL: ${{ steps.github_server.outputs.SERVER_URL }}
+          EDITOR_EMAIL: ${{ steps.github_server.outputs.DA_ADMIN_EMAIL }}
+          EDITOR_PASSWORD: ${{ steps.github_server.outputs.DA_ADMIN_PASSWORD }}
+        run: node .github/scripts/labeler_a11y.js
+
+      - name: Upload axe results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: axe-results
+          path: axe-results.json
+          if-no-files-found: ignore

--- a/.github/workflows/javascript_checks.yml
+++ b/.github/workflows/javascript_checks.yml
@@ -1,0 +1,30 @@
+name: JavaScript static checks
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: javascript-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  javascript-checks:
+    name: Prettier, ESLint, TypeScript, and syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install JavaScript tooling
+        run: npm ci
+
+      - name: Run JavaScript checks
+        run: npm run check

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ venv/
 build/
 dist/
 
+# Node tooling
+node_modules/
+
 # Local secrets
 .env
 .env.*
@@ -17,3 +20,6 @@ dist/
 *Zone.Identifier*
 
 .codex
+
+# Accessibility check output
+axe-results.json

--- a/docassemble/ALDashboard/data/static/docx_labeler.css
+++ b/docassemble/ALDashboard/data/static/docx_labeler.css
@@ -411,6 +411,23 @@
   background-color: var(--bs-light);
 }
 
+/* Repair buttons live in the repair modal body, not the header.
+   Darkened from Bootstrap's .btn-outline-danger for WCAG AA contrast
+   (9.2:1 on the modal's light background). */
+.repair-action-btn {
+  color: #8a1c28;
+  border-color: #8a1c28;
+}
+
+/* Bootstrap's default secondary (#6c757d) falls just under 4.5:1 on the
+   modal footer/body background (var(--bs-light), #f8f9fa): 4.45:1.
+   Darkened to Bootstrap's own secondary-hover shade, which clears AA on
+   both white and the modal-light background. */
+.dl-app .btn-outline-secondary {
+  color: #565e64;
+  border-color: #565e64;
+}
+
 /* ============================================================
    Empty / loading / error state icons
    ============================================================ */

--- a/docassemble/ALDashboard/data/static/docx_labeler.js
+++ b/docassemble/ALDashboard/data/static/docx_labeler.js
@@ -1,3480 +1,4716 @@
-    (function() {
-        function parseBootstrapJson() {
-            var bootstrapEl = document.getElementById('labeler-bootstrap');
-            if (!bootstrapEl) return {};
-            try {
-                return JSON.parse(bootstrapEl.textContent || '{}');
-            } catch (_e) {
-                return {};
-            }
+(function () {
+  function parseBootstrapJson() {
+    var bootstrapEl = document.getElementById("labeler-bootstrap");
+    if (!bootstrapEl) return {};
+    try {
+      return JSON.parse(bootstrapEl.textContent || "{}");
+    } catch (_e) {
+      return {};
+    }
+  }
+
+  const LABELER_BOOTSTRAP = parseBootstrapJson();
+  const INITIAL_PLAYGROUND_SOURCE =
+    LABELER_BOOTSTRAP.initialPlaygroundSource || {};
+  const DOCX_LABELER_CONFIG =
+    typeof window !== "undefined" && window.DOCX_LABELER_CONFIG
+      ? window.DOCX_LABELER_CONFIG
+      : {};
+  const DOCX_LABELER_API = DOCX_LABELER_CONFIG.api || {};
+  const DOCX_LABELER_UI = DOCX_LABELER_CONFIG.ui || {};
+
+  function endpointPath(key, fallback) {
+    var override = DOCX_LABELER_API[key];
+    return typeof override === "string" && override.trim()
+      ? override.trim()
+      : fallback;
+  }
+
+  function shouldHideInterviewPicker() {
+    return !!DOCX_LABELER_UI.hideInterviewPicker;
+  }
+
+  function cloneVariableTree(value) {
+    if (Array.isArray(value)) {
+      return value.map(cloneVariableTree);
+    }
+    if (!value || typeof value !== "object") {
+      return value;
+    }
+    var clone = {};
+    Object.keys(value).forEach(function (key) {
+      clone[key] = cloneVariableTree(value[key]);
+    });
+    return clone;
+  }
+
+  function mergeVariableTree(baseTree, extraTree) {
+    var merged = cloneVariableTree(baseTree || {});
+    if (!extraTree || typeof extraTree !== "object") {
+      return merged;
+    }
+    Object.keys(extraTree).forEach(function (key) {
+      var extraValue = extraTree[key];
+      var mergedValue = merged[key];
+      if (
+        mergedValue &&
+        extraValue &&
+        typeof mergedValue === "object" &&
+        typeof extraValue === "object" &&
+        !Array.isArray(mergedValue) &&
+        !Array.isArray(extraValue)
+      ) {
+        merged[key] = mergeVariableTree(mergedValue, extraValue);
+      } else {
+        merged[key] = cloneVariableTree(extraValue);
+      }
+    });
+    return merged;
+  }
+
+  function getSingletonListChild(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return null;
+    }
+    var childKeys = Object.keys(value).filter(function (key) {
+      return !key.startsWith("_");
+    });
+    if (childKeys.length !== 1 || childKeys[0] !== "[0]") {
+      return null;
+    }
+    var child = value["[0]"];
+    return child && typeof child === "object" && !Array.isArray(child)
+      ? child
+      : null;
+  }
+
+  const DOCX_LABELER_VARIABLE_TREE_EXTRAS =
+    DOCX_LABELER_CONFIG.variableTreeExtras || {};
+
+  // ================================================================
+  // AssemblyLine Variable Tree Structure
+  // ================================================================
+  const PERSON_ATTRIBUTES = {
+    name: {
+      _description: "Name components",
+      first: "First name",
+      middle: "Middle name",
+      "middle_initial()": "Middle initial",
+      last: "Last name",
+      suffix: "Suffix (Jr., Sr., III, etc.)",
+      "full()": "Full name",
+    },
+    address: {
+      _description: "Address components",
+      "block()": "Full address (multiple lines)",
+      "on_one_line()": "Full address (single line)",
+      "line_one()": "Street + unit",
+      "line_two()": "City, state, zip",
+      address: "Street address",
+      unit: "Unit/Apt/Suite",
+      city: "City",
+      state: "State",
+      zip: "ZIP/Postal code",
+      county: "County",
+      country: "Country",
+    },
+    birthdate: "Date of birth",
+    "age_in_years()": "Age (calculated)",
+    gender: "Gender",
+    gender_female: "Is female (checkbox)",
+    gender_male: "Is male (checkbox)",
+    gender_other: "Other gender (checkbox)",
+    gender_nonbinary: "Nonbinary (checkbox)",
+    gender_undisclosed: "Undisclosed (checkbox)",
+    phone_number: "Phone number",
+    mobile_number: "Mobile phone",
+    "phone_numbers()": "All phone numbers",
+    email: "Email address",
+    signature: "Signature",
+  };
+
+  const ATTORNEY_ATTRIBUTES = {
+    ...PERSON_ATTRIBUTES,
+    bar_number: "Bar/License number",
+  };
+
+  const AL_VARIABLE_TREE = mergeVariableTree(
+    {
+      users: {
+        _description: "People benefiting from the form (pro se filers)",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      other_parties: {
+        _description: "Opposing/transactional parties",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      plaintiffs: {
+        _description: "Plaintiffs in lawsuit",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      defendants: {
+        _description: "Defendants in lawsuit",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      petitioners: { _description: "Petitioners", "[0]": PERSON_ATTRIBUTES },
+      respondents: { _description: "Respondents", "[0]": PERSON_ATTRIBUTES },
+      children: { _description: "Children involved", "[0]": PERSON_ATTRIBUTES },
+      spouses: { _description: "Spouses", "[0]": PERSON_ATTRIBUTES },
+      parents: { _description: "Parents", "[0]": PERSON_ATTRIBUTES },
+      caregivers: { _description: "Caregivers", "[0]": PERSON_ATTRIBUTES },
+      guardians: { _description: "Guardians", "[0]": PERSON_ATTRIBUTES },
+      guardians_ad_litem: {
+        _description: "Guardians ad litem",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      witnesses: { _description: "Witnesses", "[0]": PERSON_ATTRIBUTES },
+      attorneys: { _description: "Attorneys", "[0]": ATTORNEY_ATTRIBUTES },
+      translators: {
+        _description: "Translators/Interpreters",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      creditors: { _description: "Creditors", "[0]": PERSON_ATTRIBUTES },
+      debt_collectors: {
+        _description: "Debt collectors",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      decedents: { _description: "Deceased persons", "[0]": PERSON_ATTRIBUTES },
+      interested_parties: {
+        _description: "Other interested parties",
+        "[0]": PERSON_ATTRIBUTES,
+      },
+      trial_court: {
+        _description: "Court information",
+        name: "Court name",
+        address: {
+          county: "County",
+          address: "Street address",
+          city: "City",
+          state: "State",
+        },
+        division: "Division",
+        department: "Department",
+      },
+      docket_number: "Case/Docket number",
+      docket_numbers: "Multiple docket numbers (comma-separated)",
+      case_name: "Case name/caption",
+      signature_date: "Date form is signed",
+      user_needs_interpreter: "User needs interpreter (checkbox)",
+      user_preferred_language: "User's preferred language",
+    },
+    DOCX_LABELER_VARIABLE_TREE_EXTRAS,
+  );
+
+  // ================================================================
+  // State
+  // ================================================================
+  var previewUtils =
+    typeof window !== "undefined" && window.DocxLabelerPreviewUtils
+      ? window.DocxLabelerPreviewUtils
+      : null;
+
+  let state = {
+    file: null,
+    fileContent: null,
+    originalHtml: "",
+    playgroundSource: null,
+    initialPlaygroundSource: {
+      project: INITIAL_PLAYGROUND_SOURCE.project || "",
+      filename: INITIAL_PLAYGROUND_SOURCE.filename || "",
+      attempted: false,
+    },
+    runs: [], // original runs from extract-runs endpoint
+    existingLabels: [],
+    suggestions: [],
+    labelRenames: {},
+    defaultModel: "gpt-5-mini",
+    recommendedModels: ["gpt-5-mini"],
+    availableModels: [],
+    auth: {
+      isAuthenticated: false,
+      email: "",
+      loginUrl: "/user/sign-in",
+      logoutUrl: "/user/sign-out",
+      aiEnabled: false,
+    },
+    interviewSourceMode: "playground",
+    playground: {
+      projects: [],
+      files: [],
+      selectedProject: "default",
+      selectedFile: "",
+      variables: [],
+      topLevelNames: [],
+    },
+    installed: {
+      packages: [],
+      files: [],
+      selectedPackage: "",
+      selectedFile: "",
+      variables: [],
+      topLevelNames: [],
+    },
+    ui: {
+      editInterviewSourceInSettings: false,
+    },
+    settings: {
+      additionalInstructions:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.additionalInstructions) ||
+        "",
+      contextText:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.contextText) ||
+        "",
+      customPeople:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.customPeople) ||
+        "",
+      primaryPersonVariable:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.primaryPersonVariable) ||
+        "",
+      promptProfile:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.promptProfile) ||
+        "standard",
+      model:
+        (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.model) ||
+        "gpt-5-mini",
+      judgeModel:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.judgeModel) ||
+        "",
+      generationMethod:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.generationMethod) ||
+        "multi_run",
+      generatorModels:
+        (DOCX_LABELER_CONFIG.settings &&
+          DOCX_LABELER_CONFIG.settings.generatorModels) ||
+        "",
+      defragmentRuns:
+        DOCX_LABELER_CONFIG.settings &&
+        typeof DOCX_LABELER_CONFIG.settings.defragmentRuns === "boolean"
+          ? DOCX_LABELER_CONFIG.settings.defragmentRuns
+          : true,
+      usePlaygroundVariables:
+        DOCX_LABELER_CONFIG.settings &&
+        typeof DOCX_LABELER_CONFIG.settings.usePlaygroundVariables === "boolean"
+          ? DOCX_LABELER_CONFIG.settings.usePlaygroundVariables
+          : false,
+      showLowConfidence:
+        DOCX_LABELER_CONFIG.settings &&
+        typeof DOCX_LABELER_CONFIG.settings.showLowConfidence === "boolean"
+          ? DOCX_LABELER_CONFIG.settings.showLowConfidence
+          : false,
+    },
+    activeTab: "existing",
+    editingLabelId: null,
+    validation: null,
+    syntaxValidation: null,
+    syntaxValidationPending: false,
+    syntaxValidationTimer: null,
+    syntaxValidationRequestToken: 0,
+  };
+
+  // ================================================================
+  // DOM Elements
+  // ================================================================
+  const fileInput = document.getElementById("file-input");
+  const fileName = document.getElementById("file-name");
+  const openPlaygroundBtn = document.getElementById("open-playground-btn");
+  const savePlaygroundBtn = document.getElementById("save-playground-btn");
+  const openPlaygroundModalEl = document.getElementById(
+    "open-playground-modal",
+  );
+  const savePlaygroundModalEl = document.getElementById(
+    "save-playground-modal",
+  );
+  const interviewPickerPanel = document.getElementById(
+    "interview-picker-panel",
+  );
+  const interviewPickerSidebarHost = document.getElementById(
+    "interview-picker-sidebar-host",
+  );
+  const settingsInterviewPickerHost = document.getElementById(
+    "settings-interview-picker-host",
+  );
+  const changeInterviewSourceBtn = document.getElementById(
+    "change-interview-source-btn",
+  );
+  const interviewSourceModeInputs = Array.from(
+    document.querySelectorAll('input[name="interview-source-mode"]'),
+  );
+  const playgroundFields = document.getElementById("playground-fields");
+  const installedFields = document.getElementById("installed-fields");
+  const playgroundProjectSelect = document.getElementById("playground-project");
+  const playgroundYamlFileSelect = document.getElementById(
+    "playground-yaml-file",
+  );
+  const installedPackageSelect = document.getElementById("installed-package");
+  const installedYamlFileSelect = document.getElementById(
+    "installed-yaml-file",
+  );
+  const interviewVariableSummary = document.getElementById(
+    "interview-variable-summary",
+  );
+  const loadingState = document.getElementById("loading-state");
+  const loadingMessage = document.getElementById("loading-message");
+  const errorState = document.getElementById("error-state");
+  const errorMessage = document.getElementById("error-message");
+  const emptyState = document.getElementById("empty-state");
+  const mainPanel = document.getElementById("main-panel");
+  const previewEmpty = document.getElementById("preview-empty");
+  const previewContent = document.getElementById("preview-content");
+  const applyHighlightsBtn = document.getElementById("apply-highlights-btn");
+  const downloadBtn = document.getElementById("download-btn");
+  const downloadStatus = document.getElementById("download-status");
+  const syntaxValidationBanner = document.getElementById("syntax-validation");
+  const existingPanel = document.getElementById("existing-panel");
+  const manualPanel = document.getElementById("manual-panel");
+  const suggestionsPanel = document.getElementById("suggestions-panel");
+
+  const suggestionsList = document.getElementById("suggestions-list");
+  const manualLabelsList = document.getElementById("manual-labels-list");
+  const existingLabelsTree = document.getElementById("existing-labels-tree");
+  const existingCount = document.getElementById("existing-count");
+  const manualCount = document.getElementById("manual-count");
+  const suggestionsCount = document.getElementById("suggestions-count");
+  const tabExisting = document.getElementById("tab-existing");
+  const tabManual = document.getElementById("tab-manual");
+  const tabSuggestions = document.getElementById("tab-suggestions");
+
+  var TAB_ORDER = [
+    { name: "existing", tab: tabExisting, panel: existingPanel },
+    { name: "manual", tab: tabManual, panel: manualPanel },
+    { name: "suggestions", tab: tabSuggestions, panel: suggestionsPanel },
+  ];
+
+  // Arrow-key navigation between tabs, per the ARIA tabs pattern.
+  TAB_ORDER.forEach(function (entry) {
+    entry.tab.addEventListener("keydown", function (event) {
+      var visible = TAB_ORDER.filter(function (candidate) {
+        return !candidate.tab.classList.contains("hidden");
+      });
+      var index = visible.indexOf(entry);
+      if (index === -1) return;
+      var next = null;
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        next = visible[(index + 1) % visible.length];
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        next = visible[(index - 1 + visible.length) % visible.length];
+      } else if (event.key === "Home") {
+        next = visible[0];
+      } else if (event.key === "End") {
+        next = visible[visible.length - 1];
+      }
+      if (!next) return;
+      event.preventDefault();
+      switchTab(next.name, { focusTab: true });
+    });
+  });
+
+  const variableTree = document.getElementById("variable-tree");
+  const variableSearch = document.getElementById("variable-search");
+  const settingsModal = document.getElementById("settings-modal");
+  const bulkReplaceModal = document.getElementById("bulk-replace-modal");
+  const editLabelModal = document.getElementById("edit-label-modal");
+  const selPopover = document.getElementById("sel-popover");
+  const selOriginalText = document.getElementById("sel-original-text");
+  const selVarInput = document.getElementById("sel-var-input");
+  const selVarPanel = document.getElementById("sel-var-panel");
+  const selVarTree = document.getElementById("sel-var-tree");
+  const selVarSearch = document.getElementById("sel-var-search");
+  const aiModelInput = document.getElementById("ai-model");
+  const aiModelSuggestions = document.getElementById("ai-model-suggestions");
+  const promptProfileInput = document.getElementById("prompt-profile");
+  const generationMethodInput = document.getElementById("generation-method");
+  const generatorModelsGroup = document.getElementById(
+    "generator-models-group",
+  );
+  const generatorModelsInput = document.getElementById("generator-models");
+  const judgeModelInput = document.getElementById("judge-model");
+  const usePlaygroundVariablesInput = document.getElementById(
+    "use-playground-variables",
+  );
+  const usePlaygroundVarsGroup = document.getElementById(
+    "use-playground-vars-group",
+  );
+  const playgroundSettingsSummary = document.getElementById(
+    "playground-settings-summary",
+  );
+  const authControls = document.getElementById("auth-controls");
+  const utilitiesBtn = document.getElementById("utilities-btn");
+  const repairBtn = document.getElementById("repair-btn");
+  const aiAuthNotice = document.getElementById("ai-auth-notice");
+  const suggestionsValidation = document.getElementById(
+    "suggestions-validation",
+  );
+  const toggleLowConfidence = document.getElementById("toggle-low-confidence");
+  const lowConfidenceSummary = document.getElementById(
+    "low-confidence-summary",
+  );
+  const utilitiesModal = document.getElementById("utilities-modal");
+  const repairModal = document.getElementById("repair-modal");
+  const utilityFileInput = document.getElementById("utility-file-input");
+  const repairFileInput = document.getElementById("repair-file-input");
+  const utilitySourceActive = document.getElementById("utility-source-active");
+  const utilitySourceUpload = document.getElementById("utility-source-upload");
+  const repairSourceActive = document.getElementById("repair-source-active");
+  const repairSourceUpload = document.getElementById("repair-source-upload");
+  const utilitiesResult = document.getElementById("utilities-result");
+  const repairResult = document.getElementById("repair-result");
+  const utilitySourceStatus = document.getElementById("utility-source-status");
+  const repairSourceStatus = document.getElementById("repair-source-status");
+
+  // ================================================================
+  // Helpers
+  // ================================================================
+  function escapeHtml(text) {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function generateId() {
+    return "id-" + Math.random().toString(36).substr(2, 9);
+  }
+
+  function getConfidenceMeta(tier) {
+    if (tier === "high") {
+      return {
+        label: "High confidence",
+        badge:
+          "bg-success-subtle text-success-emphasis border border-success-subtle",
+      };
+    }
+    if (tier === "medium") {
+      return {
+        label: "Medium confidence",
+        badge:
+          "bg-warning-subtle text-warning-emphasis border border-warning-subtle",
+      };
+    }
+    return {
+      label: "Low confidence",
+      badge:
+        "bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle",
+    };
+  }
+
+  function summarizeSuggestionSources(suggestion) {
+    var sources = Array.isArray(suggestion.sources) ? suggestion.sources : [];
+    var models = [];
+    sources.forEach(function (source) {
+      if (source && source.model && models.indexOf(source.model) === -1) {
+        models.push(source.model);
+      }
+    });
+    return models.join(", ");
+  }
+
+  function isManualSuggestion(suggestion) {
+    return !!(suggestion && suggestion._isManual);
+  }
+
+  function getManualLabelGroups() {
+    return state.suggestions.filter(function (suggestion) {
+      return isManualSuggestion(suggestion) && !suggestion._isCompanion;
+    });
+  }
+
+  function applyManualLabelText(groupId, variableName) {
+    state.suggestions.forEach(function (suggestion) {
+      if (suggestion.group !== groupId) return;
+      suggestion._displayLabel = variableName;
+      var manualKind = suggestion._manualKind || "replace";
+      if (manualKind === "if_wrap" || manualKind === "ifp_wrap") {
+        var openTag =
+          manualKind === "ifp_wrap"
+            ? "{%p if " + variableName + " %}"
+            : "{% if " + variableName + " %}";
+        var closeTag =
+          manualKind === "ifp_wrap" ? "{%p endif %}" : "{% endif %}";
+        var selectedFragment = suggestion._selectedFragment || "";
+        if (suggestion._manualRole === "single") {
+          suggestion.text =
+            (suggestion._manualPrefix || "") +
+            openTag +
+            selectedFragment +
+            closeTag +
+            (suggestion._manualSuffix || "");
+        } else if (suggestion._manualRole === "first") {
+          suggestion.text =
+            (suggestion._manualPrefix || "") + openTag + selectedFragment;
+        } else if (suggestion._manualRole === "last") {
+          suggestion.text =
+            selectedFragment + closeTag + (suggestion._manualSuffix || "");
+        } else if (suggestion._manualRole === "middle") {
+          suggestion.text = selectedFragment;
         }
+        return;
+      }
+      if (suggestion._manualRole === "single") {
+        suggestion.text =
+          (suggestion._manualPrefix || "") +
+          variableName +
+          (suggestion._manualSuffix || "");
+      } else if (suggestion._manualRole === "first") {
+        suggestion.text = (suggestion._manualPrefix || "") + variableName;
+      } else if (suggestion._manualRole === "last") {
+        suggestion.text = suggestion._manualSuffix || "";
+      } else if (suggestion._manualRole === "middle") {
+        suggestion.text = "";
+      }
+    });
+  }
 
-        const LABELER_BOOTSTRAP = parseBootstrapJson();
-        const INITIAL_PLAYGROUND_SOURCE = LABELER_BOOTSTRAP.initialPlaygroundSource || {};
-        const DOCX_LABELER_CONFIG = (typeof window !== 'undefined' && window.DOCX_LABELER_CONFIG)
-            ? window.DOCX_LABELER_CONFIG
-            : {};
-        const DOCX_LABELER_API = DOCX_LABELER_CONFIG.api || {};
-        const DOCX_LABELER_UI = DOCX_LABELER_CONFIG.ui || {};
+  function collectRenamePayload() {
+    // Labels with run positioning are handled as run-level patches
+    // in collectAcceptedLabels(). For unresolved labels without run
+    // coordinates, only allow a global rename when the document has a
+    // single such occurrence, which avoids clobbering duplicates.
+    var renames = [];
+    var unresolvedCounts = {};
+    (state.existingLabels || []).forEach(function (label) {
+      if (!label) return;
+      if (typeof label.paragraph === "number" && typeof label.run === "number")
+        return;
+      if (Array.isArray(label.segments) && label.segments.length > 0) return;
+      unresolvedCounts[label.original] =
+        (unresolvedCounts[label.original] || 0) + 1;
+    });
+    (state.existingLabels || []).forEach(function (label) {
+      if (!label || label.current === label.original) return;
+      if (typeof label.paragraph === "number" && typeof label.run === "number")
+        return;
+      if (Array.isArray(label.segments) && label.segments.length > 0) return;
+      if ((unresolvedCounts[label.original] || 0) !== 1) return;
+      renames.push({ original: label.original, replacement: label.current });
+    });
+    return renames;
+  }
 
-        function endpointPath(key, fallback) {
-            var override = DOCX_LABELER_API[key];
-            return (typeof override === 'string' && override.trim()) ? override.trim() : fallback;
-        }
+  function collectAcceptedLabels() {
+    var acceptedByKey = {};
+    if (previewUtils && previewUtils.buildAcceptedRunPatchLookup) {
+      acceptedByKey = previewUtils.buildAcceptedRunPatchLookup(
+        state.runs,
+        state.existingLabels,
+        state.suggestions,
+      );
+    } else {
+      state.suggestions
+        .filter(function (s) {
+          return s.status === "accepted";
+        })
+        .forEach(function (s) {
+          var key = s.paragraph + "," + s.run + "," + (s.new_paragraph || 0);
+          acceptedByKey[key] = {
+            paragraph: s.paragraph,
+            run: s.run,
+            text: s.text,
+            new_paragraph: s.new_paragraph,
+          };
+        });
+    }
 
-        function shouldHideInterviewPicker() {
-            return !!DOCX_LABELER_UI.hideInterviewPicker;
-        }
+    return Object.keys(acceptedByKey).map(function (key) {
+      return acceptedByKey[key];
+    });
+  }
 
-        function cloneVariableTree(value) {
-            if (Array.isArray(value)) {
-                return value.map(cloneVariableTree);
-            }
-            if (!value || typeof value !== 'object') {
-                return value;
-            }
-            var clone = {};
-            Object.keys(value).forEach(function(key) {
-                clone[key] = cloneVariableTree(value[key]);
-            });
-            return clone;
-        }
+  function renderSyntaxValidation() {
+    if (!syntaxValidationBanner) return;
+    var validation = state.syntaxValidation;
+    var errors =
+      validation && Array.isArray(validation.errors) ? validation.errors : [];
+    var warnings =
+      validation && Array.isArray(validation.warnings)
+        ? validation.warnings
+        : [];
 
-        function mergeVariableTree(baseTree, extraTree) {
-            var merged = cloneVariableTree(baseTree || {});
-            if (!extraTree || typeof extraTree !== 'object') {
-                return merged;
-            }
-            Object.keys(extraTree).forEach(function(key) {
-                var extraValue = extraTree[key];
-                var mergedValue = merged[key];
-                if (
-                    mergedValue && extraValue
-                    && typeof mergedValue === 'object'
-                    && typeof extraValue === 'object'
-                    && !Array.isArray(mergedValue)
-                    && !Array.isArray(extraValue)
-                ) {
-                    merged[key] = mergeVariableTree(mergedValue, extraValue);
-                } else {
-                    merged[key] = cloneVariableTree(extraValue);
-                }
-            });
-            return merged;
-        }
+    if (
+      !state.syntaxValidationPending &&
+      errors.length === 0 &&
+      warnings.length === 0
+    ) {
+      syntaxValidationBanner.className = "hidden alert small mb-2";
+      syntaxValidationBanner.textContent = "";
+      return;
+    }
 
-        function getSingletonListChild(value) {
-            if (!value || typeof value !== 'object' || Array.isArray(value)) {
-                return null;
-            }
-            var childKeys = Object.keys(value).filter(function(key) { return !key.startsWith('_'); });
-            if (childKeys.length !== 1 || childKeys[0] !== '[0]') {
-                return null;
-            }
-            var child = value['[0]'];
-            return child && typeof child === 'object' && !Array.isArray(child) ? child : null;
-        }
+    var className = "alert small mb-2";
+    var html = "";
+    if (errors.length > 0) {
+      className += " alert-danger";
+      html += '<div class="fw-semibold">Jinja syntax errors detected</div>';
+      errors.forEach(function (issue) {
+        var label =
+          issue.paragraph !== undefined
+            ? "Paragraph " + (issue.paragraph + 1)
+            : "Template";
+        html +=
+          "<div>" +
+          escapeHtml(
+            label + ": " + (issue.message || issue.code || "Syntax error"),
+          ) +
+          "</div>";
+      });
+    } else if (warnings.length > 0) {
+      className += " alert-warning";
+      html += '<div class="fw-semibold">Jinja validation warnings</div>';
+      warnings.forEach(function (issue) {
+        html +=
+          "<div>" +
+          escapeHtml(issue.message || issue.code || "Warning") +
+          "</div>";
+      });
+    } else {
+      className += " alert-info";
+      html = "<div>Checking Jinja syntax...</div>";
+    }
 
-        const DOCX_LABELER_VARIABLE_TREE_EXTRAS = DOCX_LABELER_CONFIG.variableTreeExtras || {};
+    if (
+      state.syntaxValidationPending &&
+      (errors.length > 0 || warnings.length > 0)
+    ) {
+      html += '<div class="mt-1 text-muted">Rechecking...</div>';
+    }
 
-        // ================================================================
-        // AssemblyLine Variable Tree Structure
-        // ================================================================
-        const PERSON_ATTRIBUTES = {
-            'name': {
-                _description: 'Name components',
-                'first': 'First name',
-                'middle': 'Middle name',
-                'middle_initial()': 'Middle initial',
-                'last': 'Last name',
-                'suffix': 'Suffix (Jr., Sr., III, etc.)',
-                'full()': 'Full name'
+    syntaxValidationBanner.className = className;
+    syntaxValidationBanner.innerHTML = html;
+  }
+
+  async function validateCurrentSyntax(options) {
+    options = options || {};
+    if (!state.file) {
+      state.syntaxValidation = null;
+      state.syntaxValidationPending = false;
+      renderSyntaxValidation();
+      return null;
+    }
+
+    var renames = collectRenamePayload();
+    var acceptedLabels = collectAcceptedLabels();
+    if (!options.force && renames.length === 0 && acceptedLabels.length === 0) {
+      state.syntaxValidation = null;
+      state.syntaxValidationPending = false;
+      renderSyntaxValidation();
+      return null;
+    }
+
+    var requestToken = state.syntaxValidationRequestToken + 1;
+    state.syntaxValidationRequestToken = requestToken;
+    state.syntaxValidationPending = true;
+    renderSyntaxValidation();
+
+    try {
+      var formData = new FormData();
+      formData.append("file", state.file);
+      formData.append(
+        "defragment_runs",
+        state.settings.defragmentRuns ? "true" : "false",
+      );
+      if (renames.length > 0)
+        formData.append("renames", JSON.stringify(renames));
+      if (acceptedLabels.length > 0)
+        formData.append("labels", JSON.stringify(acceptedLabels));
+      var response = await fetch("/al/docx-labeler/api/validate-syntax", {
+        method: "POST",
+        body: formData,
+      });
+      var data = await parseApiResponse(response);
+      if (requestToken === state.syntaxValidationRequestToken) {
+        state.syntaxValidation =
+          data.data && data.data.validation ? data.data.validation : null;
+      }
+    } catch (error) {
+      if (requestToken === state.syntaxValidationRequestToken) {
+        state.syntaxValidation = {
+          valid: false,
+          errors: [
+            {
+              code: "validation_request_failed",
+              message: error.message || "Syntax validation failed.",
             },
-            'address': {
-                _description: 'Address components',
-                'block()': 'Full address (multiple lines)',
-                'on_one_line()': 'Full address (single line)',
-                'line_one()': 'Street + unit',
-                'line_two()': 'City, state, zip',
-                'address': 'Street address',
-                'unit': 'Unit/Apt/Suite',
-                'city': 'City',
-                'state': 'State',
-                'zip': 'ZIP/Postal code',
-                'county': 'County',
-                'country': 'Country'
-            },
-            'birthdate': 'Date of birth',
-            'age_in_years()': 'Age (calculated)',
-            'gender': 'Gender',
-            'gender_female': 'Is female (checkbox)',
-            'gender_male': 'Is male (checkbox)',
-            'gender_other': 'Other gender (checkbox)',
-            'gender_nonbinary': 'Nonbinary (checkbox)',
-            'gender_undisclosed': 'Undisclosed (checkbox)',
-            'phone_number': 'Phone number',
-            'mobile_number': 'Mobile phone',
-            'phone_numbers()': 'All phone numbers',
-            'email': 'Email address',
-            'signature': 'Signature'
+          ],
+          warnings: [],
         };
+      }
+    } finally {
+      if (requestToken === state.syntaxValidationRequestToken) {
+        state.syntaxValidationPending = false;
+        renderSyntaxValidation();
+        updateDownloadButton();
+      }
+    }
 
-        const ATTORNEY_ATTRIBUTES = {
-            ...PERSON_ATTRIBUTES,
-            'bar_number': 'Bar/License number'
+    return state.syntaxValidation;
+  }
+
+  function scheduleSyntaxValidation(delay) {
+    if (state.syntaxValidationTimer) {
+      window.clearTimeout(state.syntaxValidationTimer);
+    }
+    state.syntaxValidationTimer = window.setTimeout(
+      function () {
+        validateCurrentSyntax();
+      },
+      typeof delay === "number" ? delay : 400,
+    );
+  }
+
+  async function ensureSyntaxValidationBeforeWrite(actionLabel) {
+    var validation = await validateCurrentSyntax({ force: true });
+    var errors =
+      validation && Array.isArray(validation.errors) ? validation.errors : [];
+    if (errors.length === 0) {
+      return {
+        allowed: true,
+        validation: validation,
+        allowInvalidSyntax: false,
+      };
+    }
+
+    var summary = errors
+      .slice(0, 3)
+      .map(function (issue) {
+        return "- " + (issue.message || issue.code || "Syntax error");
+      })
+      .join("\n");
+    var proceed = window.confirm(
+      "The Jinja syntax validator found errors before " +
+        actionLabel +
+        ":\n\n" +
+        summary +
+        "\n\nSave anyway?",
+    );
+    return {
+      allowed: proceed,
+      validation: validation,
+      allowInvalidSyntax: proceed,
+    };
+  }
+
+  function swapSuggestionWithAlternate(suggestion, alternateIndex) {
+    if (!suggestion || !Array.isArray(suggestion.alternates)) return;
+    var alternate = suggestion.alternates[alternateIndex];
+    if (!alternate) return;
+    var currentPrimary = {
+      text: suggestion.text,
+      paragraph: suggestion.paragraph,
+      run: suggestion.run,
+      new_paragraph: suggestion.new_paragraph,
+      validation_flags: suggestion.validation_flags || [],
+      judge_review: suggestion.judge_review || null,
+      confidence: suggestion.confidence || "low",
+      vote_count: suggestion.vote_count || 0,
+      clean_vote_count: suggestion.clean_vote_count || 0,
+      vote_total: suggestion.vote_total || 0,
+      sources: suggestion.sources || [],
+    };
+    suggestion.text = alternate.text;
+    suggestion.validation_flags = alternate.validation_flags || [];
+    suggestion.judge_review = alternate.judge_review || null;
+    suggestion.confidence = alternate.confidence || "low";
+    suggestion.vote_count = alternate.vote_count || 0;
+    suggestion.clean_vote_count = alternate.clean_vote_count || 0;
+    suggestion.vote_total = alternate.vote_total || suggestion.vote_total || 0;
+    suggestion.sources = alternate.sources || [];
+    suggestion.alternates.splice(alternateIndex, 1, currentPrimary);
+  }
+
+  async function fetchModelCatalog() {
+    try {
+      var response = await fetch(
+        endpointPath("models", "/al/labeler/api/models"),
+        { method: "GET" },
+      );
+      var data = await response.json();
+      if (!data.success || !data.data) return;
+      state.defaultModel = data.data.default_model || state.defaultModel;
+      state.recommendedModels =
+        Array.isArray(data.data.recommended_models) &&
+        data.data.recommended_models.length
+          ? data.data.recommended_models
+          : [state.defaultModel];
+      state.availableModels = Array.isArray(data.data.available_models)
+        ? data.data.available_models
+        : [];
+      state.settings.model = state.defaultModel;
+      renderModelSuggestions("");
+    } catch (_error) {
+      renderModelSuggestions("");
+    }
+  }
+
+  function renderAuthControls() {
+    if (!authControls) return;
+    if (state.auth.isAuthenticated) {
+      var emailText = state.auth.email || "Account";
+      authControls.innerHTML =
+        '<button id="auth-menu-btn" class="btn btn-outline-light btn-sm dropdown-toggle" type="button" aria-expanded="false">' +
+        escapeHtml(emailText) +
+        "</button>" +
+        '<div id="auth-menu" class="dropdown-menu dropdown-menu-end">' +
+        '<a class="dropdown-item" href="' +
+        escapeHtml(state.auth.logoutUrl || "/user/sign-out") +
+        '">Log out</a>' +
+        "</div>";
+      var menuBtn = document.getElementById("auth-menu-btn");
+      var menu = document.getElementById("auth-menu");
+      menuBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        menu.classList.toggle("show");
+      });
+    } else {
+      authControls.innerHTML =
+        '<a class="btn btn-outline-light btn-sm" href="' +
+        escapeHtml(state.auth.loginUrl || "/user/sign-in") +
+        '">Log in</a>';
+    }
+  }
+
+  function updateAiUiState() {
+    var aiEnabled = !!state.auth.aiEnabled;
+    var regenerateBtn = document.getElementById("regenerate-btn");
+    if (regenerateBtn) {
+      regenerateBtn.disabled = !aiEnabled;
+    }
+    if (!aiEnabled) {
+      aiAuthNotice.classList.remove("hidden");
+      aiAuthNotice.innerHTML =
+        'AI labeling requires login. <a href="' +
+        escapeHtml(state.auth.loginUrl || "/user/sign-in") +
+        '">Log in</a> to enable suggestions.';
+    } else {
+      aiAuthNotice.classList.add("hidden");
+    }
+    // Show playground buttons only when authenticated
+    if (state.auth.isAuthenticated) {
+      openPlaygroundBtn.classList.remove("hidden");
+    } else {
+      openPlaygroundBtn.classList.add("hidden");
+      savePlaygroundBtn.classList.add("hidden");
+    }
+  }
+
+  function getActiveInterviewSourceState() {
+    return state.interviewSourceMode === "installed"
+      ? state.installed
+      : state.playground;
+  }
+
+  function moveInterviewPickerTo(hostElement) {
+    if (!hostElement || !interviewPickerPanel) return;
+    if (interviewPickerPanel.parentElement !== hostElement) {
+      hostElement.appendChild(interviewPickerPanel);
+    }
+  }
+
+  function getActiveInterviewSourceLabel() {
+    var sourceState = getActiveInterviewSourceState();
+    if (state.interviewSourceMode === "installed") {
+      if (!sourceState.selectedPackage || !sourceState.selectedFile) return "";
+      return sourceState.selectedPackage + "/" + sourceState.selectedFile;
+    }
+    if (!sourceState.selectedProject || !sourceState.selectedFile) return "";
+    return sourceState.selectedProject + "/" + sourceState.selectedFile;
+  }
+
+  function renderInterviewSourceSummary() {
+    if (!interviewVariableSummary || !playgroundSettingsSummary) return;
+    var sourceLabel = getActiveInterviewSourceLabel();
+    var sourceState = getActiveInterviewSourceState();
+    var sourceText =
+      state.interviewSourceMode === "installed"
+        ? "installed interview"
+        : "Playground interview";
+    var count = sourceState.variables.length;
+    if (sourceLabel) {
+      interviewVariableSummary.textContent =
+        sourceLabel +
+        (count
+          ? " (" +
+            count +
+            " vars, " +
+            sourceState.topLevelNames.length +
+            " top-level)"
+          : " (no variables detected yet)");
+      interviewVariableSummary.classList.remove("hidden");
+      playgroundSettingsSummary.textContent =
+        "Selected " +
+        sourceText +
+        ": " +
+        sourceLabel +
+        (count ? ". The prompt will prefer its existing variable names." : ".");
+    } else {
+      interviewVariableSummary.classList.add("hidden");
+      playgroundSettingsSummary.textContent =
+        "Select a Playground or installed interview from the sidebar to use its variable list in the prompt.";
+    }
+  }
+
+  function renderInterviewPicker() {
+    if (
+      !interviewPickerPanel ||
+      !interviewPickerSidebarHost ||
+      !settingsInterviewPickerHost ||
+      !usePlaygroundVarsGroup
+    )
+      return;
+    if (shouldHideInterviewPicker()) {
+      usePlaygroundVarsGroup.classList.add("hidden");
+      if (changeInterviewSourceBtn)
+        changeInterviewSourceBtn.classList.add("hidden");
+      interviewPickerPanel.classList.add("hidden");
+      interviewPickerSidebarHost.classList.add("hidden");
+      settingsInterviewPickerHost.classList.add("hidden");
+      state.settings.usePlaygroundVariables = false;
+      usePlaygroundVariablesInput.checked = false;
+      usePlaygroundVariablesInput.disabled = true;
+      return;
+    }
+    var showPicker = !!state.auth.isAuthenticated;
+    usePlaygroundVarsGroup.classList.toggle("hidden", !showPicker);
+    if (changeInterviewSourceBtn) {
+      changeInterviewSourceBtn.classList.toggle("hidden", !showPicker);
+      changeInterviewSourceBtn.textContent = state.ui
+        .editInterviewSourceInSettings
+        ? "Done"
+        : "Change";
+    }
+    if (showPicker && state.ui.editInterviewSourceInSettings) {
+      moveInterviewPickerTo(settingsInterviewPickerHost);
+    } else {
+      moveInterviewPickerTo(interviewPickerSidebarHost);
+    }
+    interviewPickerPanel.classList.toggle("hidden", !showPicker);
+    interviewPickerSidebarHost.classList.toggle(
+      "hidden",
+      !showPicker || state.ui.editInterviewSourceInSettings,
+    );
+    settingsInterviewPickerHost.classList.toggle(
+      "hidden",
+      !showPicker || !state.ui.editInterviewSourceInSettings,
+    );
+    playgroundFields.classList.toggle(
+      "hidden",
+      state.interviewSourceMode !== "playground",
+    );
+    installedFields.classList.toggle(
+      "hidden",
+      state.interviewSourceMode !== "installed",
+    );
+    interviewSourceModeInputs.forEach(function (input) {
+      input.checked = input.value === state.interviewSourceMode;
+    });
+
+    playgroundProjectSelect.innerHTML = "";
+    state.playground.projects.forEach(function (projectName) {
+      var option = document.createElement("option");
+      option.value = projectName;
+      option.textContent = projectName;
+      if (projectName === state.playground.selectedProject)
+        option.selected = true;
+      playgroundProjectSelect.appendChild(option);
+    });
+
+    playgroundYamlFileSelect.innerHTML = "";
+    if (!state.playground.files.length) {
+      var emptyPlaygroundOption = document.createElement("option");
+      emptyPlaygroundOption.value = "";
+      emptyPlaygroundOption.textContent = "No YAML files found";
+      playgroundYamlFileSelect.appendChild(emptyPlaygroundOption);
+    } else {
+      state.playground.files.forEach(function (fileInfo) {
+        var option = document.createElement("option");
+        option.value = fileInfo.filename;
+        option.textContent = fileInfo.label || fileInfo.filename;
+        if (fileInfo.filename === state.playground.selectedFile)
+          option.selected = true;
+        playgroundYamlFileSelect.appendChild(option);
+      });
+    }
+
+    installedPackageSelect.innerHTML = "";
+    state.installed.packages.forEach(function (packageName) {
+      var option = document.createElement("option");
+      option.value = packageName;
+      option.textContent = packageName;
+      if (packageName === state.installed.selectedPackage)
+        option.selected = true;
+      installedPackageSelect.appendChild(option);
+    });
+
+    installedYamlFileSelect.innerHTML = "";
+    if (!state.installed.files.length) {
+      var emptyInstalledOption = document.createElement("option");
+      emptyInstalledOption.value = "";
+      emptyInstalledOption.textContent = "No YAML files found";
+      installedYamlFileSelect.appendChild(emptyInstalledOption);
+    } else {
+      state.installed.files.forEach(function (fileInfo) {
+        var option = document.createElement("option");
+        option.value = fileInfo.filename;
+        option.textContent = fileInfo.label || fileInfo.filename;
+        if (fileInfo.filename === state.installed.selectedFile)
+          option.selected = true;
+        installedYamlFileSelect.appendChild(option);
+      });
+    }
+
+    var activeSourceState = getActiveInterviewSourceState();
+    usePlaygroundVariablesInput.disabled =
+      !showPicker || !activeSourceState.selectedFile;
+    if (usePlaygroundVariablesInput.disabled) {
+      state.settings.usePlaygroundVariables = false;
+      usePlaygroundVariablesInput.checked = false;
+    }
+    renderInterviewSourceSummary();
+  }
+
+  function deriveTopLevelNames(variableNames) {
+    return Array.from(
+      new Set(
+        (Array.isArray(variableNames) ? variableNames : [])
+          .map(function (name) {
+            return String(name || "").trim();
+          })
+          .filter(function (name) {
+            return !!name;
+          })
+          .map(function (name) {
+            return name.split(".", 1)[0].split("[", 1)[0];
+          })
+          .filter(function (name) {
+            return !!name;
+          }),
+      ),
+    ).sort(function (a, b) {
+      return a.localeCompare(b);
+    });
+  }
+
+  function splitVariablePathSegments(variableName) {
+    var raw = String(variableName || "").trim();
+    if (!raw) return [];
+    var matches = raw.match(/([^[.\]]+|\[[^\]]*\])/g);
+    return Array.isArray(matches)
+      ? matches.filter(function (part) {
+          return !!part;
+        })
+      : [raw];
+  }
+
+  function buildInterviewVariableTree(variableNames) {
+    var root = {
+      _description: "Variables detected from the selected interview",
+    };
+    (Array.isArray(variableNames) ? variableNames : []).forEach(
+      function (variableName) {
+        var segments = splitVariablePathSegments(variableName);
+        if (!segments.length) return;
+        var node = root;
+        segments.forEach(function (segment, index) {
+          var isLeaf = index === segments.length - 1;
+          if (!node[segment] || typeof node[segment] !== "object") {
+            node[segment] = {};
+          }
+          if (isLeaf) {
+            node[segment]._variable = true;
+            node[segment]._description = "Selected interview variable";
+          }
+          node = node[segment];
+        });
+      },
+    );
+    return root;
+  }
+
+  function getEffectiveVariableTree() {
+    var sourceState = getActiveInterviewSourceState();
+    var baseTree = AL_VARIABLE_TREE;
+
+    if (
+      state.settings &&
+      state.settings.primaryPersonVariable &&
+      state.settings.primaryPersonVariable !== "users"
+    ) {
+      baseTree = cloneVariableTree(AL_VARIABLE_TREE);
+      if (baseTree["users"]) {
+        baseTree[state.settings.primaryPersonVariable] = baseTree["users"];
+        delete baseTree["users"];
+      }
+    }
+
+    if (!sourceState.variables.length) {
+      return baseTree;
+    }
+    return Object.assign(
+      {
+        "Selected interview variables": buildInterviewVariableTree(
+          sourceState.variables,
+        ),
+      },
+      baseTree,
+    );
+  }
+
+  async function fetchJsonOrThrow(url) {
+    var response = await fetch(url, {
+      method: "GET",
+      credentials: "same-origin",
+    });
+    if (!response.ok) {
+      throw new Error("Request failed with status " + response.status);
+    }
+    return response.json();
+  }
+
+  async function parseApiResponse(response) {
+    var contentType = response.headers.get("content-type") || "";
+    var data;
+    if (contentType.indexOf("application/json") !== -1) {
+      data = await response.json();
+    } else {
+      var text = await response.text();
+      if (!response.ok) {
+        throw new Error(text || "Request failed (" + response.status + ").");
+      }
+      throw new Error("The server returned a non-JSON response.");
+    }
+    if (!response.ok) {
+      throw new Error(
+        data && data.error && data.error.message
+          ? data.error.message
+          : "Request failed (" + response.status + ").",
+      );
+    }
+    return data;
+  }
+
+  function updateModalSourceStatus() {
+    var hasActiveFile = !!state.file;
+    utilityFileInput.classList.toggle("hidden", utilitySourceActive.checked);
+    repairFileInput.classList.toggle("hidden", repairSourceActive.checked);
+    utilitySourceStatus.textContent = utilitySourceActive.checked
+      ? hasActiveFile
+        ? "The active DOCX will be used."
+        : "No active DOCX is loaded. Choose a separate DOCX upload instead."
+      : utilityFileInput.files[0]
+        ? utilityFileInput.files[0].name
+        : "Choose a DOCX file for utilities.";
+    repairSourceStatus.textContent = repairSourceActive.checked
+      ? hasActiveFile
+        ? "The active DOCX will be used."
+        : "No active DOCX is loaded. Choose a separate DOCX upload instead."
+      : repairFileInput.files[0]
+        ? repairFileInput.files[0].name
+        : "Choose a DOCX file for repair.";
+  }
+
+  function getModalSourceFile(kind) {
+    if (kind === "utility") {
+      return utilitySourceActive.checked
+        ? state.file
+        : utilityFileInput.files[0];
+    }
+    return repairSourceActive.checked ? state.file : repairFileInput.files[0];
+  }
+
+  function downloadBase64Docx(docxBase64, filename) {
+    var binaryString = atob(docxBase64);
+    var bytes = new Uint8Array(binaryString.length);
+    for (var i = 0; i < binaryString.length; i++)
+      bytes[i] = binaryString.charCodeAt(i);
+    var blob = new Blob([bytes], {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement("a");
+    link.href = url;
+    link.download = filename || "output.docx";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function formatReportAsHtml(report) {
+    if (!report) return '<div class="text-muted">No report returned.</div>';
+    if (typeof report === "string")
+      return "<div>" + escapeHtml(report) + "</div>";
+    if (Array.isArray(report))
+      return (
+        '<pre class="bg-light rounded p-2 small mb-0">' +
+        escapeHtml(JSON.stringify(report, null, 2)) +
+        "</pre>"
+      );
+
+    var html = "";
+    if (Array.isArray(report.errors) && report.errors.length) {
+      html +=
+        '<div class="alert alert-danger small"><div class="fw-semibold mb-1">Errors</div>';
+      report.errors.forEach(function (issue) {
+        html +=
+          "<div>" +
+          escapeHtml(issue.message || issue.error || JSON.stringify(issue)) +
+          "</div>";
+      });
+      html += "</div>";
+    }
+    if (
+      Array.isArray(report.warning_details) &&
+      report.warning_details.length
+    ) {
+      html +=
+        '<div class="alert alert-warning small"><div class="fw-semibold mb-1">Warnings</div>';
+      report.warning_details.forEach(function (issue) {
+        html +=
+          "<div>" +
+          escapeHtml(issue.message || issue.code || JSON.stringify(issue)) +
+          "</div>";
+      });
+      html += "</div>";
+    } else if (Array.isArray(report.warnings) && report.warnings.length) {
+      html +=
+        '<div class="alert alert-warning small"><div class="fw-semibold mb-1">Warnings</div>';
+      report.warnings.forEach(function (issue) {
+        html +=
+          "<div>" +
+          escapeHtml(
+            typeof issue === "string"
+              ? issue
+              : issue.message || issue.code || JSON.stringify(issue),
+          ) +
+          "</div>";
+      });
+      html += "</div>";
+    }
+    if (
+      Array.isArray(report.xml_parse_errors) &&
+      report.xml_parse_errors.length
+    ) {
+      html +=
+        '<div class="alert alert-danger small"><div class="fw-semibold mb-1">XML Parse Errors</div>';
+      report.xml_parse_errors.forEach(function (issue) {
+        html +=
+          "<div>" +
+          escapeHtml(
+            (issue.part || "part") + ": " + (issue.error || "Parse error"),
+          ) +
+          "</div>";
+      });
+      html += "</div>";
+    }
+    if (Array.isArray(report.schema_errors) && report.schema_errors.length) {
+      html +=
+        '<div class="alert alert-danger small"><div class="fw-semibold mb-1">Schema Errors</div>';
+      report.schema_errors.forEach(function (issue) {
+        html +=
+          "<div>" +
+          escapeHtml(
+            (issue.part || "part") + ": " + (issue.error || "Schema error"),
+          ) +
+          "</div>";
+      });
+      html += "</div>";
+    }
+    if (report.message) {
+      html +=
+        '<div class="alert alert-info small">' +
+        escapeHtml(report.message) +
+        "</div>";
+    }
+    html +=
+      '<pre class="bg-light rounded p-2 small mb-0">' +
+      escapeHtml(JSON.stringify(report, null, 2)) +
+      "</pre>";
+    return html;
+  }
+
+  async function runDocxOperation(kind, action, progressMessage) {
+    var sourceFile = getModalSourceFile(kind);
+    if (!sourceFile) {
+      showError("Choose a DOCX file or load one into the editor first.");
+      return;
+    }
+
+    var resultContainer = kind === "utility" ? utilitiesResult : repairResult;
+    var endpoint =
+      kind === "utility"
+        ? "/al/docx-labeler/api/utilities"
+        : "/al/docx-labeler/api/repair";
+    resultContainer.innerHTML = '<div class="text-muted">Running...</div>';
+    showLoading(progressMessage);
+    try {
+      var formData = new FormData();
+      formData.append("file", sourceFile);
+      formData.append("action", action);
+      var response = await fetch(endpoint, { method: "POST", body: formData });
+      var payload = await parseApiResponse(response);
+      var data = payload.data || {};
+      var html = formatReportAsHtml(data.report);
+      if (data.docx_base64) {
+        html +=
+          '<div class="mt-3"><button class="btn btn-primary btn-sm" id="' +
+          kind +
+          '-download-result">Download Result</button></div>';
+      }
+      resultContainer.innerHTML = html;
+      if (data.docx_base64) {
+        document
+          .getElementById(kind + "-download-result")
+          .addEventListener("click", function () {
+            downloadBase64Docx(data.docx_base64, data.filename);
+          });
+      }
+    } catch (error) {
+      resultContainer.innerHTML =
+        '<div class="alert alert-danger small mb-0">' +
+        escapeHtml(error.message || "Operation failed.") +
+        "</div>";
+    } finally {
+      hideLoading();
+    }
+  }
+
+  function sleep(milliseconds) {
+    return new Promise(function (resolve) {
+      window.setTimeout(resolve, milliseconds);
+    });
+  }
+
+  async function pollLabelerJob(jobUrl, progressMessage) {
+    var startedAt = Date.now();
+    var timeoutMs = 15 * 60 * 1000;
+    while (Date.now() - startedAt < timeoutMs) {
+      await sleep(1500);
+      var response = await fetch(jobUrl, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+      var payload = await parseApiResponse(response);
+      if (payload.status === "queued" || payload.status === "running") {
+        showLoading(progressMessage);
+        continue;
+      }
+      if (payload.status === "failed") {
+        throw new Error(
+          (payload.error && payload.error.message) || "Background job failed.",
+        );
+      }
+      if (payload.status === "succeeded") {
+        return payload.data || {};
+      }
+      throw new Error("Unexpected background job status.");
+    }
+    throw new Error("The background job timed out before it completed.");
+  }
+
+  async function requestAsyncLabelerAction(
+    endpointPath,
+    formData,
+    progressMessage,
+  ) {
+    formData.append("mode", "async");
+    var response = await fetch(endpointPath, {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+    var payload = await parseApiResponse(response);
+    if (payload.status === "queued" && payload.job_url) {
+      showLoading(progressMessage);
+      return pollLabelerJob(payload.job_url, progressMessage);
+    }
+    return payload && payload.data ? payload.data : {};
+  }
+
+  async function fetchPlaygroundProjects() {
+    if (!state.auth.isAuthenticated) {
+      state.playground.projects = [];
+      state.playground.files = [];
+      state.playground.selectedFile = "";
+      state.playground.variables = [];
+      state.playground.topLevelNames = [];
+      renderInterviewPicker();
+      return;
+    }
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath(
+          "playgroundProjects",
+          "/al/labeler/api/playground-projects",
+        ),
+      );
+      state.playground.projects =
+        data && data.success && data.data && Array.isArray(data.data.projects)
+          ? data.data.projects
+          : [];
+      if (
+        state.playground.projects.indexOf(state.playground.selectedProject) ===
+        -1
+      ) {
+        state.playground.selectedProject =
+          state.playground.projects[0] || "default";
+      }
+      await fetchPlaygroundFiles();
+      return;
+    } catch (_error) {}
+    state.playground.projects = [];
+    state.playground.files = [];
+    state.playground.selectedFile = "";
+    state.playground.variables = [];
+    state.playground.topLevelNames = [];
+    renderInterviewPicker();
+  }
+
+  async function fetchPlaygroundFiles() {
+    if (!state.auth.isAuthenticated || !state.playground.selectedProject) {
+      state.playground.files = [];
+      state.playground.selectedFile = "";
+      state.playground.variables = [];
+      state.playground.topLevelNames = [];
+      renderInterviewPicker();
+      return;
+    }
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath("playgroundFiles", "/al/labeler/api/playground-files") +
+          "?project=" +
+          encodeURIComponent(state.playground.selectedProject),
+      );
+      var files =
+        data && data.success && data.data && Array.isArray(data.data.files)
+          ? data.data.files
+          : [];
+      state.playground.files = files;
+      var currentStillExists = files.some(function (item) {
+        return item.filename === state.playground.selectedFile;
+      });
+      state.playground.selectedFile = currentStillExists
+        ? state.playground.selectedFile
+        : files[0]
+          ? files[0].filename
+          : "";
+      renderInterviewPicker();
+      await fetchPlaygroundVariables();
+      return;
+    } catch (_error) {}
+    state.playground.files = [];
+    state.playground.selectedFile = "";
+    state.playground.variables = [];
+    state.playground.topLevelNames = [];
+    renderInterviewPicker();
+  }
+
+  async function fetchPlaygroundVariables() {
+    if (
+      !state.auth.isAuthenticated ||
+      !state.playground.selectedProject ||
+      !state.playground.selectedFile
+    ) {
+      state.playground.variables = [];
+      state.playground.topLevelNames = [];
+      renderInterviewPicker();
+      return;
+    }
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath(
+          "playgroundVariables",
+          "/al/labeler/api/playground-variables",
+        ) +
+          "?project=" +
+          encodeURIComponent(state.playground.selectedProject) +
+          "&filename=" +
+          encodeURIComponent(state.playground.selectedFile),
+      );
+      state.playground.variables =
+        data && data.success && data.data && Array.isArray(data.data.all_names)
+          ? data.data.all_names
+          : [];
+      state.playground.topLevelNames =
+        data &&
+        data.success &&
+        data.data &&
+        Array.isArray(data.data.top_level_names)
+          ? data.data.top_level_names
+          : deriveTopLevelNames(state.playground.variables);
+    } catch (_error) {
+      state.playground.variables = [];
+      state.playground.topLevelNames = [];
+    }
+    renderInterviewPicker();
+  }
+
+  async function fetchInstalledPackages() {
+    if (!state.auth.isAuthenticated) {
+      state.installed.packages = [];
+      state.installed.files = [];
+      state.installed.selectedPackage = "";
+      state.installed.selectedFile = "";
+      state.installed.variables = [];
+      state.installed.topLevelNames = [];
+      renderInterviewPicker();
+      return;
+    }
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath("installedPackages", "/al/labeler/api/installed-packages"),
+      );
+      state.installed.packages =
+        data && data.success && data.data && Array.isArray(data.data.packages)
+          ? data.data.packages
+          : [];
+      if (
+        state.installed.packages.indexOf(state.installed.selectedPackage) === -1
+      ) {
+        state.installed.selectedPackage = state.installed.packages[0] || "";
+      }
+      await fetchInstalledFiles();
+      return;
+    } catch (_error) {}
+    state.installed.packages = [];
+    state.installed.files = [];
+    state.installed.selectedPackage = "";
+    state.installed.selectedFile = "";
+    state.installed.variables = [];
+    state.installed.topLevelNames = [];
+    renderInterviewPicker();
+  }
+
+  async function fetchInstalledFiles() {
+    if (!state.auth.isAuthenticated || !state.installed.selectedPackage) {
+      state.installed.files = [];
+      state.installed.selectedFile = "";
+      state.installed.variables = [];
+      state.installed.topLevelNames = [];
+      renderInterviewPicker();
+      return;
+    }
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath("installedFiles", "/al/labeler/api/installed-files") +
+          "?package=" +
+          encodeURIComponent(state.installed.selectedPackage),
+      );
+      var files =
+        data && data.success && data.data && Array.isArray(data.data.files)
+          ? data.data.files
+          : [];
+      state.installed.files = files;
+      var currentStillExists = files.some(function (item) {
+        return item.filename === state.installed.selectedFile;
+      });
+      state.installed.selectedFile = currentStillExists
+        ? state.installed.selectedFile
+        : files[0]
+          ? files[0].filename
+          : "";
+      renderInterviewPicker();
+      await fetchInstalledVariables();
+      return;
+    } catch (_error) {}
+    state.installed.files = [];
+    state.installed.selectedFile = "";
+    state.installed.variables = [];
+    state.installed.topLevelNames = [];
+    renderInterviewPicker();
+  }
+
+  async function fetchInstalledVariables() {
+    if (
+      !state.auth.isAuthenticated ||
+      !state.installed.selectedPackage ||
+      !state.installed.selectedFile
+    ) {
+      state.installed.variables = [];
+      state.installed.topLevelNames = [];
+      renderInterviewPicker();
+      return;
+    }
+    try {
+      var interviewPath =
+        state.installed.selectedPackage + ":" + state.installed.selectedFile;
+      var data = await fetchJsonOrThrow(
+        endpointPath(
+          "installedVariables",
+          "/al/labeler/api/installed-variables",
+        ) +
+          "?interview_path=" +
+          encodeURIComponent(interviewPath),
+      );
+      state.installed.variables =
+        data && data.success && data.data && Array.isArray(data.data.all_names)
+          ? data.data.all_names
+          : [];
+      state.installed.topLevelNames =
+        data &&
+        data.success &&
+        data.data &&
+        Array.isArray(data.data.top_level_names)
+          ? data.data.top_level_names
+          : deriveTopLevelNames(state.installed.variables);
+    } catch (_error) {
+      state.installed.variables = [];
+      state.installed.topLevelNames = [];
+    }
+    renderInterviewPicker();
+  }
+
+  async function fetchAuthStatus() {
+    try {
+      var nextTarget = window.location.pathname + window.location.search;
+      var response = await fetch(
+        endpointPath("authStatus", "/al/labeler/api/auth-status") +
+          "?next=" +
+          encodeURIComponent(nextTarget),
+        { method: "GET" },
+      );
+      var data = await response.json();
+      if (data.success && data.data) {
+        state.auth.isAuthenticated = !!data.data.is_authenticated;
+        state.auth.email = data.data.email || "";
+        state.auth.loginUrl = data.data.login_url || "/user/sign-in";
+        state.auth.logoutUrl = data.data.logout_url || "/user/sign-out";
+        state.auth.aiEnabled = !!data.data.ai_enabled;
+      }
+    } catch (_error) {
+      state.auth = {
+        isAuthenticated: false,
+        email: "",
+        loginUrl: "/user/sign-in",
+        logoutUrl: "/user/sign-out",
+        aiEnabled: false,
+      };
+    }
+    renderAuthControls();
+    updateAiUiState();
+    if (state.auth.isAuthenticated) {
+      await fetchPlaygroundProjects();
+      await maybeOpenInitialPlaygroundTemplate();
+      await fetchInstalledPackages();
+    } else if (!shouldHideInterviewPicker()) {
+      await fetchPlaygroundProjects();
+      await fetchInstalledPackages();
+    }
+  }
+
+  function renderModelSuggestions(filterText) {
+    var filter = (filterText || "").trim().toLowerCase();
+    var modelChoices = [];
+    if (filter) {
+      var source = state.availableModels.length
+        ? state.availableModels
+        : state.recommendedModels;
+      modelChoices = source
+        .filter(function (model) {
+          return model.toLowerCase().includes(filter);
+        })
+        .slice(0, 20);
+    } else {
+      modelChoices = state.recommendedModels.slice(0, 8);
+    }
+    aiModelSuggestions.innerHTML = "";
+    modelChoices.forEach(function (modelName) {
+      var button = document.createElement("button");
+      button.type = "button";
+      button.className = "btn btn-sm btn-outline-secondary font-monospace";
+      button.textContent = modelName;
+      button.addEventListener("click", function () {
+        aiModelInput.value = modelName;
+        state.settings.model = modelName;
+        renderModelSuggestions(modelName);
+      });
+      aiModelSuggestions.appendChild(button);
+    });
+  }
+
+  function renderGenerationMethodFields() {
+    var method =
+      generationMethodInput.value ||
+      state.settings.generationMethod ||
+      "multi_run";
+    generatorModelsGroup.classList.toggle("hidden", method !== "multi_model");
+  }
+
+  function parseGeneratorModelsInput(rawValue) {
+    return (rawValue || "")
+      .split(/[\n,]/)
+      .map(function (item) {
+        return item.trim();
+      })
+      .filter(function (item) {
+        return item.length > 0;
+      });
+  }
+
+  // ================================================================
+  // UI state transitions
+  // ================================================================
+  function showLoading(message) {
+    loadingMessage.textContent = message;
+    loadingState.classList.remove("hidden");
+    emptyState.classList.add("hidden");
+    mainPanel.classList.add("hidden");
+    errorState.classList.add("hidden");
+  }
+
+  function hideLoading() {
+    loadingState.classList.add("hidden");
+  }
+
+  function showError(message) {
+    errorMessage.textContent = message;
+    errorState.classList.remove("hidden");
+    emptyState.classList.add("hidden");
+    mainPanel.classList.add("hidden");
+  }
+
+  function showMainPanel() {
+    mainPanel.classList.remove("hidden");
+    emptyState.classList.add("hidden");
+    errorState.classList.add("hidden");
+  }
+
+  // ================================================================
+  // Label extraction from mammoth HTML
+  // ================================================================
+  function extractExistingLabels(html) {
+    const labels = [];
+    // Combined scan in document order: {{ }} and {% %}
+    const allPattern = /\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}/g;
+    let match;
+    while ((match = allPattern.exec(html)) !== null) {
+      const text = match[0];
+      labels.push({
+        id: generateId(),
+        original: text,
+        current: text,
+        isControl: text.startsWith("{%"),
+      });
+    }
+    return labels;
+  }
+
+  function extractExistingLabelsFromRuns(runs) {
+    if (previewUtils && previewUtils.extractLabelsFromRuns) {
+      return previewUtils.extractLabelsFromRuns(runs, generateId);
+    }
+    var labels = [];
+    var pattern = /\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}/g;
+    (runs || []).forEach(function (run) {
+      var paragraph = run[0];
+      var runIndex = run[1];
+      var text = String(run[2] || "");
+      pattern.lastIndex = 0;
+      var match;
+      while ((match = pattern.exec(text)) !== null) {
+        var labelText = match[0];
+        labels.push({
+          id: generateId(),
+          original: labelText,
+          current: labelText,
+          isControl: labelText.startsWith("{%"),
+          paragraph: paragraph,
+          run: runIndex,
+          start: match.index,
+          end: match.index + labelText.length,
+        });
+      }
+    });
+    return labels;
+  }
+
+  // ================================================================
+  // Paragraph / run index for mapping selections to runs
+  // ================================================================
+  function buildParagraphIndex() {
+    var index = {};
+    state.runs.forEach(function (r) {
+      var para = r[0],
+        run = r[1],
+        text = r[2];
+      if (!index[para]) index[para] = { runs: [], fullText: "" };
+      index[para].runs.push({
+        runIdx: run,
+        text: text,
+        start: index[para].fullText.length,
+        end: 0,
+      });
+      index[para].fullText += text;
+    });
+    Object.keys(index).forEach(function (p) {
+      index[p].runs.forEach(function (r) {
+        r.end = r.start + r.text.length;
+      });
+    });
+    return index;
+  }
+
+  /**
+   * Given a user-selected text string, find the paragraph and set of
+   * consecutive runs whose concatenated text contains the selection.
+   * Returns null when no match is found.
+   */
+  function findRunsForSelection(selectedText) {
+    if (!selectedText || !selectedText.trim()) return null;
+    var paraIndex = buildParagraphIndex();
+    var trimmed = selectedText.trim();
+
+    for (var paraNum in paraIndex) {
+      var para = paraIndex[paraNum];
+      // Direct substring lookup in this paragraph’s concatenated text
+      var pos = para.fullText.indexOf(trimmed);
+      if (pos === -1) {
+        // Normalised whitespace fallback
+        var normFull = para.fullText.replace(/\s+/g, " ");
+        var normSel = trimmed.replace(/\s+/g, " ");
+        pos = normFull.indexOf(normSel);
+        if (pos === -1) continue;
+      }
+      var end = pos + trimmed.length;
+
+      var matchedRuns = [];
+      para.runs.forEach(function (r) {
+        if (r.end > pos && r.start < end) {
+          matchedRuns.push({
+            paragraph: parseInt(paraNum),
+            run: r.runIdx,
+            originalText: r.text,
+            selStart: Math.max(0, pos - r.start),
+            selEnd: Math.min(r.text.length, end - r.start),
+            isFullySelected: pos <= r.start && end >= r.end,
+          });
+        }
+      });
+      if (matchedRuns.length > 0) {
+        return {
+          paraNum: parseInt(paraNum),
+          runs: matchedRuns,
+          selectedText: trimmed,
         };
+      }
+    }
+    return null;
+  }
 
-        const AL_VARIABLE_TREE = mergeVariableTree({
-            'users': { _description: 'People benefiting from the form (pro se filers)', '[0]': PERSON_ATTRIBUTES },
-            'other_parties': { _description: 'Opposing/transactional parties', '[0]': PERSON_ATTRIBUTES },
-            'plaintiffs': { _description: 'Plaintiffs in lawsuit', '[0]': PERSON_ATTRIBUTES },
-            'defendants': { _description: 'Defendants in lawsuit', '[0]': PERSON_ATTRIBUTES },
-            'petitioners': { _description: 'Petitioners', '[0]': PERSON_ATTRIBUTES },
-            'respondents': { _description: 'Respondents', '[0]': PERSON_ATTRIBUTES },
-            'children': { _description: 'Children involved', '[0]': PERSON_ATTRIBUTES },
-            'spouses': { _description: 'Spouses', '[0]': PERSON_ATTRIBUTES },
-            'parents': { _description: 'Parents', '[0]': PERSON_ATTRIBUTES },
-            'caregivers': { _description: 'Caregivers', '[0]': PERSON_ATTRIBUTES },
-            'guardians': { _description: 'Guardians', '[0]': PERSON_ATTRIBUTES },
-            'guardians_ad_litem': { _description: 'Guardians ad litem', '[0]': PERSON_ATTRIBUTES },
-            'witnesses': { _description: 'Witnesses', '[0]': PERSON_ATTRIBUTES },
-            'attorneys': { _description: 'Attorneys', '[0]': ATTORNEY_ATTRIBUTES },
-            'translators': { _description: 'Translators/Interpreters', '[0]': PERSON_ATTRIBUTES },
-            'creditors': { _description: 'Creditors', '[0]': PERSON_ATTRIBUTES },
-            'debt_collectors': { _description: 'Debt collectors', '[0]': PERSON_ATTRIBUTES },
-            'decedents': { _description: 'Deceased persons', '[0]': PERSON_ATTRIBUTES },
-            'interested_parties': { _description: 'Other interested parties', '[0]': PERSON_ATTRIBUTES },
-            'trial_court': {
-                _description: 'Court information',
-                'name': 'Court name',
-                'address': {
-                    'county': 'County',
-                    'address': 'Street address',
-                    'city': 'City',
-                    'state': 'State'
-                },
-                'division': 'Division',
-                'department': 'Department'
-            },
-            'docket_number': 'Case/Docket number',
-            'docket_numbers': 'Multiple docket numbers (comma-separated)',
-            'case_name': 'Case name/caption',
-            'signature_date': 'Date form is signed',
-            'user_needs_interpreter': 'User needs interpreter (checkbox)',
-            'user_preferred_language': 'User\'s preferred language'
-        }, DOCX_LABELER_VARIABLE_TREE_EXTRAS);
+  /**
+   * Build suggestion entries that replace the matched runs with a Jinja2
+   * variable.  The first run keeps any unselected prefix and gets the
+   * label; the last run keeps any unselected suffix; middle runs are
+   * blanked.  All entries share a `group` id so the UI and preview can
+   * treat them as one logical operation.
+   */
+  function createLabelFromSelection(variableName, match) {
+    var groupId = generateId();
+    var labels = [];
+    match.runs.forEach(function (r, i) {
+      var newText;
+      var manualRole;
+      var manualPrefix = "";
+      var manualSuffix = "";
+      if (match.runs.length === 1) {
+        // Only run: prefix + label + suffix
+        manualPrefix = r.originalText.substring(0, r.selStart);
+        manualSuffix = r.originalText.substring(r.selEnd);
+        newText = manualPrefix + variableName + manualSuffix;
+        manualRole = "single";
+      } else if (i === 0) {
+        manualPrefix = r.originalText.substring(0, r.selStart);
+        newText = manualPrefix + variableName;
+        manualRole = "first";
+      } else if (i === match.runs.length - 1) {
+        manualSuffix = r.originalText.substring(r.selEnd);
+        newText = manualSuffix;
+        manualRole = "last";
+      } else {
+        newText = "";
+        manualRole = "middle";
+      }
+      labels.push({
+        paragraph: r.paragraph,
+        run: r.run,
+        text: newText,
+        new_paragraph: 0,
+        id: generateId(),
+        status: "accepted",
+        group: groupId,
+        _isCompanion: i > 0,
+        _isManual: true,
+        _selectedText: match.selectedText,
+        _displayLabel: variableName,
+        _manualKind: "replace",
+        _manualRole: manualRole,
+        _manualPrefix: manualPrefix,
+        _manualSuffix: manualSuffix,
+      });
+    });
+    return labels;
+  }
 
-        // ================================================================
-        // State
-        // ================================================================
-        var previewUtils = (typeof window !== 'undefined' && window.DocxLabelerPreviewUtils)
-            ? window.DocxLabelerPreviewUtils
-            : null;
+  function createWrappedLabelFromSelection(
+    conditionExpression,
+    match,
+    wrapperKind,
+  ) {
+    var groupId = generateId();
+    var labels = [];
+    var openTag =
+      wrapperKind === "ifp_wrap"
+        ? "{%p if " + conditionExpression + " %}"
+        : "{% if " + conditionExpression + " %}";
+    var closeTag = wrapperKind === "ifp_wrap" ? "{%p endif %}" : "{% endif %}";
+    match.runs.forEach(function (r, i) {
+      var selectedFragment = r.originalText.substring(r.selStart, r.selEnd);
+      var manualPrefix = "";
+      var manualSuffix = "";
+      var manualRole = "middle";
+      var newText = selectedFragment;
+      if (match.runs.length === 1) {
+        manualRole = "single";
+        manualPrefix = r.originalText.substring(0, r.selStart);
+        manualSuffix = r.originalText.substring(r.selEnd);
+        newText =
+          manualPrefix + openTag + selectedFragment + closeTag + manualSuffix;
+      } else if (i === 0) {
+        manualRole = "first";
+        manualPrefix = r.originalText.substring(0, r.selStart);
+        newText = manualPrefix + openTag + selectedFragment;
+      } else if (i === match.runs.length - 1) {
+        manualRole = "last";
+        manualSuffix = r.originalText.substring(r.selEnd);
+        newText = selectedFragment + closeTag + manualSuffix;
+      }
+      labels.push({
+        paragraph: r.paragraph,
+        run: r.run,
+        text: newText,
+        new_paragraph: 0,
+        id: generateId(),
+        status: "accepted",
+        group: groupId,
+        _isCompanion: i > 0,
+        _isManual: true,
+        _selectedText: match.selectedText,
+        _displayLabel: conditionExpression,
+        _manualKind: wrapperKind,
+        _manualRole: manualRole,
+        _manualPrefix: manualPrefix,
+        _manualSuffix: manualSuffix,
+        _selectedFragment: selectedFragment,
+      });
+    });
+    return labels;
+  }
 
-        let state = {
-            file: null,
-            fileContent: null,
-            originalHtml: '',
-            playgroundSource: null,
-            initialPlaygroundSource: {
-                project: INITIAL_PLAYGROUND_SOURCE.project || '',
-                filename: INITIAL_PLAYGROUND_SOURCE.filename || '',
-                attempted: false
-            },
-            runs: [],          // original runs from extract-runs endpoint
-            existingLabels: [],
-            suggestions: [],
-            labelRenames: {},
-            defaultModel: 'gpt-5-mini',
-            recommendedModels: ['gpt-5-mini'],
-            availableModels: [],
-            auth: {
-                isAuthenticated: false,
-                email: '',
-                loginUrl: '/user/sign-in',
-                logoutUrl: '/user/sign-out',
-                aiEnabled: false
-            },
-            interviewSourceMode: 'playground',
-            playground: {
-                projects: [],
-                files: [],
-                selectedProject: 'default',
-                selectedFile: '',
-                variables: [],
-                topLevelNames: []
-            },
-            installed: {
-                packages: [],
-                files: [],
-                selectedPackage: '',
-                selectedFile: '',
-                variables: [],
-                topLevelNames: []
-            },
-            ui: {
-                editInterviewSourceInSettings: false
-            },
-            settings: {
-                additionalInstructions: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.additionalInstructions) || '',
-                contextText: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.contextText) || '',
-                customPeople: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.customPeople) || '',
-                primaryPersonVariable: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.primaryPersonVariable) || '',
-                promptProfile: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.promptProfile) || 'standard',
-                model: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.model) || 'gpt-5-mini',
-                judgeModel: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.judgeModel) || '',
-                generationMethod: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.generationMethod) || 'multi_run',
-                generatorModels: (DOCX_LABELER_CONFIG.settings && DOCX_LABELER_CONFIG.settings.generatorModels) || '',
-                defragmentRuns: DOCX_LABELER_CONFIG.settings && typeof DOCX_LABELER_CONFIG.settings.defragmentRuns === 'boolean' ? DOCX_LABELER_CONFIG.settings.defragmentRuns : true,
-                usePlaygroundVariables: DOCX_LABELER_CONFIG.settings && typeof DOCX_LABELER_CONFIG.settings.usePlaygroundVariables === 'boolean' ? DOCX_LABELER_CONFIG.settings.usePlaygroundVariables : false,
-                showLowConfidence: DOCX_LABELER_CONFIG.settings && typeof DOCX_LABELER_CONFIG.settings.showLowConfidence === 'boolean' ? DOCX_LABELER_CONFIG.settings.showLowConfidence : false
-            },
-            activeTab: 'existing',
-            editingLabelId: null,
-            validation: null,
-            syntaxValidation: null,
-            syntaxValidationPending: false,
-            syntaxValidationTimer: null,
-            syntaxValidationRequestToken: 0
-        };
+  // ================================================================
+  // Selection popover logic
+  // ================================================================
+  var _selMatch = null; // stashed findRunsForSelection() result
+  var _selectionMode = "replace";
 
-        // ================================================================
-        // DOM Elements
-        // ================================================================
-        const fileInput = document.getElementById('file-input');
-        const fileName = document.getElementById('file-name');
-        const openPlaygroundBtn = document.getElementById('open-playground-btn');
-        const savePlaygroundBtn = document.getElementById('save-playground-btn');
-        const openPlaygroundModalEl = document.getElementById('open-playground-modal');
-        const savePlaygroundModalEl = document.getElementById('save-playground-modal');
-        const interviewPickerPanel = document.getElementById('interview-picker-panel');
-        const interviewPickerSidebarHost = document.getElementById('interview-picker-sidebar-host');
-        const settingsInterviewPickerHost = document.getElementById('settings-interview-picker-host');
-        const changeInterviewSourceBtn = document.getElementById('change-interview-source-btn');
-        const interviewSourceModeInputs = Array.from(document.querySelectorAll('input[name="interview-source-mode"]'));
-        const playgroundFields = document.getElementById('playground-fields');
-        const installedFields = document.getElementById('installed-fields');
-        const playgroundProjectSelect = document.getElementById('playground-project');
-        const playgroundYamlFileSelect = document.getElementById('playground-yaml-file');
-        const installedPackageSelect = document.getElementById('installed-package');
-        const installedYamlFileSelect = document.getElementById('installed-yaml-file');
-        const interviewVariableSummary = document.getElementById('interview-variable-summary');
-        const loadingState = document.getElementById('loading-state');
-        const loadingMessage = document.getElementById('loading-message');
-        const errorState = document.getElementById('error-state');
-        const errorMessage = document.getElementById('error-message');
-        const emptyState = document.getElementById('empty-state');
-        const mainPanel = document.getElementById('main-panel');
-        const previewEmpty = document.getElementById('preview-empty');
-        const previewContent = document.getElementById('preview-content');
-        const applyHighlightsBtn = document.getElementById('apply-highlights-btn');
-        const downloadBtn = document.getElementById('download-btn');
-        const downloadStatus = document.getElementById('download-status');
-        const syntaxValidationBanner = document.getElementById('syntax-validation');
-        const existingPanel = document.getElementById('existing-panel');
-        const manualPanel = document.getElementById('manual-panel');
-        const suggestionsPanel = document.getElementById('suggestions-panel');
-        const suggestionsList = document.getElementById('suggestions-list');
-        const manualLabelsList = document.getElementById('manual-labels-list');
-        const existingLabelsTree = document.getElementById('existing-labels-tree');
-        const existingCount = document.getElementById('existing-count');
-        const manualCount = document.getElementById('manual-count');
-        const suggestionsCount = document.getElementById('suggestions-count');
-        const tabExisting = document.getElementById('tab-existing');
-        const tabManual = document.getElementById('tab-manual');
-        const tabSuggestions = document.getElementById('tab-suggestions');
-        const variableTree = document.getElementById('variable-tree');
-        const variableSearch = document.getElementById('variable-search');
-        const settingsModal = document.getElementById('settings-modal');
-        const bulkReplaceModal = document.getElementById('bulk-replace-modal');
-        const editLabelModal = document.getElementById('edit-label-modal');
-        const selPopover = document.getElementById('sel-popover');
-        const selOriginalText = document.getElementById('sel-original-text');
-        const selVarInput = document.getElementById('sel-var-input');
-        const selVarPanel = document.getElementById('sel-var-panel');
-        const selVarTree = document.getElementById('sel-var-tree');
-        const selVarSearch = document.getElementById('sel-var-search');
-        const aiModelInput = document.getElementById('ai-model');
-        const aiModelSuggestions = document.getElementById('ai-model-suggestions');
-        const promptProfileInput = document.getElementById('prompt-profile');
-        const generationMethodInput = document.getElementById('generation-method');
-        const generatorModelsGroup = document.getElementById('generator-models-group');
-        const generatorModelsInput = document.getElementById('generator-models');
-        const judgeModelInput = document.getElementById('judge-model');
-        const usePlaygroundVariablesInput = document.getElementById('use-playground-variables');
-        const usePlaygroundVarsGroup = document.getElementById('use-playground-vars-group');
-        const playgroundSettingsSummary = document.getElementById('playground-settings-summary');
-        const authControls = document.getElementById('auth-controls');
-        const utilitiesBtn = document.getElementById('utilities-btn');
-        const repairBtn = document.getElementById('repair-btn');
-        const aiAuthNotice = document.getElementById('ai-auth-notice');
-        const suggestionsValidation = document.getElementById('suggestions-validation');
-        const toggleLowConfidence = document.getElementById('toggle-low-confidence');
-        const lowConfidenceSummary = document.getElementById('low-confidence-summary');
-        const utilitiesModal = document.getElementById('utilities-modal');
-        const repairModal = document.getElementById('repair-modal');
-        const utilityFileInput = document.getElementById('utility-file-input');
-        const repairFileInput = document.getElementById('repair-file-input');
-        const utilitySourceActive = document.getElementById('utility-source-active');
-        const utilitySourceUpload = document.getElementById('utility-source-upload');
-        const repairSourceActive = document.getElementById('repair-source-active');
-        const repairSourceUpload = document.getElementById('repair-source-upload');
-        const utilitiesResult = document.getElementById('utilities-result');
-        const repairResult = document.getElementById('repair-result');
-        const utilitySourceStatus = document.getElementById('utility-source-status');
-        const repairSourceStatus = document.getElementById('repair-source-status');
+  function ensureSelectionModeControls() {
+    if (document.getElementById("sel-mode-group")) return;
+    var controls = document.createElement("div");
+    controls.className = "mb-2";
+    controls.innerHTML =
+      '<div id="sel-mode-group" class="btn-group btn-group-sm w-100" role="group" aria-label="Selection mode">' +
+      '<button type="button" class="btn btn-outline-secondary sel-mode-btn active" data-mode="replace">Replace</button>' +
+      '<button type="button" class="btn btn-outline-secondary sel-mode-btn" data-mode="insert">Insert</button>' +
+      '<button type="button" class="btn btn-outline-secondary sel-mode-btn" data-mode="if_wrap">{% if %}</button>' +
+      '<button type="button" class="btn btn-outline-secondary sel-mode-btn" data-mode="ifp_wrap">{%p if %}</button>' +
+      "</div>";
+    var body = selPopover.querySelector(".dl-sel-popover-body");
+    if (body) {
+      body.insertBefore(controls, body.firstChild);
+      var filterBtn = document.createElement("button");
+      filterBtn.type = "button";
+      filterBtn.id = "sel-catchall-btn";
+      filterBtn.className = "btn btn-sm btn-outline-primary mt-2 w-100";
+      filterBtn.textContent = "Catchall / Request Filters";
+      filterBtn.addEventListener("click", function () {
+        openCatchallDialog(selVarInput);
+      });
+      body.appendChild(filterBtn);
+    }
+    controls.querySelectorAll(".sel-mode-btn").forEach(function (button) {
+      button.addEventListener("click", function () {
+        _selectionMode = /** @type {any} */ (button).dataset.mode || "replace";
+        updateSelectionModeButtons();
+        updateSelectionModeInputHints();
+      });
+    });
+    updateSelectionModeButtons();
+    updateSelectionModeInputHints();
+  }
 
-        // ================================================================
-        // Helpers
-        // ================================================================
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+  function updateSelectionModeButtons() {
+    document.querySelectorAll(".sel-mode-btn").forEach(function (button) {
+      var isActive = button.dataset.mode === _selectionMode;
+      button.classList.toggle("active", isActive);
+      button.classList.toggle("btn-primary", isActive);
+      button.classList.toggle("btn-outline-secondary", !isActive);
+    });
+  }
+
+  function updateSelectionModeInputHints() {
+    var mainPerson =
+      state.settings &&
+      state.settings.primaryPersonVariable &&
+      state.settings.primaryPersonVariable !== ""
+        ? state.settings.primaryPersonVariable
+        : "users";
+    if (_selectionMode === "replace" || _selectionMode === "insert") {
+      selVarInput.placeholder = "{{ " + mainPerson + "[0].name.first }}";
+    } else {
+      selVarInput.placeholder = mainPerson + "[0].is_active";
+    }
+    if (_selMatch && _selMatch.isInsertion) {
+      selOriginalText.textContent = "(insert at cursor)";
+    }
+  }
+
+  function normalizeSelectionInput(raw) {
+    if (_selectionMode === "replace" || _selectionMode === "insert") {
+      var varName = raw;
+      if (!/^\{[{%]/.test(varName)) {
+        varName = "{{ " + varName + " }}";
+      }
+      return varName;
+    }
+    return raw
+      .replace(/^\{%\s*p?\s*if\s*/i, "")
+      .replace(/\s*%\}$/, "")
+      .replace(/^\{\{\s*/, "")
+      .replace(/\s*\}\}$/, "")
+      .trim();
+  }
+
+  /**
+   * Build a global run index that reflects the current preview state
+   * by applying accepted suggestions and existing-label renames.
+   * This keeps DOM text offsets aligned with the run map.
+   */
+  function buildCurrentGlobalRunIndex() {
+    var modifications = {};
+    if (previewUtils && previewUtils.buildAcceptedRunPatchLookup) {
+      modifications = previewUtils.buildAcceptedRunPatchLookup(
+        state.runs,
+        state.existingLabels,
+        state.suggestions,
+      );
+    }
+    var sortedRuns = state.runs.slice().sort(function (a, b) {
+      if (a[0] !== b[0]) return a[0] - b[0];
+      return a[1] - b[1];
+    });
+    var entries = [];
+    var globalOffset = 0;
+    var lastParagraph = null;
+    sortedRuns.forEach(function (r) {
+      var paragraph = r[0];
+      var run = r[1];
+      var key = paragraph + "," + run + ",0";
+      var text = String(r[2] || "");
+      if (Object.prototype.hasOwnProperty.call(modifications, key)) {
+        text = String(modifications[key].text || "");
+      } else {
+        text = String(r[2] || "");
+      }
+      if (lastParagraph !== null && paragraph !== lastParagraph) {
+        globalOffset += 1;
+      }
+      entries.push({
+        paragraph: paragraph,
+        run: run,
+        text: text,
+        start: globalOffset,
+        end: globalOffset + text.length,
+      });
+      globalOffset += text.length;
+      lastParagraph = paragraph;
+    });
+    return entries;
+  }
+
+  function findRunMatchForCaret(caretRange) {
+    if (!caretRange) return null;
+    var prefixRange = document.createRange();
+    prefixRange.selectNodeContents(previewContent);
+    prefixRange.setEnd(caretRange.startContainer, caretRange.startOffset);
+    var globalOffset = prefixRange.toString().length;
+    var runIndex = buildCurrentGlobalRunIndex();
+    if (!runIndex.length) return null;
+    var target = runIndex.find(function (entry) {
+      return globalOffset >= entry.start && globalOffset <= entry.end;
+    });
+    if (!target) {
+      target = runIndex[runIndex.length - 1];
+    }
+    var offsetInRun = Math.max(
+      0,
+      Math.min(target.text.length, globalOffset - target.start),
+    );
+    return {
+      paraNum: target.paragraph,
+      runs: [
+        {
+          paragraph: target.paragraph,
+          run: target.run,
+          originalText: target.text,
+          selStart: offsetInRun,
+          selEnd: offsetInRun,
+          isFullySelected: false,
+        },
+      ],
+      selectedText: "",
+      isInsertion: true,
+    };
+  }
+
+  function showSelectionPopover(match, mouseX, mouseY) {
+    ensureSelectionModeControls();
+    _selMatch = match;
+    selOriginalText.textContent = match.isInsertion
+      ? "(insert at cursor)"
+      : match.selectedText;
+    selVarInput.value = "";
+    selVarPanel.classList.add("hidden");
+    selVarSearch.value = "";
+    if (match.isInsertion) {
+      _selectionMode = "insert";
+    } else if (_selectionMode === "insert") {
+      _selectionMode = "replace";
+    }
+    updateSelectionModeButtons();
+    updateSelectionModeInputHints();
+
+    // Position near the cursor, clamped to viewport
+    var pw = 380,
+      ph = 260;
+    var vw = window.innerWidth,
+      vh = window.innerHeight;
+    var left = Math.min(mouseX + 4, vw - pw - 12);
+    var top = mouseY + 12;
+    if (top + ph > vh) top = Math.max(8, mouseY - ph - 8);
+    selPopover.style.left = Math.max(4, left) + "px";
+    selPopover.style.top = top + "px";
+    selPopover.classList.remove("hidden");
+    selVarInput.focus();
+  }
+
+  function hideSelectionPopover() {
+    selPopover.classList.add("hidden");
+    _selMatch = null;
+  }
+
+  function saveSelectionLabel() {
+    var raw = selVarInput.value.trim();
+    if (!raw || !_selMatch) return;
+    if (
+      (_selectionMode === "if_wrap" || _selectionMode === "ifp_wrap") &&
+      _selMatch.isInsertion
+    ) {
+      showError("Select text first when adding conditional wrappers.");
+      return;
+    }
+    var value = normalizeSelectionInput(raw);
+    var newLabels;
+    if (_selectionMode === "if_wrap" || _selectionMode === "ifp_wrap") {
+      newLabels = createWrappedLabelFromSelection(
+        value,
+        _selMatch,
+        _selectionMode,
+      );
+    } else {
+      newLabels = createLabelFromSelection(value, _selMatch);
+    }
+    state.suggestions = state.suggestions.concat(newLabels);
+    hideSelectionPopover();
+    renderSuggestions();
+    updatePreview();
+    updateDownloadButton();
+    switchTab("manual");
+  }
+
+  function onPreviewMouseUp(e) {
+    if (previewUtils && previewUtils.shouldSuppressSelectionPopoverFromTarget) {
+      if (previewUtils.shouldSuppressSelectionPopoverFromTarget(e.target))
+        return;
+    } else if (
+      e.target &&
+      e.target.closest &&
+      e.target.closest(".existing-inline-label")
+    ) {
+      return;
+    }
+    // Ignore if popover is already open or no document loaded
+    if (!selPopover.classList.contains("hidden")) return;
+    if (!state.file || state.runs.length === 0) return;
+
+    var sel = window.getSelection();
+    if (!sel) return;
+
+    // Make sure the selection is inside the preview area
+    var anchor = sel.anchorNode,
+      focus = sel.focusNode;
+    if (!previewContent.contains(anchor) || !previewContent.contains(focus))
+      return;
+
+    var match = null;
+    if (sel.isCollapsed) {
+      if (document.caretRangeFromPoint) {
+        match = findRunMatchForCaret(
+          document.caretRangeFromPoint(e.clientX, e.clientY),
+        );
+      } else if (document.caretPositionFromPoint) {
+        var caretPos = document.caretPositionFromPoint(e.clientX, e.clientY);
+        if (caretPos) {
+          var fallbackRange = document.createRange();
+          fallbackRange.setStart(caretPos.offsetNode, caretPos.offset);
+          fallbackRange.setEnd(caretPos.offsetNode, caretPos.offset);
+          match = findRunMatchForCaret(fallbackRange);
         }
+      }
+      if (!match) return;
+    } else {
+      var text = sel.toString();
+      if (!text || !text.trim()) return;
+      match = findRunsForSelection(text);
+      if (!match) return;
+    }
 
-        function generateId() {
-            return 'id-' + Math.random().toString(36).substr(2, 9);
-        }
+    showSelectionPopover(match, e.clientX, e.clientY);
+  }
 
-        function getConfidenceMeta(tier) {
-            if (tier === 'high') {
-                return { label: 'High confidence', badge: 'bg-success-subtle text-success-emphasis border border-success-subtle' };
-            }
-            if (tier === 'medium') {
-                return { label: 'Medium confidence', badge: 'bg-warning-subtle text-warning-emphasis border border-warning-subtle' };
-            }
-            return { label: 'Low confidence', badge: 'bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle' };
-        }
+  // Render the variable tree inside the popover (reuses the same builder)
+  function renderSelPopoverTree(filter) {
+    selVarTree.innerHTML = "";
+    renderVariableTree(
+      getEffectiveVariableTree(),
+      "",
+      selVarTree,
+      filter || "",
+      function (varPath) {
+        selVarInput.value = "{{ " + varPath + " }}";
+        selVarInput.focus();
+      },
+    );
+  }
 
-        function summarizeSuggestionSources(suggestion) {
-            var sources = Array.isArray(suggestion.sources) ? suggestion.sources : [];
-            var models = [];
-            sources.forEach(function(source) {
-                if (source && source.model && models.indexOf(source.model) === -1) {
-                    models.push(source.model);
-                }
-            });
-            return models.join(', ');
-        }
+  // ================================================================
+  // Preview rendering with highlights
+  // ================================================================
+  function updatePreview() {
+    let html = state.originalHtml;
 
-        function isManualSuggestion(suggestion) {
-            return !!(suggestion && suggestion._isManual);
-        }
-
-        function getManualLabelGroups() {
-            return state.suggestions.filter(function(suggestion) {
-                return isManualSuggestion(suggestion) && !suggestion._isCompanion;
-            });
-        }
-
-        function applyManualLabelText(groupId, variableName) {
-            state.suggestions.forEach(function(suggestion) {
-                if (suggestion.group !== groupId) return;
-                suggestion._displayLabel = variableName;
-                var manualKind = suggestion._manualKind || 'replace';
-                if (manualKind === 'if_wrap' || manualKind === 'ifp_wrap') {
-                    var openTag = manualKind === 'ifp_wrap'
-                        ? '{%p if ' + variableName + ' %}'
-                        : '{% if ' + variableName + ' %}';
-                    var closeTag = manualKind === 'ifp_wrap'
-                        ? '{%p endif %}'
-                        : '{% endif %}';
-                    var selectedFragment = suggestion._selectedFragment || '';
-                    if (suggestion._manualRole === 'single') {
-                        suggestion.text =
-                            (suggestion._manualPrefix || '') +
-                            openTag +
-                            selectedFragment +
-                            closeTag +
-                            (suggestion._manualSuffix || '');
-                    } else if (suggestion._manualRole === 'first') {
-                        suggestion.text =
-                            (suggestion._manualPrefix || '') + openTag + selectedFragment;
-                    } else if (suggestion._manualRole === 'last') {
-                        suggestion.text = selectedFragment + closeTag + (suggestion._manualSuffix || '');
-                    } else if (suggestion._manualRole === 'middle') {
-                        suggestion.text = selectedFragment;
-                    }
-                    return;
-                }
-                if (suggestion._manualRole === 'single') {
-                    suggestion.text = (suggestion._manualPrefix || '') + variableName + (suggestion._manualSuffix || '');
-                } else if (suggestion._manualRole === 'first') {
-                    suggestion.text = (suggestion._manualPrefix || '') + variableName;
-                } else if (suggestion._manualRole === 'last') {
-                    suggestion.text = suggestion._manualSuffix || '';
-                } else if (suggestion._manualRole === 'middle') {
-                    suggestion.text = '';
-                }
-            });
-        }
-
-        function collectRenamePayload() {
-            // Labels with run positioning are handled as run-level patches
-            // in collectAcceptedLabels(). For unresolved labels without run
-            // coordinates, only allow a global rename when the document has a
-            // single such occurrence, which avoids clobbering duplicates.
-            var renames = [];
-            var unresolvedCounts = {};
-            (state.existingLabels || []).forEach(function(label) {
-                if (!label) return;
-                if (typeof label.paragraph === 'number' && typeof label.run === 'number') return;
-                if (Array.isArray(label.segments) && label.segments.length > 0) return;
-                unresolvedCounts[label.original] = (unresolvedCounts[label.original] || 0) + 1;
-            });
-            (state.existingLabels || []).forEach(function(label) {
-                if (!label || label.current === label.original) return;
-                if (typeof label.paragraph === 'number' && typeof label.run === 'number') return;
-                if (Array.isArray(label.segments) && label.segments.length > 0) return;
-                if ((unresolvedCounts[label.original] || 0) !== 1) return;
-                renames.push({ original: label.original, replacement: label.current });
-            });
-            return renames;
-        }
-
-        function collectAcceptedLabels() {
-            var acceptedByKey = {};
-            if (previewUtils && previewUtils.buildAcceptedRunPatchLookup) {
-                acceptedByKey = previewUtils.buildAcceptedRunPatchLookup(
-                    state.runs,
-                    state.existingLabels,
-                    state.suggestions
+    // --- Grouped selection labels (multi-run) ---
+    // Replace the full selected text span with the display label for
+    // each unique group, before handling single-run suggestions.
+    var processedGroups = {};
+    state.suggestions.forEach(function (s) {
+      if (s.status === "accepted" && s.group && !processedGroups[s.group]) {
+        processedGroups[s.group] = true;
+        var selectedText = s._selectedText;
+        if (s._manualKind === "if_wrap" || s._manualKind === "ifp_wrap") {
+          // Show the fully wrapped form in the preview
+          var wrapDisplay =
+            previewUtils && previewUtils.formatManualWrapPreviewDisplay
+              ? previewUtils.formatManualWrapPreviewDisplay(
+                  s._manualKind,
+                  s._displayLabel || "",
+                  selectedText || "",
+                  escapeHtml,
+                )
+              : escapeHtml(
+                  (s._manualKind === "ifp_wrap" ? "{%p if " : "{% if ") +
+                    (s._displayLabel || "") +
+                    " %}" +
+                    (selectedText || "") +
+                    (s._manualKind === "ifp_wrap"
+                      ? "{%p endif %}"
+                      : "{% endif %}"),
                 );
-            } else {
-                state.suggestions.filter(function(s) { return s.status === 'accepted'; }).forEach(function(s) {
-                    var key = s.paragraph + ',' + s.run + ',' + (s.new_paragraph || 0);
-                    acceptedByKey[key] = {
-                        paragraph: s.paragraph,
-                        run: s.run,
-                        text: s.text,
-                        new_paragraph: s.new_paragraph
-                    };
-                });
-            }
-
-            return Object.keys(acceptedByKey).map(function(key) {
-                return acceptedByKey[key];
-            });
-        }
-
-        function renderSyntaxValidation() {
-            if (!syntaxValidationBanner) return;
-            var validation = state.syntaxValidation;
-            var errors = validation && Array.isArray(validation.errors) ? validation.errors : [];
-            var warnings = validation && Array.isArray(validation.warnings) ? validation.warnings : [];
-
-            if (!state.syntaxValidationPending && errors.length === 0 && warnings.length === 0) {
-                syntaxValidationBanner.className = 'hidden alert small mb-2';
-                syntaxValidationBanner.textContent = '';
-                return;
-            }
-
-            var className = 'alert small mb-2';
-            var html = '';
-            if (errors.length > 0) {
-                className += ' alert-danger';
-                html += '<div class="fw-semibold">Jinja syntax errors detected</div>';
-                errors.forEach(function(issue) {
-                    var label = issue.paragraph !== undefined ? 'Paragraph ' + (issue.paragraph + 1) : 'Template';
-                    html += '<div>' + escapeHtml(label + ': ' + (issue.message || issue.code || 'Syntax error')) + '</div>';
-                });
-            } else if (warnings.length > 0) {
-                className += ' alert-warning';
-                html += '<div class="fw-semibold">Jinja validation warnings</div>';
-                warnings.forEach(function(issue) {
-                    html += '<div>' + escapeHtml(issue.message || issue.code || 'Warning') + '</div>';
-                });
-            } else {
-                className += ' alert-info';
-                html = '<div>Checking Jinja syntax...</div>';
-            }
-
-            if (state.syntaxValidationPending && (errors.length > 0 || warnings.length > 0)) {
-                html += '<div class="mt-1 text-muted">Rechecking...</div>';
-            }
-
-            syntaxValidationBanner.className = className;
-            syntaxValidationBanner.innerHTML = html;
-        }
-
-        async function validateCurrentSyntax(options) {
-            options = options || {};
-            if (!state.file) {
-                state.syntaxValidation = null;
-                state.syntaxValidationPending = false;
-                renderSyntaxValidation();
-                return null;
-            }
-
-            var renames = collectRenamePayload();
-            var acceptedLabels = collectAcceptedLabels();
-            if (!options.force && renames.length === 0 && acceptedLabels.length === 0) {
-                state.syntaxValidation = null;
-                state.syntaxValidationPending = false;
-                renderSyntaxValidation();
-                return null;
-            }
-
-            var requestToken = state.syntaxValidationRequestToken + 1;
-            state.syntaxValidationRequestToken = requestToken;
-            state.syntaxValidationPending = true;
-            renderSyntaxValidation();
-
-            try {
-                var formData = new FormData();
-                formData.append('file', state.file);
-                formData.append('defragment_runs', state.settings.defragmentRuns ? 'true' : 'false');
-                if (renames.length > 0) formData.append('renames', JSON.stringify(renames));
-                if (acceptedLabels.length > 0) formData.append('labels', JSON.stringify(acceptedLabels));
-                var response = await fetch('/al/docx-labeler/api/validate-syntax', { method: 'POST', body: formData });
-                var data = await parseApiResponse(response);
-                if (requestToken === state.syntaxValidationRequestToken) {
-                    state.syntaxValidation = data.data && data.data.validation ? data.data.validation : null;
-                }
-            } catch (error) {
-                if (requestToken === state.syntaxValidationRequestToken) {
-                    state.syntaxValidation = {
-                        valid: false,
-                        errors: [{ code: 'validation_request_failed', message: error.message || 'Syntax validation failed.' }],
-                        warnings: []
-                    };
-                }
-            } finally {
-                if (requestToken === state.syntaxValidationRequestToken) {
-                    state.syntaxValidationPending = false;
-                    renderSyntaxValidation();
-                    updateDownloadButton();
-                }
-            }
-
-            return state.syntaxValidation;
-        }
-
-        function scheduleSyntaxValidation(delay) {
-            if (state.syntaxValidationTimer) {
-                window.clearTimeout(state.syntaxValidationTimer);
-            }
-            state.syntaxValidationTimer = window.setTimeout(function() {
-                validateCurrentSyntax();
-            }, typeof delay === 'number' ? delay : 400);
-        }
-
-        async function ensureSyntaxValidationBeforeWrite(actionLabel) {
-            var validation = await validateCurrentSyntax({ force: true });
-            var errors = validation && Array.isArray(validation.errors) ? validation.errors : [];
-            if (errors.length === 0) {
-                return { allowed: true, validation: validation, allowInvalidSyntax: false };
-            }
-
-            var summary = errors.slice(0, 3).map(function(issue) {
-                return '- ' + (issue.message || issue.code || 'Syntax error');
-            }).join('\n');
-            var proceed = window.confirm(
-                'The Jinja syntax validator found errors before ' + actionLabel + ':\n\n'
-                + summary
-                + '\n\nSave anyway?'
-            );
-            return { allowed: proceed, validation: validation, allowInvalidSyntax: proceed };
-        }
-
-        function swapSuggestionWithAlternate(suggestion, alternateIndex) {
-            if (!suggestion || !Array.isArray(suggestion.alternates)) return;
-            var alternate = suggestion.alternates[alternateIndex];
-            if (!alternate) return;
-            var currentPrimary = {
-                text: suggestion.text,
-                paragraph: suggestion.paragraph,
-                run: suggestion.run,
-                new_paragraph: suggestion.new_paragraph,
-                validation_flags: suggestion.validation_flags || [],
-                judge_review: suggestion.judge_review || null,
-                confidence: suggestion.confidence || 'low',
-                vote_count: suggestion.vote_count || 0,
-                clean_vote_count: suggestion.clean_vote_count || 0,
-                vote_total: suggestion.vote_total || 0,
-                sources: suggestion.sources || []
-            };
-            suggestion.text = alternate.text;
-            suggestion.validation_flags = alternate.validation_flags || [];
-            suggestion.judge_review = alternate.judge_review || null;
-            suggestion.confidence = alternate.confidence || 'low';
-            suggestion.vote_count = alternate.vote_count || 0;
-            suggestion.clean_vote_count = alternate.clean_vote_count || 0;
-            suggestion.vote_total = alternate.vote_total || suggestion.vote_total || 0;
-            suggestion.sources = alternate.sources || [];
-            suggestion.alternates.splice(alternateIndex, 1, currentPrimary);
-        }
-
-        async function fetchModelCatalog() {
-            try {
-                var response = await fetch(endpointPath('models', '/al/labeler/api/models'), { method: 'GET' });
-                var data = await response.json();
-                if (!data.success || !data.data) return;
-                state.defaultModel = data.data.default_model || state.defaultModel;
-                state.recommendedModels = Array.isArray(data.data.recommended_models) && data.data.recommended_models.length
-                    ? data.data.recommended_models
-                    : [state.defaultModel];
-                state.availableModels = Array.isArray(data.data.available_models) ? data.data.available_models : [];
-                state.settings.model = state.defaultModel;
-                renderModelSuggestions('');
-            } catch (_error) {
-                renderModelSuggestions('');
-            }
-        }
-
-        function renderAuthControls() {
-            if (!authControls) return;
-            if (state.auth.isAuthenticated) {
-                var emailText = state.auth.email || 'Account';
-                authControls.innerHTML =
-                    '<button id="auth-menu-btn" class="btn btn-outline-light btn-sm dropdown-toggle" type="button" aria-expanded="false">' + escapeHtml(emailText) + '</button>' +
-                    '<div id="auth-menu" class="dropdown-menu dropdown-menu-end">' +
-                        '<a class="dropdown-item" href="' + escapeHtml(state.auth.logoutUrl || '/user/sign-out') + '">Log out</a>' +
-                    '</div>';
-                var menuBtn = document.getElementById('auth-menu-btn');
-                var menu = document.getElementById('auth-menu');
-                menuBtn.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    menu.classList.toggle('show');
-                });
-            } else {
-                authControls.innerHTML =
-                    '<a class="btn btn-outline-light btn-sm" href="' + escapeHtml(state.auth.loginUrl || '/user/sign-in') + '">Log in</a>';
-            }
-        }
-
-        function updateAiUiState() {
-            var aiEnabled = !!state.auth.aiEnabled;
-            var regenerateBtn = document.getElementById('regenerate-btn');
-            if (regenerateBtn) {
-                regenerateBtn.disabled = !aiEnabled;
-            }
-            if (!aiEnabled) {
-                aiAuthNotice.classList.remove('hidden');
-                aiAuthNotice.innerHTML = 'AI labeling requires login. <a href="' + escapeHtml(state.auth.loginUrl || '/user/sign-in') + '">Log in</a> to enable suggestions.';
-            } else {
-                aiAuthNotice.classList.add('hidden');
-            }
-            // Show playground buttons only when authenticated
-            if (state.auth.isAuthenticated) {
-                openPlaygroundBtn.classList.remove('hidden');
-            } else {
-                openPlaygroundBtn.classList.add('hidden');
-                savePlaygroundBtn.classList.add('hidden');
-            }
-        }
-
-        function getActiveInterviewSourceState() {
-            return state.interviewSourceMode === 'installed' ? state.installed : state.playground;
-        }
-
-        function moveInterviewPickerTo(hostElement) {
-            if (!hostElement || !interviewPickerPanel) return;
-            if (interviewPickerPanel.parentElement !== hostElement) {
-                hostElement.appendChild(interviewPickerPanel);
-            }
-        }
-
-        function getActiveInterviewSourceLabel() {
-            var sourceState = getActiveInterviewSourceState();
-            if (state.interviewSourceMode === 'installed') {
-                if (!sourceState.selectedPackage || !sourceState.selectedFile) return '';
-                return sourceState.selectedPackage + '/' + sourceState.selectedFile;
-            }
-            if (!sourceState.selectedProject || !sourceState.selectedFile) return '';
-            return sourceState.selectedProject + '/' + sourceState.selectedFile;
-        }
-
-        function renderInterviewSourceSummary() {
-            if (!interviewVariableSummary || !playgroundSettingsSummary) return;
-            var sourceLabel = getActiveInterviewSourceLabel();
-            var sourceState = getActiveInterviewSourceState();
-            var sourceText = state.interviewSourceMode === 'installed' ? 'installed interview' : 'Playground interview';
-            var count = sourceState.variables.length;
-            if (sourceLabel) {
-                interviewVariableSummary.textContent =
-                    sourceLabel
-                    + (count ? ' (' + count + ' vars, ' + sourceState.topLevelNames.length + ' top-level)' : ' (no variables detected yet)');
-                interviewVariableSummary.classList.remove('hidden');
-                playgroundSettingsSummary.textContent =
-                    'Selected ' + sourceText + ': ' + sourceLabel
-                    + (count ? '. The prompt will prefer its existing variable names.' : '.');
-            } else {
-                interviewVariableSummary.classList.add('hidden');
-                playgroundSettingsSummary.textContent =
-                    'Select a Playground or installed interview from the sidebar to use its variable list in the prompt.';
-            }
-        }
-
-        function renderInterviewPicker() {
-            if (!interviewPickerPanel || !interviewPickerSidebarHost || !settingsInterviewPickerHost || !usePlaygroundVarsGroup) return;
-            if (shouldHideInterviewPicker()) {
-                usePlaygroundVarsGroup.classList.add('hidden');
-                if (changeInterviewSourceBtn) changeInterviewSourceBtn.classList.add('hidden');
-                interviewPickerPanel.classList.add('hidden');
-                interviewPickerSidebarHost.classList.add('hidden');
-                settingsInterviewPickerHost.classList.add('hidden');
-                state.settings.usePlaygroundVariables = false;
-                usePlaygroundVariablesInput.checked = false;
-                usePlaygroundVariablesInput.disabled = true;
-                return;
-            }
-            var showPicker = !!state.auth.isAuthenticated;
-            usePlaygroundVarsGroup.classList.toggle('hidden', !showPicker);
-            if (changeInterviewSourceBtn) {
-                changeInterviewSourceBtn.classList.toggle('hidden', !showPicker);
-                changeInterviewSourceBtn.textContent = state.ui.editInterviewSourceInSettings ? 'Done' : 'Change';
-            }
-            if (showPicker && state.ui.editInterviewSourceInSettings) {
-                moveInterviewPickerTo(settingsInterviewPickerHost);
-            } else {
-                moveInterviewPickerTo(interviewPickerSidebarHost);
-            }
-            interviewPickerPanel.classList.toggle('hidden', !showPicker);
-            interviewPickerSidebarHost.classList.toggle('hidden', !showPicker || state.ui.editInterviewSourceInSettings);
-            settingsInterviewPickerHost.classList.toggle('hidden', !showPicker || !state.ui.editInterviewSourceInSettings);
-            playgroundFields.classList.toggle('hidden', state.interviewSourceMode !== 'playground');
-            installedFields.classList.toggle('hidden', state.interviewSourceMode !== 'installed');
-            interviewSourceModeInputs.forEach(function(input) {
-                input.checked = input.value === state.interviewSourceMode;
-            });
-
-            playgroundProjectSelect.innerHTML = '';
-            state.playground.projects.forEach(function(projectName) {
-                var option = document.createElement('option');
-                option.value = projectName;
-                option.textContent = projectName;
-                if (projectName === state.playground.selectedProject) option.selected = true;
-                playgroundProjectSelect.appendChild(option);
-            });
-
-            playgroundYamlFileSelect.innerHTML = '';
-            if (!state.playground.files.length) {
-                var emptyPlaygroundOption = document.createElement('option');
-                emptyPlaygroundOption.value = '';
-                emptyPlaygroundOption.textContent = 'No YAML files found';
-                playgroundYamlFileSelect.appendChild(emptyPlaygroundOption);
-            } else {
-                state.playground.files.forEach(function(fileInfo) {
-                    var option = document.createElement('option');
-                    option.value = fileInfo.filename;
-                    option.textContent = fileInfo.label || fileInfo.filename;
-                    if (fileInfo.filename === state.playground.selectedFile) option.selected = true;
-                    playgroundYamlFileSelect.appendChild(option);
-                });
-            }
-
-            installedPackageSelect.innerHTML = '';
-            state.installed.packages.forEach(function(packageName) {
-                var option = document.createElement('option');
-                option.value = packageName;
-                option.textContent = packageName;
-                if (packageName === state.installed.selectedPackage) option.selected = true;
-                installedPackageSelect.appendChild(option);
-            });
-
-            installedYamlFileSelect.innerHTML = '';
-            if (!state.installed.files.length) {
-                var emptyInstalledOption = document.createElement('option');
-                emptyInstalledOption.value = '';
-                emptyInstalledOption.textContent = 'No YAML files found';
-                installedYamlFileSelect.appendChild(emptyInstalledOption);
-            } else {
-                state.installed.files.forEach(function(fileInfo) {
-                    var option = document.createElement('option');
-                    option.value = fileInfo.filename;
-                    option.textContent = fileInfo.label || fileInfo.filename;
-                    if (fileInfo.filename === state.installed.selectedFile) option.selected = true;
-                    installedYamlFileSelect.appendChild(option);
-                });
-            }
-
-            var activeSourceState = getActiveInterviewSourceState();
-            usePlaygroundVariablesInput.disabled = !showPicker || !activeSourceState.selectedFile;
-            if (usePlaygroundVariablesInput.disabled) {
-                state.settings.usePlaygroundVariables = false;
-                usePlaygroundVariablesInput.checked = false;
-            }
-            renderInterviewSourceSummary();
-        }
-
-        function deriveTopLevelNames(variableNames) {
-            return Array.from(new Set(
-                (Array.isArray(variableNames) ? variableNames : [])
-                    .map(function(name) { return String(name || '').trim(); })
-                    .filter(function(name) { return !!name; })
-                    .map(function(name) { return name.split('.', 1)[0].split('[', 1)[0]; })
-                    .filter(function(name) { return !!name; })
-            )).sort(function(a, b) { return a.localeCompare(b); });
-        }
-
-        function splitVariablePathSegments(variableName) {
-            var raw = String(variableName || '').trim();
-            if (!raw) return [];
-            var matches = raw.match(/([^[.\]]+|\[[^\]]*\])/g);
-            return Array.isArray(matches) ? matches.filter(function(part) { return !!part; }) : [raw];
-        }
-
-        function buildInterviewVariableTree(variableNames) {
-            var root = {
-                _description: 'Variables detected from the selected interview'
-            };
-            (Array.isArray(variableNames) ? variableNames : []).forEach(function(variableName) {
-                var segments = splitVariablePathSegments(variableName);
-                if (!segments.length) return;
-                var node = root;
-                segments.forEach(function(segment, index) {
-                    var isLeaf = index === segments.length - 1;
-                    if (!node[segment] || typeof node[segment] !== 'object') {
-                        node[segment] = {};
-                    }
-                    if (isLeaf) {
-                        node[segment]._variable = true;
-                        node[segment]._description = 'Selected interview variable';
-                    }
-                    node = node[segment];
-                });
-            });
-            return root;
-        }
-
-        function getEffectiveVariableTree() {
-            var sourceState = getActiveInterviewSourceState();
-            var baseTree = AL_VARIABLE_TREE;
-            
-            if (state.settings && state.settings.primaryPersonVariable && state.settings.primaryPersonVariable !== 'users') {
-                baseTree = cloneVariableTree(AL_VARIABLE_TREE);
-                if (baseTree['users']) {
-                    baseTree[state.settings.primaryPersonVariable] = baseTree['users'];
-                    delete baseTree['users'];
-                }
-            }
-
-            if (!sourceState.variables.length) {
-                return baseTree;
-            }
-            return Object.assign(
-                {
-                    'Selected interview variables': buildInterviewVariableTree(sourceState.variables)
-                },
-                baseTree
-            );
-        }
-
-        async function fetchJsonOrThrow(url) {
-            var response = await fetch(url, {
-                method: 'GET',
-                credentials: 'same-origin'
-            });
-            if (!response.ok) {
-                throw new Error('Request failed with status ' + response.status);
-            }
-            return response.json();
-        }
-
-        async function parseApiResponse(response) {
-            var contentType = response.headers.get('content-type') || '';
-            var data;
-            if (contentType.indexOf('application/json') !== -1) {
-                data = await response.json();
-            } else {
-                var text = await response.text();
-                if (!response.ok) {
-                    throw new Error(text || ('Request failed (' + response.status + ').'));
-                }
-                throw new Error('The server returned a non-JSON response.');
-            }
-            if (!response.ok) {
-                throw new Error((data && data.error && data.error.message) ? data.error.message : ('Request failed (' + response.status + ').'));
-            }
-            return data;
-        }
-
-        function updateModalSourceStatus() {
-            var hasActiveFile = !!state.file;
-            utilityFileInput.classList.toggle('hidden', utilitySourceActive.checked);
-            repairFileInput.classList.toggle('hidden', repairSourceActive.checked);
-            utilitySourceStatus.textContent = utilitySourceActive.checked
-                ? (hasActiveFile ? 'The active DOCX will be used.' : 'No active DOCX is loaded. Choose a separate DOCX upload instead.')
-                : (utilityFileInput.files[0] ? utilityFileInput.files[0].name : 'Choose a DOCX file for utilities.');
-            repairSourceStatus.textContent = repairSourceActive.checked
-                ? (hasActiveFile ? 'The active DOCX will be used.' : 'No active DOCX is loaded. Choose a separate DOCX upload instead.')
-                : (repairFileInput.files[0] ? repairFileInput.files[0].name : 'Choose a DOCX file for repair.');
-        }
-
-        function getModalSourceFile(kind) {
-            if (kind === 'utility') {
-                return utilitySourceActive.checked ? state.file : utilityFileInput.files[0];
-            }
-            return repairSourceActive.checked ? state.file : repairFileInput.files[0];
-        }
-
-        function downloadBase64Docx(docxBase64, filename) {
-            var binaryString = atob(docxBase64);
-            var bytes = new Uint8Array(binaryString.length);
-            for (var i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
-            var blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
-            var url = URL.createObjectURL(blob);
-            var link = document.createElement('a');
-            link.href = url;
-            link.download = filename || 'output.docx';
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-            URL.revokeObjectURL(url);
-        }
-
-        function formatReportAsHtml(report) {
-            if (!report) return '<div class="text-muted">No report returned.</div>';
-            if (typeof report === 'string') return '<div>' + escapeHtml(report) + '</div>';
-            if (Array.isArray(report)) return '<pre class="bg-light rounded p-2 small mb-0">' + escapeHtml(JSON.stringify(report, null, 2)) + '</pre>';
-
-            var html = '';
-            if (Array.isArray(report.errors) && report.errors.length) {
-                html += '<div class="alert alert-danger small"><div class="fw-semibold mb-1">Errors</div>';
-                report.errors.forEach(function(issue) {
-                    html += '<div>' + escapeHtml(issue.message || issue.error || JSON.stringify(issue)) + '</div>';
-                });
-                html += '</div>';
-            }
-            if (Array.isArray(report.warning_details) && report.warning_details.length) {
-                html += '<div class="alert alert-warning small"><div class="fw-semibold mb-1">Warnings</div>';
-                report.warning_details.forEach(function(issue) {
-                    html += '<div>' + escapeHtml(issue.message || issue.code || JSON.stringify(issue)) + '</div>';
-                });
-                html += '</div>';
-            } else if (Array.isArray(report.warnings) && report.warnings.length) {
-                html += '<div class="alert alert-warning small"><div class="fw-semibold mb-1">Warnings</div>';
-                report.warnings.forEach(function(issue) {
-                    html += '<div>' + escapeHtml(typeof issue === 'string' ? issue : (issue.message || issue.code || JSON.stringify(issue))) + '</div>';
-                });
-                html += '</div>';
-            }
-            if (Array.isArray(report.xml_parse_errors) && report.xml_parse_errors.length) {
-                html += '<div class="alert alert-danger small"><div class="fw-semibold mb-1">XML Parse Errors</div>';
-                report.xml_parse_errors.forEach(function(issue) {
-                    html += '<div>' + escapeHtml((issue.part || 'part') + ': ' + (issue.error || 'Parse error')) + '</div>';
-                });
-                html += '</div>';
-            }
-            if (Array.isArray(report.schema_errors) && report.schema_errors.length) {
-                html += '<div class="alert alert-danger small"><div class="fw-semibold mb-1">Schema Errors</div>';
-                report.schema_errors.forEach(function(issue) {
-                    html += '<div>' + escapeHtml((issue.part || 'part') + ': ' + (issue.error || 'Schema error')) + '</div>';
-                });
-                html += '</div>';
-            }
-            if (report.message) {
-                html += '<div class="alert alert-info small">' + escapeHtml(report.message) + '</div>';
-            }
-            html += '<pre class="bg-light rounded p-2 small mb-0">' + escapeHtml(JSON.stringify(report, null, 2)) + '</pre>';
-            return html;
-        }
-
-        async function runDocxOperation(kind, action, progressMessage) {
-            var sourceFile = getModalSourceFile(kind);
-            if (!sourceFile) {
-                showError('Choose a DOCX file or load one into the editor first.');
-                return;
-            }
-
-            var resultContainer = kind === 'utility' ? utilitiesResult : repairResult;
-            var endpoint = kind === 'utility' ? '/al/docx-labeler/api/utilities' : '/al/docx-labeler/api/repair';
-            resultContainer.innerHTML = '<div class="text-muted">Running...</div>';
-            showLoading(progressMessage);
-            try {
-                var formData = new FormData();
-                formData.append('file', sourceFile);
-                formData.append('action', action);
-                var response = await fetch(endpoint, { method: 'POST', body: formData });
-                var payload = await parseApiResponse(response);
-                var data = payload.data || {};
-                var html = formatReportAsHtml(data.report);
-                if (data.docx_base64) {
-                    html += '<div class="mt-3"><button class="btn btn-primary btn-sm" id="' + kind + '-download-result">Download Result</button></div>';
-                }
-                resultContainer.innerHTML = html;
-                if (data.docx_base64) {
-                    document.getElementById(kind + '-download-result').addEventListener('click', function() {
-                        downloadBase64Docx(data.docx_base64, data.filename);
-                    });
-                }
-            } catch (error) {
-                resultContainer.innerHTML = '<div class="alert alert-danger small mb-0">' + escapeHtml(error.message || 'Operation failed.') + '</div>';
-            } finally {
-                hideLoading();
-            }
-        }
-
-        function sleep(milliseconds) {
-            return new Promise(function(resolve) {
-                window.setTimeout(resolve, milliseconds);
-            });
-        }
-
-        async function pollLabelerJob(jobUrl, progressMessage) {
-            var startedAt = Date.now();
-            var timeoutMs = 15 * 60 * 1000;
-            while ((Date.now() - startedAt) < timeoutMs) {
-                await sleep(1500);
-                var response = await fetch(jobUrl, {
-                    method: 'GET',
-                    headers: { 'Accept': 'application/json' }
-                });
-                var payload = await parseApiResponse(response);
-                if (payload.status === 'queued' || payload.status === 'running') {
-                    showLoading(progressMessage);
-                    continue;
-                }
-                if (payload.status === 'failed') {
-                    throw new Error((payload.error && payload.error.message) || 'Background job failed.');
-                }
-                if (payload.status === 'succeeded') {
-                    return payload.data || {};
-                }
-                throw new Error('Unexpected background job status.');
-            }
-            throw new Error('The background job timed out before it completed.');
-        }
-
-        async function requestAsyncLabelerAction(endpointPath, formData, progressMessage) {
-            formData.append('mode', 'async');
-            var response = await fetch(endpointPath, {
-                method: 'POST',
-                headers: { 'Accept': 'application/json' },
-                body: formData
-            });
-            var payload = await parseApiResponse(response);
-            if (payload.status === 'queued' && payload.job_url) {
-                showLoading(progressMessage);
-                return pollLabelerJob(payload.job_url, progressMessage);
-            }
-            return (payload && payload.data) ? payload.data : {};
-        }
-
-        async function fetchPlaygroundProjects() {
-            if (!state.auth.isAuthenticated) {
-                state.playground.projects = [];
-                state.playground.files = [];
-                state.playground.selectedFile = '';
-                state.playground.variables = [];
-                state.playground.topLevelNames = [];
-                renderInterviewPicker();
-                return;
-            }
-            try {
-                var data = await fetchJsonOrThrow(endpointPath('playgroundProjects', '/al/labeler/api/playground-projects'));
-                state.playground.projects =
-                    data && data.success && data.data && Array.isArray(data.data.projects)
-                        ? data.data.projects
-                        : [];
-                if (state.playground.projects.indexOf(state.playground.selectedProject) === -1) {
-                    state.playground.selectedProject = state.playground.projects[0] || 'default';
-                }
-                await fetchPlaygroundFiles();
-                return;
-            } catch (_error) {}
-            state.playground.projects = [];
-            state.playground.files = [];
-            state.playground.selectedFile = '';
-            state.playground.variables = [];
-            state.playground.topLevelNames = [];
-            renderInterviewPicker();
-        }
-
-        async function fetchPlaygroundFiles() {
-            if (!state.auth.isAuthenticated || !state.playground.selectedProject) {
-                state.playground.files = [];
-                state.playground.selectedFile = '';
-                state.playground.variables = [];
-                state.playground.topLevelNames = [];
-                renderInterviewPicker();
-                return;
-            }
-            try {
-                var data = await fetchJsonOrThrow(
-                    endpointPath('playgroundFiles', '/al/labeler/api/playground-files') + '?project='
-                    + encodeURIComponent(state.playground.selectedProject)
-                );
-                var files =
-                    data && data.success && data.data && Array.isArray(data.data.files)
-                        ? data.data.files
-                        : [];
-                state.playground.files = files;
-                var currentStillExists = files.some(function(item) { return item.filename === state.playground.selectedFile; });
-                state.playground.selectedFile = currentStillExists ? state.playground.selectedFile : (files[0] ? files[0].filename : '');
-                renderInterviewPicker();
-                await fetchPlaygroundVariables();
-                return;
-            } catch (_error) {}
-            state.playground.files = [];
-            state.playground.selectedFile = '';
-            state.playground.variables = [];
-            state.playground.topLevelNames = [];
-            renderInterviewPicker();
-        }
-
-        async function fetchPlaygroundVariables() {
-            if (!state.auth.isAuthenticated || !state.playground.selectedProject || !state.playground.selectedFile) {
-                state.playground.variables = [];
-                state.playground.topLevelNames = [];
-                renderInterviewPicker();
-                return;
-            }
-            try {
-                var data = await fetchJsonOrThrow(
-                    endpointPath('playgroundVariables', '/al/labeler/api/playground-variables') + '?project='
-                    + encodeURIComponent(state.playground.selectedProject)
-                    + '&filename=' + encodeURIComponent(state.playground.selectedFile)
-                );
-                state.playground.variables =
-                    data && data.success && data.data && Array.isArray(data.data.all_names)
-                        ? data.data.all_names
-                        : [];
-                state.playground.topLevelNames =
-                    data && data.success && data.data && Array.isArray(data.data.top_level_names)
-                        ? data.data.top_level_names
-                        : deriveTopLevelNames(state.playground.variables);
-            } catch (_error) {
-                state.playground.variables = [];
-                state.playground.topLevelNames = [];
-            }
-            renderInterviewPicker();
-        }
-
-        async function fetchInstalledPackages() {
-            if (!state.auth.isAuthenticated) {
-                state.installed.packages = [];
-                state.installed.files = [];
-                state.installed.selectedPackage = '';
-                state.installed.selectedFile = '';
-                state.installed.variables = [];
-                state.installed.topLevelNames = [];
-                renderInterviewPicker();
-                return;
-            }
-            try {
-                var data = await fetchJsonOrThrow(endpointPath('installedPackages', '/al/labeler/api/installed-packages'));
-                state.installed.packages =
-                    data && data.success && data.data && Array.isArray(data.data.packages)
-                        ? data.data.packages
-                        : [];
-                if (state.installed.packages.indexOf(state.installed.selectedPackage) === -1) {
-                    state.installed.selectedPackage = state.installed.packages[0] || '';
-                }
-                await fetchInstalledFiles();
-                return;
-            } catch (_error) {}
-            state.installed.packages = [];
-            state.installed.files = [];
-            state.installed.selectedPackage = '';
-            state.installed.selectedFile = '';
-            state.installed.variables = [];
-            state.installed.topLevelNames = [];
-            renderInterviewPicker();
-        }
-
-        async function fetchInstalledFiles() {
-            if (!state.auth.isAuthenticated || !state.installed.selectedPackage) {
-                state.installed.files = [];
-                state.installed.selectedFile = '';
-                state.installed.variables = [];
-                state.installed.topLevelNames = [];
-                renderInterviewPicker();
-                return;
-            }
-            try {
-                var data = await fetchJsonOrThrow(
-                    endpointPath('installedFiles', '/al/labeler/api/installed-files') + '?package='
-                    + encodeURIComponent(state.installed.selectedPackage)
-                );
-                var files =
-                    data && data.success && data.data && Array.isArray(data.data.files)
-                        ? data.data.files
-                        : [];
-                state.installed.files = files;
-                var currentStillExists = files.some(function(item) { return item.filename === state.installed.selectedFile; });
-                state.installed.selectedFile = currentStillExists ? state.installed.selectedFile : (files[0] ? files[0].filename : '');
-                renderInterviewPicker();
-                await fetchInstalledVariables();
-                return;
-            } catch (_error) {}
-            state.installed.files = [];
-            state.installed.selectedFile = '';
-            state.installed.variables = [];
-            state.installed.topLevelNames = [];
-            renderInterviewPicker();
-        }
-
-        async function fetchInstalledVariables() {
-            if (!state.auth.isAuthenticated || !state.installed.selectedPackage || !state.installed.selectedFile) {
-                state.installed.variables = [];
-                state.installed.topLevelNames = [];
-                renderInterviewPicker();
-                return;
-            }
-            try {
-                var interviewPath = state.installed.selectedPackage + ':' + state.installed.selectedFile;
-                var data = await fetchJsonOrThrow(
-                    endpointPath('installedVariables', '/al/labeler/api/installed-variables') + '?interview_path='
-                    + encodeURIComponent(interviewPath)
-                );
-                state.installed.variables =
-                    data && data.success && data.data && Array.isArray(data.data.all_names)
-                        ? data.data.all_names
-                        : [];
-                state.installed.topLevelNames =
-                    data && data.success && data.data && Array.isArray(data.data.top_level_names)
-                        ? data.data.top_level_names
-                        : deriveTopLevelNames(state.installed.variables);
-            } catch (_error) {
-                state.installed.variables = [];
-                state.installed.topLevelNames = [];
-            }
-            renderInterviewPicker();
-        }
-
-        async function fetchAuthStatus() {
-            try {
-                var nextTarget = window.location.pathname + window.location.search;
-                var response = await fetch(endpointPath('authStatus', '/al/labeler/api/auth-status') + '?next=' + encodeURIComponent(nextTarget), { method: 'GET' });
-                var data = await response.json();
-                if (data.success && data.data) {
-                    state.auth.isAuthenticated = !!data.data.is_authenticated;
-                    state.auth.email = data.data.email || '';
-                    state.auth.loginUrl = data.data.login_url || '/user/sign-in';
-                    state.auth.logoutUrl = data.data.logout_url || '/user/sign-out';
-                    state.auth.aiEnabled = !!data.data.ai_enabled;
-                }
-            } catch (_error) {
-                state.auth = {
-                    isAuthenticated: false,
-                    email: '',
-                    loginUrl: '/user/sign-in',
-                    logoutUrl: '/user/sign-out',
-                    aiEnabled: false
-                };
-            }
-            renderAuthControls();
-            updateAiUiState();
-            if (state.auth.isAuthenticated) {
-                await fetchPlaygroundProjects();
-                await maybeOpenInitialPlaygroundTemplate();
-                await fetchInstalledPackages();
-            } else if (!shouldHideInterviewPicker()) {
-                await fetchPlaygroundProjects();
-                await fetchInstalledPackages();
-            }
-        }
-
-        function renderModelSuggestions(filterText) {
-            var filter = (filterText || '').trim().toLowerCase();
-            var modelChoices = [];
-            if (filter) {
-                var source = state.availableModels.length ? state.availableModels : state.recommendedModels;
-                modelChoices = source.filter(function(model) {
-                    return model.toLowerCase().includes(filter);
-                }).slice(0, 20);
-            } else {
-                modelChoices = state.recommendedModels.slice(0, 8);
-            }
-            aiModelSuggestions.innerHTML = '';
-            modelChoices.forEach(function(modelName) {
-                var button = document.createElement('button');
-                button.type = 'button';
-                button.className = 'btn btn-sm btn-outline-secondary font-monospace';
-                button.textContent = modelName;
-                button.addEventListener('click', function() {
-                    aiModelInput.value = modelName;
-                    state.settings.model = modelName;
-                    renderModelSuggestions(modelName);
-                });
-                aiModelSuggestions.appendChild(button);
-            });
-        }
-
-        function renderGenerationMethodFields() {
-            var method = generationMethodInput.value || state.settings.generationMethod || 'multi_run';
-            generatorModelsGroup.classList.toggle('hidden', method !== 'multi_model');
-        }
-
-        function parseGeneratorModelsInput(rawValue) {
-            return (rawValue || '')
-                .split(/[\n,]/)
-                .map(function(item) { return item.trim(); })
-                .filter(function(item) { return item.length > 0; });
-        }
-
-        // ================================================================
-        // UI state transitions
-        // ================================================================
-        function showLoading(message) {
-            loadingMessage.textContent = message;
-            loadingState.classList.remove('hidden');
-            emptyState.classList.add('hidden');
-            mainPanel.classList.add('hidden');
-            errorState.classList.add('hidden');
-        }
-
-        function hideLoading() {
-            loadingState.classList.add('hidden');
-        }
-
-        function showError(message) {
-            errorMessage.textContent = message;
-            errorState.classList.remove('hidden');
-            emptyState.classList.add('hidden');
-            mainPanel.classList.add('hidden');
-        }
-
-        function showMainPanel() {
-            mainPanel.classList.remove('hidden');
-            emptyState.classList.add('hidden');
-            errorState.classList.add('hidden');
-        }
-
-        // ================================================================
-        // Label extraction from mammoth HTML
-        // ================================================================
-        function extractExistingLabels(html) {
-            const labels = [];
-            // Combined scan in document order: {{ }} and {% %}
-            const allPattern = /\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}/g;
-            let match;
-            while ((match = allPattern.exec(html)) !== null) {
-                const text = match[0];
-                labels.push({
-                    id: generateId(),
-                    original: text,
-                    current: text,
-                    isControl: text.startsWith('{%')
-                });
-            }
-            return labels;
-        }
-
-        function extractExistingLabelsFromRuns(runs) {
-            if (previewUtils && previewUtils.extractLabelsFromRuns) {
-                return previewUtils.extractLabelsFromRuns(runs, generateId);
-            }
-            var labels = [];
-            var pattern = /\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}/g;
-            (runs || []).forEach(function(run) {
-                var paragraph = run[0];
-                var runIndex = run[1];
-                var text = String(run[2] || '');
-                pattern.lastIndex = 0;
-                var match;
-                while ((match = pattern.exec(text)) !== null) {
-                    var labelText = match[0];
-                    labels.push({
-                        id: generateId(),
-                        original: labelText,
-                        current: labelText,
-                        isControl: labelText.startsWith('{%'),
-                        paragraph: paragraph,
-                        run: runIndex,
-                        start: match.index,
-                        end: match.index + labelText.length
-                    });
-                }
-            });
-            return labels;
-        }
-
-        // ================================================================
-        // Paragraph / run index for mapping selections to runs
-        // ================================================================
-        function buildParagraphIndex() {
-            var index = {};
-            state.runs.forEach(function(r) {
-                var para = r[0], run = r[1], text = r[2];
-                if (!index[para]) index[para] = { runs: [], fullText: '' };
-                index[para].runs.push({ runIdx: run, text: text, start: index[para].fullText.length, end: 0 });
-                index[para].fullText += text;
-            });
-            Object.keys(index).forEach(function(p) {
-                index[p].runs.forEach(function(r) { r.end = r.start + r.text.length; });
-            });
-            return index;
-        }
-
-        function buildGlobalRunIndex() {
-            var sortedRuns = state.runs.slice().sort(function(a, b) {
-                if (a[0] !== b[0]) return a[0] - b[0];
-                return a[1] - b[1];
-            });
-            var entries = [];
-            var globalOffset = 0;
-            var lastParagraph = null;
-            sortedRuns.forEach(function(r) {
-                var paragraph = r[0];
-                var run = r[1];
-                var text = String(r[2] || '');
-                if (lastParagraph !== null && paragraph !== lastParagraph) {
-                    globalOffset += 1;
-                }
-                entries.push({
-                    paragraph: paragraph,
-                    run: run,
-                    text: text,
-                    start: globalOffset,
-                    end: globalOffset + text.length,
-                });
-                globalOffset += text.length;
-                lastParagraph = paragraph;
-            });
-            return entries;
-        }
-
-        /**
-         * Given a user-selected text string, find the paragraph and set of
-         * consecutive runs whose concatenated text contains the selection.
-         * Returns null when no match is found.
-         */
-        function findRunsForSelection(selectedText) {
-            if (!selectedText || !selectedText.trim()) return null;
-            var paraIndex = buildParagraphIndex();
-            var trimmed = selectedText.trim();
-
-            for (var paraNum in paraIndex) {
-                var para = paraIndex[paraNum];
-                // Direct substring lookup in this paragraph’s concatenated text
-                var pos = para.fullText.indexOf(trimmed);
-                if (pos === -1) {
-                    // Normalised whitespace fallback
-                    var normFull = para.fullText.replace(/\s+/g, ' ');
-                    var normSel  = trimmed.replace(/\s+/g, ' ');
-                    pos = normFull.indexOf(normSel);
-                    if (pos === -1) continue;
-                }
-                var end = pos + trimmed.length;
-
-                var matchedRuns = [];
-                para.runs.forEach(function(r) {
-                    if (r.end > pos && r.start < end) {
-                        matchedRuns.push({
-                            paragraph: parseInt(paraNum),
-                            run: r.runIdx,
-                            originalText: r.text,
-                            selStart: Math.max(0, pos - r.start),
-                            selEnd:   Math.min(r.text.length, end - r.start),
-                            isFullySelected: pos <= r.start && end >= r.end
-                        });
-                    }
-                });
-                if (matchedRuns.length > 0) {
-                    return { paraNum: parseInt(paraNum), runs: matchedRuns, selectedText: trimmed };
-                }
-            }
-            return null;
-        }
-
-        /**
-         * Build suggestion entries that replace the matched runs with a Jinja2
-         * variable.  The first run keeps any unselected prefix and gets the
-         * label; the last run keeps any unselected suffix; middle runs are
-         * blanked.  All entries share a `group` id so the UI and preview can
-         * treat them as one logical operation.
-         */
-        function createLabelFromSelection(variableName, match) {
-            var groupId = generateId();
-            var labels = [];
-            match.runs.forEach(function(r, i) {
-                var newText;
-                var manualRole;
-                var manualPrefix = '';
-                var manualSuffix = '';
-                if (match.runs.length === 1) {
-                    // Only run: prefix + label + suffix
-                    manualPrefix = r.originalText.substring(0, r.selStart);
-                    manualSuffix = r.originalText.substring(r.selEnd);
-                    newText = manualPrefix + variableName + manualSuffix;
-                    manualRole = 'single';
-                } else if (i === 0) {
-                    manualPrefix = r.originalText.substring(0, r.selStart);
-                    newText = manualPrefix + variableName;
-                    manualRole = 'first';
-                } else if (i === match.runs.length - 1) {
-                    manualSuffix = r.originalText.substring(r.selEnd);
-                    newText = manualSuffix;
-                    manualRole = 'last';
-                } else {
-                    newText = '';
-                    manualRole = 'middle';
-                }
-                labels.push({
-                    paragraph: r.paragraph,
-                    run: r.run,
-                    text: newText,
-                    new_paragraph: 0,
-                    id: generateId(),
-                    status: 'accepted',
-                    group: groupId,
-                    _isCompanion: i > 0,
-                    _isManual: true,
-                    _selectedText: match.selectedText,
-                    _displayLabel: variableName,
-                    _manualKind: 'replace',
-                    _manualRole: manualRole,
-                    _manualPrefix: manualPrefix,
-                    _manualSuffix: manualSuffix
-                });
-            });
-            return labels;
-        }
-
-        function createWrappedLabelFromSelection(conditionExpression, match, wrapperKind) {
-            var groupId = generateId();
-            var labels = [];
-            var openTag = wrapperKind === 'ifp_wrap'
-                ? '{%p if ' + conditionExpression + ' %}'
-                : '{% if ' + conditionExpression + ' %}';
-            var closeTag = wrapperKind === 'ifp_wrap'
-                ? '{%p endif %}'
-                : '{% endif %}';
-            match.runs.forEach(function(r, i) {
-                var selectedFragment = r.originalText.substring(r.selStart, r.selEnd);
-                var manualPrefix = '';
-                var manualSuffix = '';
-                var manualRole = 'middle';
-                var newText = selectedFragment;
-                if (match.runs.length === 1) {
-                    manualRole = 'single';
-                    manualPrefix = r.originalText.substring(0, r.selStart);
-                    manualSuffix = r.originalText.substring(r.selEnd);
-                    newText = manualPrefix + openTag + selectedFragment + closeTag + manualSuffix;
-                } else if (i === 0) {
-                    manualRole = 'first';
-                    manualPrefix = r.originalText.substring(0, r.selStart);
-                    newText = manualPrefix + openTag + selectedFragment;
-                } else if (i === match.runs.length - 1) {
-                    manualRole = 'last';
-                    manualSuffix = r.originalText.substring(r.selEnd);
-                    newText = selectedFragment + closeTag + manualSuffix;
-                }
-                labels.push({
-                    paragraph: r.paragraph,
-                    run: r.run,
-                    text: newText,
-                    new_paragraph: 0,
-                    id: generateId(),
-                    status: 'accepted',
-                    group: groupId,
-                    _isCompanion: i > 0,
-                    _isManual: true,
-                    _selectedText: match.selectedText,
-                    _displayLabel: conditionExpression,
-                    _manualKind: wrapperKind,
-                    _manualRole: manualRole,
-                    _manualPrefix: manualPrefix,
-                    _manualSuffix: manualSuffix,
-                    _selectedFragment: selectedFragment
-                });
-            });
-            return labels;
-        }
-
-        // ================================================================
-        // Selection popover logic
-        // ================================================================
-        var _selMatch = null;   // stashed findRunsForSelection() result
-        var _selectionMode = 'replace';
-
-        function ensureSelectionModeControls() {
-            if (document.getElementById('sel-mode-group')) return;
-            var controls = document.createElement('div');
-            controls.className = 'mb-2';
-            controls.innerHTML =
-                '<div id="sel-mode-group" class="btn-group btn-group-sm w-100" role="group" aria-label="Selection mode">' +
-                    '<button type="button" class="btn btn-outline-secondary sel-mode-btn active" data-mode="replace">Replace</button>' +
-                    '<button type="button" class="btn btn-outline-secondary sel-mode-btn" data-mode="insert">Insert</button>' +
-                    '<button type="button" class="btn btn-outline-secondary sel-mode-btn" data-mode="if_wrap">{% if %}</button>' +
-                    '<button type="button" class="btn btn-outline-secondary sel-mode-btn" data-mode="ifp_wrap">{%p if %}</button>' +
-                '</div>';
-            var body = selPopover.querySelector('.dl-sel-popover-body');
-            if (body) {
-                body.insertBefore(controls, body.firstChild);
-                var filterBtn = document.createElement('button');
-                filterBtn.type = 'button';
-                filterBtn.id = 'sel-catchall-btn';
-                filterBtn.className = 'btn btn-sm btn-outline-primary mt-2 w-100';
-                filterBtn.textContent = 'Catchall / Request Filters';
-                filterBtn.addEventListener('click', function() {
-                    openCatchallDialog(selVarInput);
-                });
-                body.appendChild(filterBtn);
-            }
-            controls.querySelectorAll('.sel-mode-btn').forEach(function(button) {
-                button.addEventListener('click', function() {
-                    _selectionMode = button.dataset.mode || 'replace';
-                    updateSelectionModeButtons();
-                    updateSelectionModeInputHints();
-                });
-            });
-            updateSelectionModeButtons();
-            updateSelectionModeInputHints();
-        }
-
-        function updateSelectionModeButtons() {
-            document.querySelectorAll('.sel-mode-btn').forEach(function(button) {
-                var isActive = button.dataset.mode === _selectionMode;
-                button.classList.toggle('active', isActive);
-                button.classList.toggle('btn-primary', isActive);
-                button.classList.toggle('btn-outline-secondary', !isActive);
-            });
-        }
-
-        function updateSelectionModeInputHints() {
-            var mainPerson = (state.settings && state.settings.primaryPersonVariable && state.settings.primaryPersonVariable !== '') ? state.settings.primaryPersonVariable : 'users';
-            if (_selectionMode === 'replace' || _selectionMode === 'insert') {
-                selVarInput.placeholder = '{{ ' + mainPerson + '[0].name.first }}';
-            } else {
-                selVarInput.placeholder = mainPerson + '[0].is_active';
-            }
-            if (_selMatch && _selMatch.isInsertion) {
-                selOriginalText.textContent = '(insert at cursor)';
-            }
-        }
-
-        function normalizeSelectionInput(raw) {
-            if (_selectionMode === 'replace' || _selectionMode === 'insert') {
-                var varName = raw;
-                if (!/^\{[{%]/.test(varName)) {
-                    varName = '{{ ' + varName + ' }}';
-                }
-                return varName;
-            }
-            return raw
-                .replace(/^\{%\s*p?\s*if\s*/i, '')
-                .replace(/\s*%\}$/, '')
-                .replace(/^\{\{\s*/, '')
-                .replace(/\s*\}\}$/, '')
-                .trim();
-        }
-
-        /**
-         * Build a global run index that reflects the current preview state
-         * by applying accepted suggestions and existing-label renames.
-         * This keeps DOM text offsets aligned with the run map.
-         */
-        function buildCurrentGlobalRunIndex() {
-            var modifications = {};
-            if (previewUtils && previewUtils.buildAcceptedRunPatchLookup) {
-                modifications = previewUtils.buildAcceptedRunPatchLookup(
-                    state.runs,
-                    state.existingLabels,
-                    state.suggestions
-                );
-            }
-            var sortedRuns = state.runs.slice().sort(function(a, b) {
-                if (a[0] !== b[0]) return a[0] - b[0];
-                return a[1] - b[1];
-            });
-            var entries = [];
-            var globalOffset = 0;
-            var lastParagraph = null;
-            sortedRuns.forEach(function(r) {
-                var paragraph = r[0];
-                var run = r[1];
-                var key = paragraph + ',' + run + ',0';
-                var text = String(r[2] || '');
-                if (Object.prototype.hasOwnProperty.call(modifications, key)) {
-                    text = String(modifications[key].text || '');
-                } else {
-                    text = String(r[2] || '');
-                }
-                if (lastParagraph !== null && paragraph !== lastParagraph) {
-                    globalOffset += 1;
-                }
-                entries.push({
-                    paragraph: paragraph,
-                    run: run,
-                    text: text,
-                    start: globalOffset,
-                    end: globalOffset + text.length,
-                });
-                globalOffset += text.length;
-                lastParagraph = paragraph;
-            });
-            return entries;
-        }
-
-        function findRunMatchForCaret(caretRange) {
-            if (!caretRange) return null;
-            var prefixRange = document.createRange();
-            prefixRange.selectNodeContents(previewContent);
-            prefixRange.setEnd(caretRange.startContainer, caretRange.startOffset);
-            var globalOffset = prefixRange.toString().length;
-            var runIndex = buildCurrentGlobalRunIndex();
-            if (!runIndex.length) return null;
-            var target = runIndex.find(function(entry) {
-                return globalOffset >= entry.start && globalOffset <= entry.end;
-            });
-            if (!target) {
-                target = runIndex[runIndex.length - 1];
-            }
-            var offsetInRun = Math.max(0, Math.min(target.text.length, globalOffset - target.start));
-            return {
-                paraNum: target.paragraph,
-                runs: [{
-                    paragraph: target.paragraph,
-                    run: target.run,
-                    originalText: target.text,
-                    selStart: offsetInRun,
-                    selEnd: offsetInRun,
-                    isFullySelected: false
-                }],
-                selectedText: '',
-                isInsertion: true
-            };
-        }
-
-        function showSelectionPopover(match, mouseX, mouseY) {
-            ensureSelectionModeControls();
-            _selMatch = match;
-            selOriginalText.textContent = match.isInsertion ? '(insert at cursor)' : match.selectedText;
-            selVarInput.value = '';
-            selVarPanel.classList.add('hidden');
-            selVarSearch.value = '';
-            if (match.isInsertion) {
-                _selectionMode = 'insert';
-            } else if (_selectionMode === 'insert') {
-                _selectionMode = 'replace';
-            }
-            updateSelectionModeButtons();
-            updateSelectionModeInputHints();
-
-            // Position near the cursor, clamped to viewport
-            var pw = 380, ph = 260;
-            var vw = window.innerWidth, vh = window.innerHeight;
-            var left = Math.min(mouseX + 4, vw - pw - 12);
-            var top  = mouseY + 12;
-            if (top + ph > vh) top = Math.max(8, mouseY - ph - 8);
-            selPopover.style.left = Math.max(4, left) + 'px';
-            selPopover.style.top  = top + 'px';
-            selPopover.classList.remove('hidden');
-            selVarInput.focus();
-        }
-
-        function hideSelectionPopover() {
-            selPopover.classList.add('hidden');
-            _selMatch = null;
-        }
-
-        function saveSelectionLabel() {
-            var raw = selVarInput.value.trim();
-            if (!raw || !_selMatch) return;
-            if ((_selectionMode === 'if_wrap' || _selectionMode === 'ifp_wrap') && _selMatch.isInsertion) {
-                showError('Select text first when adding conditional wrappers.');
-                return;
-            }
-            var value = normalizeSelectionInput(raw);
-            var newLabels;
-            if (_selectionMode === 'if_wrap' || _selectionMode === 'ifp_wrap') {
-                newLabels = createWrappedLabelFromSelection(value, _selMatch, _selectionMode);
-            } else {
-                newLabels = createLabelFromSelection(value, _selMatch);
-            }
-            state.suggestions = state.suggestions.concat(newLabels);
-            hideSelectionPopover();
-            renderSuggestions();
-            updatePreview();
-            updateDownloadButton();
-            switchTab('manual');
-        }
-
-        function onPreviewMouseUp(e) {
-            if (previewUtils && previewUtils.shouldSuppressSelectionPopoverFromTarget) {
-                if (previewUtils.shouldSuppressSelectionPopoverFromTarget(e.target)) return;
-            } else if (e.target && e.target.closest && e.target.closest('.existing-inline-label')) {
-                return;
-            }
-            // Ignore if popover is already open or no document loaded
-            if (!selPopover.classList.contains('hidden')) return;
-            if (!state.file || state.runs.length === 0) return;
-
-            var sel = window.getSelection();
-            if (!sel) return;
-
-            // Make sure the selection is inside the preview area
-            var anchor = sel.anchorNode, focus = sel.focusNode;
-            if (!previewContent.contains(anchor) || !previewContent.contains(focus)) return;
-
-            var match = null;
-            if (sel.isCollapsed) {
-                if (document.caretRangeFromPoint) {
-                    match = findRunMatchForCaret(document.caretRangeFromPoint(e.clientX, e.clientY));
-                } else if (document.caretPositionFromPoint) {
-                    var caretPos = document.caretPositionFromPoint(e.clientX, e.clientY);
-                    if (caretPos) {
-                        var fallbackRange = document.createRange();
-                        fallbackRange.setStart(caretPos.offsetNode, caretPos.offset);
-                        fallbackRange.setEnd(caretPos.offsetNode, caretPos.offset);
-                        match = findRunMatchForCaret(fallbackRange);
-                    }
-                }
-                if (!match) return;
-            } else {
-                var text = sel.toString();
-                if (!text || !text.trim()) return;
-                match = findRunsForSelection(text);
-                if (!match) return;
-            }
-
-            showSelectionPopover(match, e.clientX, e.clientY);
-        }
-
-        // Render the variable tree inside the popover (reuses the same builder)
-        function renderSelPopoverTree(filter) {
-            selVarTree.innerHTML = '';
-            renderVariableTree(getEffectiveVariableTree(), '', selVarTree, filter || '', function(varPath) {
-                selVarInput.value = '{{ ' + varPath + ' }}';
-                selVarInput.focus();
-            });
-        }
-
-        // ================================================================
-        // Preview rendering with highlights
-        // ================================================================
-        function updatePreview() {
-            let html = state.originalHtml;
-
-            // --- Grouped selection labels (multi-run) ---
-            // Replace the full selected text span with the display label for
-            // each unique group, before handling single-run suggestions.
-            var processedGroups = {};
-            state.suggestions.forEach(function(s) {
-                if (s.status === 'accepted' && s.group && !processedGroups[s.group]) {
-                    processedGroups[s.group] = true;
-                    var selectedText = s._selectedText;
-                    if (s._manualKind === 'if_wrap' || s._manualKind === 'ifp_wrap') {
-                        // Show the fully wrapped form in the preview
-                        var wrapDisplay = previewUtils && previewUtils.formatManualWrapPreviewDisplay
-                            ? previewUtils.formatManualWrapPreviewDisplay(
-                                s._manualKind,
-                                s._displayLabel || '',
-                                selectedText || '',
-                                escapeHtml
-                            )
-                            : escapeHtml(
-                                (s._manualKind === 'ifp_wrap' ? '{%p if ' : '{% if ')
-                                + (s._displayLabel || '')
-                                + ' %}'
-                                + (selectedText || '')
-                                + (s._manualKind === 'ifp_wrap' ? '{%p endif %}' : '{% endif %}')
-                            );
-                        if (selectedText) {
-                            var wrapEncoded = escapeHtml(selectedText);
-                            var wrapPos = html.indexOf(wrapEncoded);
-                            if (wrapPos !== -1) {
-                                html = html.substring(0, wrapPos)
-                                    + '<span class="highlight-accepted">' + wrapDisplay + '</span>'
-                                    + html.substring(wrapPos + wrapEncoded.length);
-                            }
-                        }
-                    } else if (!selectedText && s._isManual) {
-                        // Insert mode: no selected text — locate the run and replace its full text
-                        var insertRun = state.runs.find(function(r) {
-                            return r[0] === s.paragraph && r[1] === s.run;
-                        });
-                        if (insertRun && insertRun[2]) {
-                            var insertOrig = escapeHtml(String(insertRun[2]));
-                            var insertPos = html.indexOf(insertOrig);
-                            if (insertPos !== -1) {
-                                html = html.substring(0, insertPos)
-                                    + '<span class="highlight-accepted">' + escapeHtml(s.text) + '</span>'
-                                    + html.substring(insertPos + insertOrig.length);
-                            }
-                        }
-                    } else {
-                        var displayLabel = s._displayLabel || s.text;
-                        if (selectedText) {
-                            var encoded = escapeHtml(selectedText);
-                            var pos = html.indexOf(encoded);
-                            if (pos !== -1) {
-                                html = html.substring(0, pos)
-                                    + '<span class="highlight-accepted">' + escapeHtml(displayLabel) + '</span>'
-                                    + html.substring(pos + encoded.length);
-                            }
-                        }
-                    }
-                }
-            });
-
-            // --- Single-run AI suggestions (no group) ---
-            const acceptedByKey = {};
-            state.suggestions.forEach(function(s) {
-                if (s.status === 'accepted' && s.new_paragraph === 0 && !s.group) {
-                    acceptedByKey[s.paragraph + ',' + s.run] = s;
-                }
-            });
-
-            const replacements = [];
-            for (const key of Object.keys(acceptedByKey)) {
-                const s = acceptedByKey[key];
-                const run = state.runs.find(function(r) {
-                    return r[0] === s.paragraph && r[1] === s.run;
-                });
-                if (run && run[2] && run[2].trim()) {
-                    replacements.push({ original: run[2], replacement: s.text });
-                }
-            }
-            replacements.sort(function(a, b) { return b.original.length - a.original.length; });
-
-            for (const r of replacements) {
-                const encoded = escapeHtml(r.original);
-                const pos = html.indexOf(encoded);
-                if (pos !== -1) {
-                    html = html.substring(0, pos)
-                        + '<span class="highlight-accepted">' + escapeHtml(r.replacement) + '</span>'
-                        + html.substring(pos + encoded.length);
-                }
-            }
-
-            // Highlight existing labels (with any renames applied) — per-occurrence
-            if (previewUtils && previewUtils.applyExistingLabelHighlightsByOccurrence) {
-                html = previewUtils.applyExistingLabelHighlightsByOccurrence(html, state.existingLabels, escapeHtml);
-            } else {
-                var existingByOriginal = {};
-                state.existingLabels.forEach(function(label) {
-                    if (!existingByOriginal[label.original]) existingByOriginal[label.original] = [];
-                    existingByOriginal[label.original].push(label);
-                });
-                Object.keys(existingByOriginal).forEach(function(original) {
-                    var entries = existingByOriginal[original];
-                    var encoded = escapeHtml(original);
-                    var offset = 0;
-                    entries.forEach(function(label) {
-                        var cls = label.current !== label.original ? 'highlight-accepted' : 'highlight-existing';
-                        var span = '<span class="' + cls + ' existing-inline-label" data-label-id="' + escapeHtml(label.id) + '">' + escapeHtml(label.current) + '</span>';
-                        var pos = html.indexOf(encoded, offset);
-                        if (pos === -1) return;
-                        html = html.substring(0, pos) + span + html.substring(pos + encoded.length);
-                        offset = pos + span.length;
-                    });
-                });
-            }
-
-            previewContent.innerHTML = html;
-            previewContent.querySelectorAll('.existing-inline-label').forEach(function(node) {
-                node.addEventListener('click', function(evt) {
-                    evt.preventDefault();
-                    evt.stopPropagation();
-                    var labelId = node.getAttribute('data-label-id');
-                    var label = state.existingLabels.find(function(item) { return item.id === labelId; });
-                    if (label) openEditLabelModal(label);
-                });
-            });
-        }
-
-        // ================================================================
-        // Existing-labels tree
-        // ================================================================
-        function renderExistingLabelsTree() {
-            existingLabelsTree.innerHTML = '';
-            // Build unique-entry list and occurrence counts from per-occurrence data
-            var seenOriginals = {};
-            var uniqueEntries = [];
-            var occurrenceCounts = {};
-            state.existingLabels.forEach(function(label) {
-                occurrenceCounts[label.original] = (occurrenceCounts[label.original] || 0) + 1;
-                if (!seenOriginals[label.original]) {
-                    seenOriginals[label.original] = true;
-                    uniqueEntries.push(label);
-                }
-            });
-            existingCount.textContent = uniqueEntries.length;
-            if (uniqueEntries.length === 0) {
-                existingLabelsTree.innerHTML = '<div class="text-center py-5 text-muted"><p>No existing labels found.</p><p class="small mt-1">Use the AI Suggestions tab to add labels.</p></div>';
-                return;
-            }
-            const groups = {};
-            uniqueEntries.forEach(function(label) {
-                const inner = label.current.replace(/^\{\{\s*|\s*\}\}$/g, '').replace(/^\{%\s*|\s*%\}$/g, '').trim();
-                const base = inner.split('.')[0].split('[')[0];
-                if (!groups[base]) groups[base] = [];
-                groups[base].push(label);
-            });
-            Object.keys(groups).sort().forEach(function(groupName) {
-                const groupDiv = document.createElement('div');
-                groupDiv.className = 'mb-3';
-                const header = document.createElement('div');
-                header.className = 'tree-item d-flex align-items-center gap-2 px-2 py-1 rounded fw-medium';
-                header.innerHTML = '<span class="tree-toggle">\u25BC</span><span>' + escapeHtml(groupName) + '</span><span class="badge bg-secondary">' + groups[groupName].length + '</span>';
-                const children = document.createElement('div');
-                children.className = 'tree-children mt-1';
-                groups[groupName].forEach(function(label) {
-                    var count = occurrenceCounts[label.original] || 1;
-                    const item = document.createElement('div');
-                    item.className = 'existing-label p-2 rounded mb-1 cursor-pointer';
-                    item.innerHTML = '<div class="font-monospace small break-all' + (label.original !== label.current ? ' text-primary' : '') + '">' + escapeHtml(label.current) + '</div>' + (label.original !== label.current ? '<div class="small text-muted mt-1 text-decoration-line-through">' + escapeHtml(label.original) + '</div>' : '') + '<div class="small text-muted mt-1">' + count + ' occurrence' + (count > 1 ? 's' : '') + '</div>';
-                    item.addEventListener('click', function() { openEditLabelModal(label); });
-                    children.appendChild(item);
-                });
-                header.addEventListener('click', function() {
-                    var toggle = header.querySelector('.tree-toggle');
-                    if (children.style.display === 'none') { children.style.display = 'block'; toggle.textContent = '\u25BC'; }
-                    else { children.style.display = 'none'; toggle.textContent = '\u25B6'; }
-                });
-                groupDiv.appendChild(header);
-                groupDiv.appendChild(children);
-                existingLabelsTree.appendChild(groupDiv);
-            });
-            updateDownloadButton();
-        }
-
-        // ================================================================
-        // Variable-picker tree
-        // ================================================================
-        function renderVariableTree(tree, prefix, container, filter, onSelectVariable) {
-            tree = tree || getEffectiveVariableTree();
-            prefix = prefix || '';
-            container = container || variableTree;
-            filter = filter || '';
-            onSelectVariable = onSelectVariable || insertVariable;
-            if (container === variableTree) container.innerHTML = '';
-            Object.keys(tree).forEach(function(key) {
-                if (key.startsWith('_')) return;
-                var value = tree[key];
-                var isSelectedInterviewGroup = !prefix && key === 'Selected interview variables';
-                var fullPath = prefix ? prefix + '.' + key : key;
-                var displayPath = fullPath.replace(/\.\[/g, '[');
-                var singletonListChild = getSingletonListChild(value);
-                var renderTarget = singletonListChild || value;
-                var childKeys = renderTarget && typeof renderTarget === 'object'
-                    ? Object.keys(renderTarget).filter(function(childKey) { return !childKey.startsWith('_'); })
-                    : [];
-                var hasChildren = childKeys.length > 0;
-                var directSelectPath = singletonListChild ? displayPath + '[0]' : null;
-                var labelPath = directSelectPath || displayPath;
-                if (filter && !labelPath.toLowerCase().includes(filter.toLowerCase())) {
-                    if (typeof renderTarget !== 'object') return;
-                    var hasMatch = JSON.stringify(renderTarget).toLowerCase().includes(filter.toLowerCase());
-                    if (!hasMatch) return;
-                }
-                var item = document.createElement('div');
-                item.className = 'mb-1';
-                var header = document.createElement('div');
-                header.className = 'tree-item d-flex align-items-center gap-1 px-2 py-1 rounded small';
-                var leafValue = renderTarget;
-                var leafDescription = typeof leafValue === 'string' ? leafValue : (leafValue && leafValue._description ? leafValue._description : '');
-                var isSelectableLeaf = typeof value === 'string' || (value !== null && typeof value === 'object' && !!value._variable) || (directSelectPath && !hasChildren);
-                if (value === null) {
-                    return; // Skip null values completely, they are effectively deleted keys
-                }
-                if (isSelectableLeaf) {
-                    header.innerHTML = '<span class="tree-toggle text-muted">\u00B7</span><span class="font-monospace text-primary cursor-pointer" data-var="' + labelPath + '">' + labelPath + '</span><span class="text-muted small ms-1 text-truncate">' + leafDescription + '</span>';
-                    header.querySelector('[data-var]').addEventListener('click', function(e) { e.stopPropagation(); onSelectVariable(labelPath); });
-                } else if (directSelectPath) {
-                    header.innerHTML = '<span class="tree-toggle cursor-pointer">\u25B6</span><span class="font-monospace text-primary cursor-pointer" data-var="' + directSelectPath + '">' + directSelectPath + '</span>' + (leafDescription ? '<span class="text-muted small ms-1">' + leafDescription + '</span>' : '');
-                    header.querySelector('[data-var]').addEventListener('click', function(e) { e.stopPropagation(); onSelectVariable(directSelectPath); });
-                } else {
-                    header.innerHTML = '<span class="tree-toggle cursor-pointer">\u25B6</span><span class="fw-medium">' + key + '</span>' + (leafDescription ? '<span class="text-muted small ms-1">' + leafDescription + '</span>' : '');
-                }
-                item.appendChild(header);
-                if (hasChildren) {
-                    var children = document.createElement('div');
-                    children.className = 'tree-children hidden';
-                    renderVariableTree(renderTarget, isSelectedInterviewGroup ? prefix : (directSelectPath || fullPath), children, filter, onSelectVariable);
-                    item.appendChild(children);
-                    header.addEventListener('click', function(e) {
-                        if (e.target.dataset && e.target.dataset.var) return;
-                        var toggle = header.querySelector('.tree-toggle');
-                        if (children.classList.contains('hidden')) { children.classList.remove('hidden'); toggle.textContent = '\u25BC'; }
-                        else { children.classList.add('hidden'); toggle.textContent = '\u25B6'; }
-                    });
-                }
-                container.appendChild(item);
-            });
-        }
-
-        function insertVariable(varPath) {
-            var input = document.getElementById('edit-label-input');
-            if (input) { input.value = '{{ ' + varPath + ' }}'; input.focus(); }
-        }
-
-        // ================================================================
-        // File processing
-        // ================================================================
-        async function processFile(file) {
-            if (!file) return;
-            state.file = file;
-            savePlaygroundBtn.classList.remove('hidden');
-            updateModalSourceStatus();
-            fileName.textContent = file.name;
-            fileName.classList.remove('hidden');
-            showLoading('Reading document...');
-            try {
-                var arrayBuffer = await file.arrayBuffer();
-                state.fileContent = new Uint8Array(arrayBuffer);
-
-                // Step 1: mammoth HTML preview
-                showLoading('Converting document to HTML...');
-                var result = await mammoth.convertToHtml({ arrayBuffer: arrayBuffer });
-                state.originalHtml = result.value;
-                previewContent.innerHTML = state.originalHtml;
-                previewContent.classList.remove('hidden');
-                previewEmpty.classList.add('hidden');
-
-                // Step 2: extract runs via API (for preview mapping)
-                showLoading('Extracting document structure...');
-                var runsFormData = new FormData();
-                runsFormData.append('file', file);
-                runsFormData.append('defragment_runs', state.settings.defragmentRuns ? 'true' : 'false');
-                try {
-                    var runsResp = await fetch('/al/docx-labeler/api/extract-runs', { method: 'POST', body: runsFormData });
-                    var runsData = await runsResp.json();
-                    if (runsData.success) {
-                        state.runs = runsData.data.runs;
-                    }
-                } catch (runErr) {
-                    console.warn('Could not extract runs for preview mapping:', runErr);
-                }
-
-                state.existingLabels = extractExistingLabelsFromRuns(state.runs);
-                if (state.existingLabels.length === 0) {
-                    state.existingLabels = extractExistingLabels(state.originalHtml);
-                }
-                state.labelRenames = {};
-                state.suggestions = [];
-                state.validation = null;
-                state.syntaxValidation = null;
-                state.syntaxValidationPending = false;
-                renderSyntaxValidation();
-
-                hideLoading();
-                showMainPanel();
-
-                if (state.existingLabels.length > 0) {
-                    switchTab('existing');
-                    renderExistingLabelsTree();
-                    updatePreview();
-                } else {
-                    switchTab('suggestions');
-                    if (state.auth.aiEnabled) {
-                        showLoading('Generating AI suggestions...');
-                        await fetchSuggestions();
-                    } else {
-                        suggestionsList.innerHTML = '<div class="alert alert-warning">AI suggestions are unavailable until you log in.</div>';
-                    }
-                    hideLoading();
-                    showMainPanel();    // <-- was missing; caused the "spin forever" bug
-                }
-            } catch (error) {
-                console.error('Error processing file:', error);
-                showError('Failed to process document: ' + error.message);
-            } finally {
-                hideLoading();
-            }
-        }
-
-        // ================================================================
-        // Tab switching
-        // ================================================================
-        function switchTab(tab) {
-            state.activeTab = tab;
-            tabExisting.classList.toggle('tab-active', tab === 'existing');
-            tabManual.classList.toggle('tab-active', tab === 'manual');
-            tabSuggestions.classList.toggle('tab-active', tab === 'suggestions');
-            existingPanel.classList.toggle('hidden', tab !== 'existing');
-            manualPanel.classList.toggle('hidden', tab !== 'manual');
-            suggestionsPanel.classList.toggle('hidden', tab !== 'suggestions');
-        }
-
-        function renderManualLabels() {
-            var manualLabels = getManualLabelGroups();
-            var hasManualLabels = manualLabels.length > 0;
-            tabManual.classList.toggle('hidden', !hasManualLabels);
-            manualCount.textContent = manualLabels.length;
-
-            if (!hasManualLabels) {
-                manualLabelsList.innerHTML = '<div class="text-center py-5 text-muted"><p>No manual labels yet.</p><p class="small mt-1">Select text in the preview to add one.</p></div>';
-                if (state.activeTab === 'manual') {
-                    switchTab(state.existingLabels.length > 0 ? 'existing' : 'suggestions');
-                }
-                return;
-            }
-
-            manualLabelsList.innerHTML = '';
-            manualLabels.forEach(function(label) {
-                var div = document.createElement('div');
-                div.className = 'p-3 rounded border border-2 mb-2 suggestion-accepted';
-                div.innerHTML =
-                    '<div class="d-flex align-items-start justify-content-between gap-2 mb-2">' +
-                        '<span class="small text-muted">Selection</span>' +
-                        '<button class="manual-remove-btn btn btn-sm btn-outline-danger" data-group="' + escapeHtml(label.group) + '" title="Remove">\u2716</button>' +
-                    '</div>' +
-                    '<div class="small text-muted mb-2">\u201C' + escapeHtml(label._selectedText || '') + '\u201D</div>' +
-                    '<label class="form-label small fw-medium mb-1">Label</label>' +
-                    '<input type="text" class="manual-edit-input form-control form-control-sm font-monospace mb-2" value="' + escapeHtml(label._displayLabel || label.text || '') + '" data-group="' + escapeHtml(label.group) + '">' +
-                    '<div class="small text-muted">Para ' + escapeHtml(String(label.paragraph)) + ', Run ' + escapeHtml(String(label.run)) + '</div>';
-                manualLabelsList.appendChild(div);
-            });
-
-            manualLabelsList.querySelectorAll('.manual-edit-input').forEach(function(input) {
-                input.addEventListener('input', function() {
-                    var value = input.value.trim();
-                    if (!value) return;
-                    applyManualLabelText(input.dataset.group, value);
-                    updatePreview();
-                    scheduleSyntaxValidation(500);
-                });
-            });
-
-            manualLabelsList.querySelectorAll('.manual-remove-btn').forEach(function(button) {
-                button.addEventListener('click', function() {
-                    var groupId = button.dataset.group;
-                    state.suggestions = state.suggestions.filter(function(suggestion) {
-                        return suggestion.group !== groupId;
-                    });
-                    renderSuggestions();
-                    updatePreview();
-                    updateDownloadButton();
-                    scheduleSyntaxValidation();
-                });
-            });
-        }
-
-        // ================================================================
-        // Edit label modal
-        // ================================================================
-        function openEditLabelModal(label) {
-            state.editingLabelId = label.id;
-            document.getElementById('edit-label-original').textContent = label.original;
-            document.getElementById('edit-label-input').value = label.current;
-            document.getElementById('variable-search').value = '';
-            renderVariableTree(getEffectiveVariableTree());
-            // Show occurrence position in title when multiple exist
-            var allSameOriginal = state.existingLabels.filter(function(l) { return l.original === label.original; });
-            var occurrenceIndex = allSameOriginal.indexOf(label) + 1;
-            var totalCount = allSameOriginal.length;
-            document.getElementById('edit-label-title').textContent = totalCount > 1
-                ? 'Edit Label (occurrence ' + occurrenceIndex + ' of ' + totalCount + ')'
-                : 'Edit Label';
-            if (!document.getElementById('edit-catchall-btn')) {
-                var footer = editLabelModal.querySelector('.dl-modal-footer');
-                if (footer) {
-                    var catchallBtn = document.createElement('button');
-                    catchallBtn.id = 'edit-catchall-btn';
-                    catchallBtn.type = 'button';
-                    catchallBtn.className = 'btn btn-outline-primary me-auto';
-                    catchallBtn.textContent = 'Catchall / Request Filters';
-                    catchallBtn.addEventListener('click', function() {
-                        openCatchallDialog(document.getElementById('edit-label-input'));
-                    });
-                    footer.insertBefore(catchallBtn, footer.firstChild);
-                }
-            }
-            // Add/update "Replace all" button depending on occurrence count
-            var replaceAllBtn = document.getElementById('edit-replace-all-btn');
-            if (totalCount > 1) {
-                if (!replaceAllBtn) {
-                    replaceAllBtn = document.createElement('button');
-                    replaceAllBtn.id = 'edit-replace-all-btn';
-                    replaceAllBtn.type = 'button';
-                    replaceAllBtn.className = 'btn btn-outline-secondary';
-                    replaceAllBtn.addEventListener('click', function() { saveEditLabel(true); });
-                    var saveBtn = document.getElementById('edit-save');
-                    var modalFooter = editLabelModal.querySelector('.dl-modal-footer');
-                    if (saveBtn && modalFooter) modalFooter.insertBefore(replaceAllBtn, saveBtn);
-                    else if (modalFooter) modalFooter.appendChild(replaceAllBtn);
-                }
-                replaceAllBtn.textContent = 'Save for all ' + totalCount + ' occurrences';
-            } else if (replaceAllBtn) {
-                replaceAllBtn.remove();
-            }
-            editLabelModal.classList.remove('hidden');
-            document.getElementById('edit-label-input').focus();
-        }
-
-        function saveEditLabel(replaceAll) {
-            var input = document.getElementById('edit-label-input').value.trim();
-            if (!input || !state.editingLabelId) return;
-            var replaceAllMode = replaceAll === true;
-            var label = state.existingLabels.find(function(l) { return l.id === state.editingLabelId; });
-            if (label) {
-                if (replaceAllMode) {
-                    var orig = label.original;
-                    state.existingLabels.forEach(function(l) {
-                        if (l.original === orig) l.current = input;
-                    });
-                } else {
-                    label.current = input;
-                }
-            }
-            editLabelModal.classList.add('hidden');
-            state.editingLabelId = null;
-            renderExistingLabelsTree();
-            updatePreview();
-            scheduleSyntaxValidation();
-        }
-
-        function quoteFilterArg(value) {
-            return '"' + String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
-        }
-
-        function expressionInsideBraces(rawValue) {
-            var text = String(rawValue || '').trim();
-            if (text.startsWith('{{') && text.endsWith('}}')) {
-                return text.replace(/^\{\{\s*/, '').replace(/\s*\}\}$/, '').trim();
-            }
-            return text;
-        }
-
-        function splitExpressionFilters(expression) {
-            var parts = String(expression || '')
-                .split('|')
-                .map(function(part) { return part.trim(); })
-                .filter(Boolean);
-            return {
-                base: parts.shift() || '',
-                filters: parts
-            };
-        }
-
-        function normalizeFilterSnippet(snippet) {
-            var text = String(snippet || '').trim();
-            if (!text) return '';
-            if (text.startsWith('|')) text = text.slice(1).trim();
-            return text;
-        }
-
-        function parseFilterChain(rawChain) {
-            return String(rawChain || '')
-                .split(/[\n|]/)
-                .map(function(part) { return normalizeFilterSnippet(part); })
-                .filter(Boolean);
-        }
-
-        function parseQuotedFilterValue(rawValue) {
-            var text = String(rawValue || '').trim();
-            if (!text) return '';
-            if ((text.startsWith('"') && text.endsWith('"')) || (text.startsWith("'") && text.endsWith("'"))) {
-                text = text.slice(1, -1);
-            }
-            return text.replace(/\\"/g, '"').replace(/\\'/g, "'").replace(/\\\\/g, '\\');
-        }
-
-        function parseCatchallInvocation(filterText) {
-            var match = String(filterText || '').trim().match(/^catchall_(complete|question|subquestion|label|datatype|options)\s*\((.*)\)$/i);
-            if (!match) return null;
-
-            var kind = match[1].toLowerCase();
-            var argsText = match[2].trim();
-            var result = {};
-
-            if (kind === 'complete') {
-                var argPattern = /(question|subquestion|label|datatype|options)\s*=\s*((?:\[[\s\S]*?\])|(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'))/gi;
-                var argMatch;
-                while ((argMatch = argPattern.exec(argsText))) {
-                    var argName = argMatch[1].toLowerCase();
-                    var argValue = argMatch[2].trim();
-                    if (argName === 'options') {
-                        var optionText = argValue;
-                        if (optionText.startsWith('[') && optionText.endsWith(']')) {
-                            optionText = optionText.slice(1, -1);
-                        }
-                        result.options = optionText
-                            .split(',')
-                            .map(function(item) { return parseQuotedFilterValue(item.trim()); })
-                            .filter(Boolean)
-                            .join(', ');
-                    } else {
-                        result[argName] = parseQuotedFilterValue(argValue);
-                    }
-                }
-                return result;
-            }
-
-            result[kind] = parseQuotedFilterValue(argsText);
-            return result;
-        }
-
-        function getCatchallEditorState(rawExpression) {
-            var parts = splitExpressionFilters(rawExpression);
-            var base = parts.base;
-            var catchall = {
-                question: '',
-                subquestion: '',
-                label: '',
-                datatype: '',
-                options: ''
-            };
-            var extraFilters = [];
-
-            parts.filters.forEach(function(filterText) {
-                var normalized = normalizeFilterSnippet(filterText);
-                if (!normalized) return;
-                if (normalized.toLowerCase().startsWith('catchall_')) {
-                    var parsed = parseCatchallInvocation(normalized);
-                    if (parsed) {
-                        Object.keys(parsed).forEach(function(key) {
-                            if (Object.prototype.hasOwnProperty.call(catchall, key) && parsed[key]) {
-                                catchall[key] = parsed[key];
-                            }
-                        });
-                    }
-                    return;
-                }
-                extraFilters.push(normalized);
-            });
-
-            return {
-                base: base,
-                catchall: catchall,
-                extraFilters: extraFilters
-            };
-        }
-
-        const COMMON_FILTER_SNIPPETS = [
-            { label: 'Docassemble: currency', value: 'currency' },
-            { label: 'Docassemble: comma_and_list', value: 'comma_and_list' },
-            { label: 'Docassemble: comma_list', value: 'comma_list' },
-            { label: 'Docassemble: add_separators', value: 'add_separators' },
-            { label: 'Docassemble: phone_number_formatted', value: 'phone_number_formatted' },
-            { label: 'Docassemble: phone_number_in_e164', value: 'phone_number_in_e164' },
-            { label: 'Docassemble: manual_line_breaks', value: 'manual_line_breaks' },
-            { label: 'Docassemble: inline_markdown', value: 'inline_markdown' },
-            { label: 'Docassemble: markdown', value: 'markdown' },
-            { label: 'Docassemble: paragraphs', value: 'paragraphs' },
-            { label: 'Docassemble: fix_punctuation', value: 'fix_punctuation' },
-            { label: 'Docassemble: nice_number', value: 'nice_number' },
-            { label: 'Docassemble: ordinal', value: 'ordinal' },
-            { label: 'Docassemble: ordinal_number', value: 'ordinal_number' },
-            { label: 'Docassemble: title_case', value: 'title_case' },
-            { label: 'Docassemble: verbatim', value: 'verbatim' },
-            { label: 'Docassemble: country_name', value: 'country_name' },
-            { label: 'Docassemble: redact', value: 'redact' },
-            { label: 'Jinja2: default("")', value: 'default("")' },
-            { label: 'Jinja2: length', value: 'length' },
-            { label: 'Jinja2: lower', value: 'lower' },
-            { label: 'Jinja2: upper', value: 'upper' },
-            { label: 'Jinja2: capitalize', value: 'capitalize' },
-            { label: 'Jinja2: title', value: 'title' },
-            { label: 'Jinja2: trim', value: 'trim' },
-            { label: 'Jinja2: replace("", "")', value: 'replace("", "")' },
-            { label: 'Jinja2: join(", ")', value: 'join(", ")' },
-            { label: 'Jinja2: round', value: 'round' },
-            { label: 'Jinja2: int', value: 'int' },
-            { label: 'Jinja2: float', value: 'float' },
-            { label: 'Jinja2: list', value: 'list' },
-            { label: 'Jinja2: safe', value: 'safe' },
-            { label: 'Jinja2: escape', value: 'escape' },
-            { label: 'Jinja2: urlize', value: 'urlize' },
-            { label: 'Jinja2: selectattr("attr")', value: 'selectattr("attr")' },
-            { label: 'Jinja2: rejectattr("attr")', value: 'rejectattr("attr")' },
-            { label: 'Jinja2: map(attribute="attr")', value: 'map(attribute="attr")' },
-            { label: 'Jinja2: sort(attribute="attr")', value: 'sort(attribute="attr")' },
-            { label: 'Jinja2: sum(attribute="attr")', value: 'sum(attribute="attr")' }
-        ];
-
-        function insertFilterSnippet(target, snippet) {
-            if (!target) return;
-            var text = normalizeFilterSnippet(snippet);
-            if (!text) return;
-            var prefix = target.value && target.value.trim() ? ' | ' : '| ';
-            var insertText = prefix + text;
-            if (typeof target.selectionStart === 'number' && typeof target.selectionEnd === 'number') {
-                var start = target.selectionStart;
-                var end = target.selectionEnd;
-                var current = target.value || '';
-                var before = current.slice(0, start);
-                var after = current.slice(end);
-                target.value = before + insertText + after;
-                var caret = before.length + insertText.length;
-                target.selectionStart = caret;
-                target.selectionEnd = caret;
-            } else {
-                target.value = (target.value || '').trim();
-                target.value += insertText;
-            }
-            target.dispatchEvent(new Event('input', { bubbles: true }));
-        }
-
-        function buildCatchallExpression(baseExpression, config) {
-            var expression = String(baseExpression || '').trim();
-            if (!expression) return '';
-            var filters = [];
-            var catchallArgs = [];
-            if (config.question) catchallArgs.push('question=' + quoteFilterArg(config.question));
-            if (config.subquestion) catchallArgs.push('subquestion=' + quoteFilterArg(config.subquestion));
-            if (config.label) catchallArgs.push('label=' + quoteFilterArg(config.label));
-            if (config.datatype) catchallArgs.push('datatype=' + quoteFilterArg(config.datatype));
-            if (config.options) {
-                var list = config.options
-                    .split('\n')
-                    .join(',')
-                    .split(',')
-                    .map(function(item) { return item.trim(); })
-                    .filter(Boolean)
-                    .map(function(item) { return quoteFilterArg(item); });
-                if (list.length) catchallArgs.push('options=[' + list.join(', ') + ']');
-            }
-            if (catchallArgs.length) {
-                filters.push('catchall_complete(' + catchallArgs.join(', ') + ')');
-            }
-            parseFilterChain(config.additionalFilters).forEach(function(filterText) {
-                if (filterText) filters.push(filterText);
-            });
-            if (filters.length) {
-                expression += ' | ' + filters.join(' | ');
-            }
-            return '{{ ' + expression + ' }}';
-        }
-
-        function ensureCatchallDialog() {
-            var existing = document.getElementById('catchall-filter-modal');
-            if (existing) return existing;
-            var modal = document.createElement('div');
-            modal.id = 'catchall-filter-modal';
-            modal.className = 'hidden dl-modal-overlay';
-            modal.innerHTML =
-                '<div class="dl-modal dl-modal-md">' +
-                    '<div class="dl-modal-header">' +
-                        '<h2 class="h5 fw-semibold mb-0">Catchall / Request Filters</h2>' +
-                        '<button type="button" id="catchall-close" class="btn btn-sm btn-light rounded">Close</button>' +
-                    '</div>' +
-                    '<div class="dl-modal-body">' +
-                        '<div class="mb-2"><label class="form-label small mb-1" for="catchall-question">Question</label><input id="catchall-question" class="form-control form-control-sm" type="text"></div>' +
-                        '<div class="mb-2"><label class="form-label small mb-1" for="catchall-subquestion">Subquestion</label><textarea id="catchall-subquestion" class="form-control form-control-sm" rows="2"></textarea></div>' +
-                        '<div class="mb-2"><label class="form-label small mb-1" for="catchall-label">Label</label><input id="catchall-label" class="form-control form-control-sm" type="text"></div>' +
-                        '<div class="mb-2"><label class="form-label small mb-1" for="catchall-datatype">Datatype</label><select id="catchall-datatype" class="form-select form-select-sm"><option value="">(none)</option><option value="text">text</option><option value="area">area</option><option value="yesno">yesno</option><option value="radio">radio</option><option value="checkboxes">checkboxes</option><option value="date">date</option><option value="email">email</option><option value="currency">currency</option><option value="integer">integer</option><option value="number">number</option></select></div>' +
-                        '<div><label class="form-label small mb-1" for="catchall-options">Options (comma or one per line)</label><textarea id="catchall-options" class="form-control form-control-sm" rows="2"></textarea></div>' +
-                        '<div class="mt-3 pt-2 border-top"><label class="form-label small mb-1" for="catchall-extra-filters">Additional filters</label><textarea id="catchall-extra-filters" class="form-control form-control-sm font-monospace" rows="4" placeholder="| default(\"\") | title"></textarea><div class="d-flex gap-2 mt-2"><select id="catchall-filter-pick" class="form-select form-select-sm flex-grow-1"><option value="">Common filters</option></select><button type="button" id="catchall-filter-add" class="btn btn-sm btn-outline-secondary">Add</button></div><div class="form-text mt-1">Add filters in order. Example: <span class="font-monospace">| default(\"\") | upper</span></div></div>' +
-                    '</div>' +
-                    '<div class="dl-modal-footer d-flex justify-content-end gap-2">' +
-                        '<button type="button" id="catchall-cancel" class="btn btn-outline-secondary">Cancel</button>' +
-                        '<button type="button" id="catchall-apply" class="btn btn-primary">Apply Catchall</button>' +
-                    '</div>' +
-                '</div>';
-            document.body.appendChild(modal);
-            modal.addEventListener('click', function(evt) {
-                if (evt.target === modal) modal.classList.add('hidden');
-            });
-            document.getElementById('catchall-close').addEventListener('click', function() {
-                modal.classList.add('hidden');
-            });
-            document.getElementById('catchall-cancel').addEventListener('click', function() {
-                modal.classList.add('hidden');
-            });
-            return modal;
-        }
-
-        function openCatchallDialog(targetInput) {
-            var input = targetInput;
-            if (!input) return;
-            var raw = String(input.value || '').trim();
-            var innerExpression = expressionInsideBraces(raw);
-            if (!innerExpression || raw.startsWith('{%')) {
-                showError('Catchall filters apply to variable expressions like {{ variable_name }}.');
-                return;
-            }
-            var parsed = getCatchallEditorState(innerExpression);
-            var modal = ensureCatchallDialog();
-            modal.classList.remove('hidden');
-            document.getElementById('catchall-question').value = parsed.catchall.question || '';
-            document.getElementById('catchall-subquestion').value = parsed.catchall.subquestion || '';
-            document.getElementById('catchall-label').value = parsed.catchall.label || '';
-            document.getElementById('catchall-datatype').value = parsed.catchall.datatype || '';
-            document.getElementById('catchall-options').value = parsed.catchall.options || '';
-            document.getElementById('catchall-extra-filters').value = parsed.extraFilters.join(' | ');
-            var pick = document.getElementById('catchall-filter-pick');
-            if (pick) {
-                pick.innerHTML = '<option value="">Common filters</option>';
-                COMMON_FILTER_SNIPPETS.forEach(function(item) {
-                    var option = document.createElement('option');
-                    option.value = item.value;
-                    option.textContent = item.label;
-                    pick.appendChild(option);
-                });
-                pick.value = '';
-            }
-            var addBtn = document.getElementById('catchall-filter-add');
-            if (addBtn && pick) {
-                addBtn.onclick = function() {
-                    insertFilterSnippet(document.getElementById('catchall-extra-filters'), pick.value);
-                    pick.value = '';
-                };
-            }
-            document.getElementById('catchall-apply').onclick = function() {
-                var updated = buildCatchallExpression(parsed.base, {
-                    question: document.getElementById('catchall-question').value.trim(),
-                    subquestion: document.getElementById('catchall-subquestion').value.trim(),
-                    label: document.getElementById('catchall-label').value.trim(),
-                    datatype: document.getElementById('catchall-datatype').value.trim(),
-                    options: document.getElementById('catchall-options').value.trim(),
-                    additionalFilters: document.getElementById('catchall-extra-filters').value.trim(),
-                });
-                if (!updated) return;
-                input.value = updated;
-                input.dispatchEvent(new Event('input', { bubbles: true }));
-                modal.classList.add('hidden');
-                input.focus();
-            };
-        }
-
-        // ================================================================
-        // Bulk find & replace
-        // ================================================================
-        function previewBulkReplace() {
-            var find = document.getElementById('bulk-find').value;
-            var replace = document.getElementById('bulk-replace').value;
-            if (!find) { document.getElementById('bulk-preview').classList.add('hidden'); return; }
-            try {
-                var regex = new RegExp(find, 'g');
-                var previewList = document.getElementById('bulk-preview-list');
-                previewList.innerHTML = '';
-                var matchCount = 0;
-                state.existingLabels.forEach(function(label) {
-                    var inner = label.current.replace(/^\{\{\s*|\s*\}\}$/g, '');
-                    if (regex.test(inner)) {
-                        regex.lastIndex = 0;
-                        var newInner = inner.replace(regex, replace);
-                        var newLabel = '{{ ' + newInner + ' }}';
-                        var div = document.createElement('div');
-                        div.className = 'font-monospace';
-                        div.innerHTML = '<span class="text-danger text-decoration-line-through">' + escapeHtml(label.current) + '</span><span class="text-muted mx-1">\u2192</span><span class="text-success">' + escapeHtml(newLabel) + '</span>';
-                        previewList.appendChild(div);
-                        matchCount++;
-                    }
-                });
-                if (matchCount > 0) { document.getElementById('bulk-preview').classList.remove('hidden'); }
-                else { previewList.innerHTML = '<span class="text-muted">No matches found</span>'; document.getElementById('bulk-preview').classList.remove('hidden'); }
-            } catch (e) {
-                document.getElementById('bulk-preview-list').innerHTML = '<span class="text-danger">Invalid regex: ' + e.message + '</span>';
-                document.getElementById('bulk-preview').classList.remove('hidden');
-            }
-        }
-
-        function applyBulkReplace() {
-            var find = document.getElementById('bulk-find').value;
-            var replace = document.getElementById('bulk-replace').value;
-            if (!find) return;
-            try {
-                var regex = new RegExp(find, 'g');
-                state.existingLabels.forEach(function(label) {
-                    var inner = label.current.replace(/^\{\{\s*|\s*\}\}$/g, '');
-                    if (regex.test(inner)) {
-                        regex.lastIndex = 0;
-                        var newInner = inner.replace(regex, replace);
-                        label.current = '{{ ' + newInner + ' }}';
-                    }
-                });
-                bulkReplaceModal.classList.add('hidden');
-                renderExistingLabelsTree();
-                updatePreview();
-                scheduleSyntaxValidation();
-            } catch (e) { alert('Invalid regex: ' + e.message); }
-        }
-
-        // ================================================================
-        // AI suggestions
-        // ================================================================
-        async function fetchSuggestions() {
-            if (!state.auth.aiEnabled) {
-                suggestionsList.innerHTML = '<div class="alert alert-warning">AI suggestions require login.</div>';
-                return;
-            }
-            var selectedSourceState = getActiveInterviewSourceState();
-            if (state.settings.usePlaygroundVariables && !selectedSourceState.selectedFile) {
-                suggestionsList.innerHTML = '<div class="alert alert-warning">Select an interview before using interview variable names.</div>';
-                return;
-            }
-            var formData = new FormData();
-            formData.append('file', state.file);
-            formData.append('defragment_runs', state.settings.defragmentRuns ? 'true' : 'false');
-            if (state.settings.additionalInstructions) formData.append('additional_instructions', state.settings.additionalInstructions);
-            if (state.settings.contextText) formData.append('context_text', state.settings.contextText);
-            if (state.settings.customPeople) formData.append('custom_people_names', state.settings.customPeople);
-            if (state.settings.primaryPersonVariable) formData.append('primary_person_variable', state.settings.primaryPersonVariable);
-            formData.append('prompt_profile', state.settings.promptProfile || 'standard');
-            formData.append('model', state.settings.model);
-            if (state.settings.judgeModel) formData.append('judge_model', state.settings.judgeModel);
-            if (state.settings.usePlaygroundVariables) {
-                if (!selectedSourceState.variables.length) {
-                    suggestionsList.innerHTML = '<div class="alert alert-warning">No interview variables were found for the selected interview.</div>';
-                    return;
-                }
-                formData.append('use_playground_variables', 'true');
-                formData.append('interview_source_mode', state.interviewSourceMode);
-                formData.append('preferred_variable_names', JSON.stringify(selectedSourceState.variables));
-                if (state.interviewSourceMode === 'installed') {
-                    formData.append('installed_package', state.installed.selectedPackage);
-                    formData.append('installed_yaml_file', state.installed.selectedFile);
-                    formData.append('installed_interview_path', state.installed.selectedPackage + ':' + state.installed.selectedFile);
-                } else {
-                    formData.append('playground_project', state.playground.selectedProject);
-                    formData.append('playground_yaml_file', state.playground.selectedFile);
-                }
-            }
-            if (state.settings.generationMethod === 'single') {
-                formData.append('generator_models', JSON.stringify([state.settings.model]));
-            } else if (state.settings.generationMethod === 'multi_model') {
-                var generatorModels = parseGeneratorModelsInput(state.settings.generatorModels);
-                if (generatorModels.length === 0) generatorModels = [state.settings.model];
-                formData.append('generator_models', JSON.stringify(generatorModels));
-            }
-            try {
-                var manualSuggestions = state.suggestions.filter(function(suggestion) {
-                    return isManualSuggestion(suggestion);
-                });
-                var data = await requestAsyncLabelerAction(
-                    '/al/docx-labeler/api/suggest-labels',
-                    formData,
-                    'AI labeling is running in the background...'
-                );
-                state.suggestions = manualSuggestions.concat((data.suggestions || []).map(function(s) {
-                    return Object.assign({}, s, { id: s.id || generateId(), status: 'pending' });
-                }));
-                state.validation = data.validation || null;
-                suggestionsCount.textContent = state.suggestions.length;
-                renderSuggestions();
-            } catch (error) {
-                console.error('Error fetching suggestions:', error);
-                state.validation = null;
-                suggestionsList.innerHTML = '<div class="alert alert-danger">' + escapeHtml(error.message) + '</div>';
-            }
-        }
-
-        function renderSuggestions() {
-            suggestionsList.innerHTML = '';
-            renderManualLabels();
-            var deterministic = state.validation && state.validation.deterministic ? state.validation.deterministic : null;
-            var syntaxValidation = deterministic && deterministic.syntax_validation ? deterministic.syntax_validation : null;
-            var documentWarnings = state.validation && Array.isArray(state.validation.document_warnings) ? state.validation.document_warnings : [];
-            var aggregation = state.validation && state.validation.aggregation ? state.validation.aggregation : null;
-            var timings = state.validation && state.validation.timings ? state.validation.timings : null;
-            var aiSuggestions = state.suggestions.filter(function(suggestion) { return !isManualSuggestion(suggestion); });
-            if ((deterministic && deterministic.flagged_count > 0) || documentWarnings.length > 0 || aggregation || (syntaxValidation && ((syntaxValidation.error_count || 0) > 0 || (syntaxValidation.warning_count || 0) > 0))) {
-                var aiReview = state.validation && state.validation.ai_review ? state.validation.ai_review : {};
-                var reviewedCount = Array.isArray(aiReview.reviews) ? aiReview.reviews.length : 0;
-                suggestionsValidation.classList.remove('hidden');
-                var summaryHtml = '';
-                if (aggregation) {
-                    var confidenceCounts = aggregation.confidence_counts || {};
-                    summaryHtml +=
-                        '<div><strong>Aggregated ' + aiSuggestions.length + '</strong> ranked suggestion' + (aiSuggestions.length === 1 ? '' : 's') +
-                        ' from ' + escapeHtml(String(aggregation.generator_runs || 0)) + ' generation run' + ((aggregation.generator_runs || 0) === 1 ? '' : 's') + '.</div>' +
-                        '<div class="mt-1">Confidence tiers: ' +
-                        '<span class="badge bg-success-subtle text-success-emphasis border border-success-subtle me-1">High ' + escapeHtml(String(confidenceCounts.high || 0)) + '</span>' +
-                        '<span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle me-1">Medium ' + escapeHtml(String(confidenceCounts.medium || 0)) + '</span>' +
-                        '<span class="badge bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle">Low ' + escapeHtml(String(confidenceCounts.low || 0)) + '</span>' +
-                        '</div>';
-                    if (aggregation.ambiguous_group_count) {
-                        summaryHtml += '<div class="mt-1">Judge reviewed ' + escapeHtml(String(reviewedCount)) + ' ambiguous group' + (reviewedCount === 1 ? '' : 's') + '.</div>';
-                    }
-                }
-                if (deterministic && deterministic.flagged_count > 0) {
-                    summaryHtml +=
-                        '<div class="mt-1"><strong>Validator flagged ' + deterministic.flagged_count + '</strong> selected suggestion' + (deterministic.flagged_count === 1 ? '' : 's') + '.</div>';
-                }
-                if (syntaxValidation && (syntaxValidation.error_count || 0) > 0) {
-                    summaryHtml += '<div class="mt-1"><strong>Final template syntax errors:</strong></div>';
-                    syntaxValidation.errors.forEach(function(issue) {
-                        summaryHtml += '<div>' + escapeHtml(issue.message || issue.code || 'Syntax error') + '</div>';
-                    });
-                } else if (syntaxValidation && (syntaxValidation.warning_count || 0) > 0) {
-                    summaryHtml += '<div class="mt-1"><strong>Final template warnings:</strong></div>';
-                    syntaxValidation.warnings.forEach(function(issue) {
-                        summaryHtml += '<div>' + escapeHtml(issue.message || issue.code || 'Warning') + '</div>';
-                    });
-                }
-                if (documentWarnings.length > 0) {
-                    summaryHtml += '<div class="mt-1"><strong>Source document warnings:</strong></div>';
-                    documentWarnings.forEach(function(warning) {
-                        summaryHtml += '<div>' + escapeHtml(warning.message || warning.code || 'Document warning') + '</div>';
-                    });
-                }                
-                suggestionsValidation.innerHTML = summaryHtml;
-            } else {
-                suggestionsValidation.classList.add('hidden');
-                suggestionsValidation.textContent = '';
-            }
-            var hiddenLowConfidenceCount = 0;
-            // Count only visible (non-companion) suggestions
-            var visibleCount = aiSuggestions.filter(function(s) {
-                if (s._isCompanion) return false;
-                if (!state.settings.showLowConfidence && (s.confidence || 'low') === 'low') {
-                    hiddenLowConfidenceCount += 1;
-                    return false;
-                }
-                return true;
-            }).length;
-            suggestionsCount.textContent = visibleCount;
-            lowConfidenceSummary.textContent = hiddenLowConfidenceCount > 0
-                ? hiddenLowConfidenceCount + ' low confidence suggestion' + (hiddenLowConfidenceCount === 1 ? '' : 's') + ' hidden'
-                : '';
-            if (visibleCount === 0) {
-                suggestionsList.innerHTML = hiddenLowConfidenceCount > 0
-                    ? '<p class="text-muted text-center py-5">Only low confidence suggestions are available. Turn on “Show low confidence” to review them.</p>'
-                    : '<p class="text-muted text-center py-5">No suggestions available.</p>';
-                return;
-            }
-            state.suggestions.forEach(function(suggestion, index) {
-                // Skip companion entries – they’re part of a multi-run group
-                if (suggestion._isCompanion) return;
-                if (isManualSuggestion(suggestion)) return;
-                if (!state.settings.showLowConfidence && (suggestion.confidence || 'low') === 'low') return;
-
-                var div = document.createElement('div');
-                var stateClass = suggestion.status === 'accepted' ? 'suggestion-accepted' : suggestion.status === 'rejected' ? 'suggestion-rejected' : 'suggestion-pending';
-                div.className = 'p-3 rounded border border-2 mb-2 ' + stateClass;
-
-                var locationLabel = suggestion.group
-                    ? '<span class="small text-muted">Selection \u2192 ' + escapeHtml(suggestion._displayLabel || suggestion.text) + '</span>'
-                    : '<span class="small text-muted">Para ' + suggestion.paragraph + ', Run ' + suggestion.run + '</span>';
-                var validationFlags = Array.isArray(suggestion.validation_flags) ? suggestion.validation_flags : [];
-                var judgeReview = suggestion.judge_review || null;
-                var confidenceMeta = getConfidenceMeta(suggestion.confidence || 'low');
-                var supportHtml = '';
-                if (!suggestion.group && suggestion.vote_total) {
-                    supportHtml =
-                        '<span class="badge ' + confidenceMeta.badge + '">' + escapeHtml(confidenceMeta.label) + '</span>' +
-                        '<span class="badge text-bg-light border ms-1">' + escapeHtml(String(suggestion.clean_vote_count || 0)) + '/' + escapeHtml(String(suggestion.vote_total || 0)) + ' clean votes</span>';
-                    var sourceSummary = summarizeSuggestionSources(suggestion);
-                    if (sourceSummary) {
-                        supportHtml += '<div class="small text-muted mt-1">Sources: ' + escapeHtml(sourceSummary) + '</div>';
-                    }
-                }
-                var reviewHtml = '';
-                if (validationFlags.length > 0) {
-                    reviewHtml += '<div class="alert alert-warning small mt-2 mb-2 py-2">';
-                    reviewHtml += '<div class="fw-semibold mb-1">Validator flags</div>';
-                    validationFlags.forEach(function(flag) {
-                        reviewHtml += '<div>' + escapeHtml(flag.message || flag.code || 'Flagged') + '</div>';
-                    });
-                    if (judgeReview && judgeReview.reason) {
-                        reviewHtml += '<div class="mt-2"><span class="fw-semibold">Judge:</span> ' + escapeHtml(judgeReview.reason) + '</div>';
-                    }
-                    reviewHtml += '</div>';
-                } else if (judgeReview && judgeReview.reason) {
-                    reviewHtml += '<div class="small text-muted mt-2">Judge note: ' + escapeHtml(judgeReview.reason) + '</div>';
-                }
-
-                var alternates = Array.isArray(suggestion.alternates) ? suggestion.alternates : [];
-                var alternatesHtml = '';
-                if (!suggestion.group && alternates.length > 0) {
-                    alternatesHtml += '<details class="mt-2"><summary class="small fw-semibold">Alternates (' + alternates.length + ')</summary>';
-                    alternates.forEach(function(alternate, altIndex) {
-                        var alternateMeta = getConfidenceMeta(alternate.confidence || 'low');
-                        var alternateFlags = Array.isArray(alternate.validation_flags) ? alternate.validation_flags : [];
-                        alternatesHtml +=
-                            '<div class="border rounded p-2 mt-2 bg-light-subtle">' +
-                                '<div class="d-flex justify-content-between align-items-start gap-2">' +
-                                    '<div class="font-monospace small break-all flex-grow-1">' + escapeHtml(alternate.text || '') + '</div>' +
-                                    '<button type="button" class="btn btn-sm btn-outline-primary use-alternate-btn" data-index="' + index + '" data-alt-index="' + altIndex + '">Use</button>' +
-                                '</div>' +
-                                '<div class="mt-2">' +
-                                    '<span class="badge ' + alternateMeta.badge + '">' + escapeHtml(alternateMeta.label) + '</span>' +
-                                    '<span class="badge text-bg-light border ms-1">' + escapeHtml(String(alternate.clean_vote_count || 0)) + '/' + escapeHtml(String(alternate.vote_total || suggestion.vote_total || 0)) + ' clean votes</span>' +
-                                '</div>';
-                        if (alternateFlags.length > 0) {
-                            alternatesHtml += '<div class="small text-warning-emphasis mt-1">';
-                            alternateFlags.forEach(function(flag) {
-                                alternatesHtml += '<div>' + escapeHtml(flag.message || flag.code || 'Flagged') + '</div>';
-                            });
-                            alternatesHtml += '</div>';
-                        }
-                        alternatesHtml += '</div>';
-                    });
-                    alternatesHtml += '</details>';
-                }
-
-                div.innerHTML =
-                    '<div class="d-flex align-items-start justify-content-between gap-2 mb-2">' +
-                        locationLabel +
-                        '<div class="d-flex gap-1">' +
-                            '<button class="accept-btn btn btn-sm ' + (suggestion.status === 'accepted' ? 'btn-success' : 'btn-outline-secondary') + '" data-index="' + index + '">\u2713</button>' +
-                            '<button class="reject-btn btn btn-sm ' + (suggestion.status === 'rejected' ? 'btn-danger' : 'btn-outline-secondary') + '" data-index="' + index + '">\u2717</button>' +
-                            (suggestion.group ? '<button class="remove-btn btn btn-sm btn-outline-danger" data-index="' + index + '" title="Remove">\u2716</button>' : '') +
-                        '</div>' +
-                    '</div>' +
-                    (suggestion._selectedText ? '<div class="small text-muted mb-1">\u201C' + escapeHtml(suggestion._selectedText) + '\u201D</div>' : '') +
-                    (supportHtml ? '<div class="mb-2">' + supportHtml + '</div>' : '') +
-                    '<div class="font-monospace small break-all">' + escapeHtml(suggestion._displayLabel || suggestion.text) + '</div>' +
-                    reviewHtml +
-                    alternatesHtml +
-                    (suggestion.group ? '' : '<input type="text" class="edit-input form-control form-control-sm font-monospace mt-2' + (suggestion.status === 'rejected' ? ' hidden' : '') + '" value="' + escapeHtml(suggestion.text) + '" data-index="' + index + '">');
-                suggestionsList.appendChild(div);
-            });
-            suggestionsList.querySelectorAll('.accept-btn').forEach(function(btn) {
-                btn.addEventListener('click', function() {
-                    var index = parseInt(btn.dataset.index);
-                    var s = state.suggestions[index];
-                    var newStatus = s.status === 'accepted' ? 'pending' : 'accepted';
-                    s.status = newStatus;
-                    // Propagate to companions in same group
-                    if (s.group) {
-                        state.suggestions.forEach(function(c) {
-                            if (c.group === s.group) c.status = newStatus;
-                        });
-                    }
-                    renderSuggestions();
-                    updatePreview();
-                    updateDownloadButton();
-                    scheduleSyntaxValidation();
-                });
-            });
-            suggestionsList.querySelectorAll('.reject-btn').forEach(function(btn) {
-                btn.addEventListener('click', function() {
-                    var index = parseInt(btn.dataset.index);
-                    var s = state.suggestions[index];
-                    var newStatus = s.status === 'rejected' ? 'pending' : 'rejected';
-                    s.status = newStatus;
-                    if (s.group) {
-                        state.suggestions.forEach(function(c) {
-                            if (c.group === s.group) c.status = newStatus;
-                        });
-                    }
-                    renderSuggestions();
-                    updatePreview();
-                    updateDownloadButton();
-                    scheduleSyntaxValidation();
-                });
-            });
-            // Remove button deletes grouped selection labels entirely
-            suggestionsList.querySelectorAll('.remove-btn').forEach(function(btn) {
-                btn.addEventListener('click', function() {
-                    var index = parseInt(btn.dataset.index);
-                    var grp = state.suggestions[index].group;
-                    if (grp) {
-                        state.suggestions = state.suggestions.filter(function(c) { return c.group !== grp; });
-                    } else {
-                        state.suggestions.splice(index, 1);
-                    }
-                    renderSuggestions();
-                    updatePreview();
-                    updateDownloadButton();
-                    scheduleSyntaxValidation();
-                });
-            });
-            suggestionsList.querySelectorAll('.edit-input').forEach(function(input) {
-                input.addEventListener('input', function() {
-                    var index = parseInt(input.dataset.index);
-                    state.suggestions[index].text = input.value;
-                    updatePreview();
-                    scheduleSyntaxValidation(500);
-                });
-            });
-            suggestionsList.querySelectorAll('.use-alternate-btn').forEach(function(btn) {
-                btn.addEventListener('click', function() {
-                    var index = parseInt(btn.dataset.index);
-                    var altIndex = parseInt(btn.dataset.altIndex);
-                    swapSuggestionWithAlternate(state.suggestions[index], altIndex);
-                    renderSuggestions();
-                    updatePreview();
-                    updateDownloadButton();
-                    scheduleSyntaxValidation();
-                });
-            });
-            updateDownloadButton();
-        }
-
-        // ================================================================
-        // Playground open / save
-        // ================================================================
-        async function openDocxPlaygroundModal() {
-            if (!state.auth.isAuthenticated) { showError('Login required to access Playground.'); return; }
-            // Show modal immediately with loading states
-            var openPgProject = document.getElementById('open-pg-project');
-            var openPgTemplate = document.getElementById('open-pg-template');
-            openPgProject.innerHTML = '<option value="">Loading projects...</option>';
-            openPgTemplate.innerHTML = '<option value="">Waiting for projects...</option>';
-            openPlaygroundModalEl.classList.remove('hidden');
-            // Load data in background
-            (async function() {
-                try {
-                    await fetchPlaygroundProjects();
-                    openPgProject.innerHTML = '';
-                    state.playground.projects.forEach(function(proj) {
-                        var opt = document.createElement('option');
-                        opt.value = proj; opt.textContent = proj;
-                        opt.selected = proj === state.playground.selectedProject;
-                        openPgProject.appendChild(opt);
-                    });
-                    await fetchDocxOpenPlaygroundTemplates();
-                } catch (e) {
-                    console.error('Error loading playground data:', e);
-                    openPgProject.innerHTML = '<option value="">(error loading projects)</option>';
-                    openPgTemplate.innerHTML = '<option value="">(error loading templates)</option>';
-                }
-            })();
-        }
-
-        async function fetchDocxOpenPlaygroundTemplates() {
-            var openPgProject = document.getElementById('open-pg-project');
-            var openPgTemplate = document.getElementById('open-pg-template');
-            var project = openPgProject.value || 'default';
-            openPgTemplate.innerHTML = '<option value="">Loading...</option>';
-            try {
-                var data = await fetchJsonOrThrow(
-                    endpointPath('playgroundTemplates', '/al/labeler/api/playground-templates') + '?project=' + encodeURIComponent(project) + '&type=docx'
-                );
-                var templates = data && data.success && data.data && Array.isArray(data.data.templates) ? data.data.templates : [];
-                openPgTemplate.innerHTML = '';
-                if (templates.length === 0) {
-                    var opt = document.createElement('option');
-                    opt.value = ''; opt.textContent = '(no DOCX templates found)';
-                    openPgTemplate.appendChild(opt);
-                    return;
-                }
-                templates.forEach(function(t) {
-                    var opt = document.createElement('option');
-                    opt.value = t.filename; opt.textContent = t.filename + (t.size ? ' (' + Math.round(t.size / 1024) + ' KB)' : '');
-                    openPgTemplate.appendChild(opt);
-                });
-            } catch (_e) {
-                openPgTemplate.innerHTML = '<option value="">(error loading templates)</option>';
-            }
-        }
-
-        async function maybeOpenInitialPlaygroundTemplate() {
-            if (!state.auth.isAuthenticated) return;
-            if (state.initialPlaygroundSource.attempted) return;
-            var project = state.initialPlaygroundSource.project;
-            var filename = state.initialPlaygroundSource.filename;
-            if (!project || !filename) {
-                state.initialPlaygroundSource.attempted = true;
-                return;
-            }
-            state.initialPlaygroundSource.attempted = true;
-            if (state.playground.projects.indexOf(project) === -1) return;
-            state.playground.selectedProject = project;
-            renderInterviewPicker();
-            await openDocxTemplateFromPlayground(project, filename, { showSuccess: false });
-        }
-
-        async function confirmOpenFromPlayground() {
-            var openPgProject = document.getElementById('open-pg-project');
-            var openPgTemplate = document.getElementById('open-pg-template');
-            var project = openPgProject.value || 'default';
-            var filename = openPgTemplate.value;
-            if (!filename) { showError('Select a template file.'); return; }
-            openPlaygroundModalEl.classList.add('hidden');
-            await openDocxTemplateFromPlayground(project, filename);
-        }
-
-        async function openDocxTemplateFromPlayground(project, filename, options) {
-            options = options || {};
-            showLoading('Loading ' + filename + ' from Playground...');
-            try {
-                var data = await fetchJsonOrThrow(
-                    endpointPath('playgroundTemplatesLoad', '/al/labeler/api/playground-templates/load') + '?project=' + encodeURIComponent(project) + '&filename=' + encodeURIComponent(filename)
-                );
-                if (!data.success || !data.data || !data.data.file_content_base64) {
-                    throw new Error((data.error && data.error.message) || 'Failed to load template.');
-                }
-                var binaryString = atob(data.data.file_content_base64);
-                var bytes = new Uint8Array(binaryString.length);
-                for (var i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
-                var blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
-                var file = new File([blob], filename, { type: blob.type });
-                state.playgroundSource = { project: project, filename: filename };
-                savePlaygroundBtn.classList.remove('hidden');
-                await processFile(file);
-            } catch (error) {
-                showError('Failed to load from Playground: ' + (error.message || 'Unknown error.'));
-            } finally { hideLoading(); }
-        }
-
-        async function openSavePlaygroundModal() {
-            if (!state.auth.isAuthenticated) { showError('Login required to save to Playground.'); return; }
-            if (!state.file) { showError('No DOCX file loaded.'); return; }
-            // Show modal immediately
-            var savePgProject = document.getElementById('save-pg-project');
-            var savePgFilename = document.getElementById('save-pg-filename');
-            var savePgStatus = document.getElementById('save-pg-status');
-            savePgProject.innerHTML = '<option value="">Loading projects...</option>';
-            savePgFilename.value = (state.playgroundSource && state.playgroundSource.filename) || (state.file && state.file.name) || 'template.docx';
-            if (!savePgFilename.value.toLowerCase().endsWith('.docx'))
-                savePgFilename.value += '.docx';
-            savePgStatus.classList.add('hidden');
-            savePlaygroundModalEl.classList.remove('hidden');
-            // Load projects in background
-            (async function() {
-                try {
-                    await fetchPlaygroundProjects();
-                    savePgProject.innerHTML = '';
-                    state.playground.projects.forEach(function(proj) {
-                        var opt = document.createElement('option');
-                        opt.value = proj; opt.textContent = proj;
-                        opt.selected = proj === ((state.playgroundSource && state.playgroundSource.project) || state.playground.selectedProject);
-                        savePgProject.appendChild(opt);
-                    });
-                } catch (e) {
-                    console.error('Error loading projects:', e);
-                    savePgProject.innerHTML = '<option value="">(error loading projects)</option>';
-                }
-            })();
-        }
-
-        async function confirmSaveToPlayground() {
-            var savePgProject = document.getElementById('save-pg-project');
-            var savePgFilename = document.getElementById('save-pg-filename');
-            var savePgStatus = document.getElementById('save-pg-status');
-            var project = savePgProject.value || 'default';
-            var filename = savePgFilename.value.trim();
-            if (!filename || !filename.toLowerCase().endsWith('.docx')) {
-                savePgStatus.textContent = 'Filename must end with .docx'; savePgStatus.classList.remove('hidden'); return;
-            }
-            savePlaygroundModalEl.classList.add('hidden');
-            showLoading('Saving to Playground...');
-            try {
-                var syntaxCheck = await ensureSyntaxValidationBeforeWrite('saving to Playground');
-                if (!syntaxCheck.allowed) {
-                    hideLoading();
-                    return;
-                }
-                // First apply any pending changes via the apply-labels endpoint
-                var renames = collectRenamePayload();
-                var acceptedLabels = collectAcceptedLabels();
-
-                var docxBase64;
-                var applyHighlights = acceptedLabels.length > 0;
-                if (renames.length > 0 || acceptedLabels.length > 0) {
-                    var formData = new FormData();
-                    formData.append('file', state.file);
-                    formData.append('defragment_runs', state.settings.defragmentRuns ? 'true' : 'false');
-                    if (renames.length > 0) formData.append('renames', JSON.stringify(renames));
-                    if (acceptedLabels.length > 0) formData.append('labels', JSON.stringify(acceptedLabels));
-                    if (applyHighlights) formData.append('apply_highlights', 'true');
-                    if (syntaxCheck.allowInvalidSyntax) formData.append('allow_invalid_syntax', 'true');
-                    var applyResponse = await fetch('/al/docx-labeler/api/apply-labels', { method: 'POST', body: formData });
-                    var applyData = await parseApiResponse(applyResponse);
-                    docxBase64 = applyData.data.docx_base64;
-                } else {
-                    // No changes - send the original file as base64
-                    var arrayBuffer = await state.file.arrayBuffer();
-                    var bytes = new Uint8Array(arrayBuffer);
-                    var raw = '';
-                    for (var i = 0; i < bytes.length; i++) raw += String.fromCharCode(bytes[i]);
-                    docxBase64 = window.btoa(raw);
-                }
-
-                var response = await fetch(endpointPath('playgroundTemplatesSave', '/al/labeler/api/playground-templates/save'), {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-WFD-Action': '1' },
-                    body: JSON.stringify({ project: project, filename: filename, file_content_base64: docxBase64 }),
-                    credentials: 'same-origin'
-                });
-                var data = await response.json();
-                if (!data.success) throw new Error((data.error && data.error.message) || 'Save failed.');
-                state.playgroundSource = { project: project, filename: filename };
-                savePlaygroundBtn.classList.remove('hidden');
-                downloadStatus.textContent = (data.data && data.data.created ? 'Created' : 'Updated') + ' ' + filename + ' in Playground.';
-                downloadStatus.classList.remove('hidden');
-            } catch (error) {
-                showError('Save to Playground failed: ' + (error.message || 'Unknown error.'));
-            } finally { hideLoading(); }
-        }
-
-        // ================================================================
-        // Download
-        // ================================================================
-        function updateDownloadButton() {
-            var hasChanges = collectRenamePayload().length > 0 || collectAcceptedLabels().length > 0;
-            downloadBtn.disabled = !hasChanges;
-            applyHighlightsBtn.disabled = !state.file;
-            // Save to Playground is enabled when a file is loaded (changes or not, the user may want to save the original)
-            savePlaygroundBtn.disabled = !state.file;
-        }
-
-        async function downloadDocument(options) {
-            options = options || {};
-            if (!state.file) return;
-            var renames = collectRenamePayload();
-            var acceptedLabels = collectAcceptedLabels();
-            var applyHighlights = !!options.forceHighlights || acceptedLabels.length > 0;
-            if (renames.length === 0 && acceptedLabels.length === 0 && !applyHighlights) { alert('No changes to apply.'); return; }
-            downloadStatus.textContent = 'Processing...';
-            downloadStatus.classList.remove('hidden');
-            downloadBtn.disabled = true;
-            applyHighlightsBtn.disabled = true;
-            try {
-                var syntaxCheck = await ensureSyntaxValidationBeforeWrite('downloading this DOCX');
-                if (!syntaxCheck.allowed) {
-                    downloadStatus.classList.add('hidden');
-                    return;
-                }
-                var formData = new FormData();
-                formData.append('file', state.file);
-                formData.append('defragment_runs', state.settings.defragmentRuns ? 'true' : 'false');
-                if (renames.length > 0) formData.append('renames', JSON.stringify(renames));
-                if (acceptedLabels.length > 0) formData.append('labels', JSON.stringify(acceptedLabels));
-                if (applyHighlights) formData.append('apply_highlights', 'true');
-                if (syntaxCheck.allowInvalidSyntax) formData.append('allow_invalid_syntax', 'true');
-                var response = await fetch('/al/docx-labeler/api/apply-labels', { method: 'POST', body: formData });
-                var data = await parseApiResponse(response);
-                var binaryString = atob(data.data.docx_base64);
-                var bytes = new Uint8Array(binaryString.length);
-                for (var i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
-                var blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
-                var url = URL.createObjectURL(blob);
-                var a = document.createElement('a');
-                a.href = url;
-                a.download = data.data.filename;
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
-                if (data.data.defragmented_before_apply && data.data.defragmentation) {
-                    var paragraphCount = data.data.defragmentation.paragraphs_defragmented || 0;
-                    var runsRemoved = data.data.defragmentation.runs_removed || 0;
-                    downloadStatus.textContent = 'Download complete. Consolidated fragmented runs in ' + paragraphCount + ' paragraph' + (paragraphCount === 1 ? '' : 's') + ' before applying labels (' + runsRemoved + ' runs merged).';
-                } else if (data.data.apply_highlights) {
-                    downloadStatus.textContent = 'Download complete with Jinja highlights.';
-                } else {
-                    downloadStatus.textContent = 'Download complete!';
-                    setTimeout(function() { downloadStatus.classList.add('hidden'); }, 2000);
-                }
-            } catch (error) {
-                console.error('Error downloading:', error);
-                downloadStatus.textContent = 'Error: ' + error.message;
-            } finally { updateDownloadButton(); }
-        }
-
-        // ================================================================
-        // Event listeners
-        // ================================================================
-        fileInput.addEventListener('change', function(e) { var file = e.target.files[0]; if (file) processFile(file); });
-
-        // Playground open / save listeners
-        openPlaygroundBtn.addEventListener('click', openDocxPlaygroundModal);
-        savePlaygroundBtn.addEventListener('click', openSavePlaygroundModal);
-        document.getElementById('open-pg-project').addEventListener('change', fetchDocxOpenPlaygroundTemplates);
-        document.getElementById('open-pg-confirm').addEventListener('click', confirmOpenFromPlayground);
-        document.getElementById('open-pg-cancel').addEventListener('click', function() { openPlaygroundModalEl.classList.add('hidden'); });
-        document.getElementById('close-open-playground').addEventListener('click', function() { openPlaygroundModalEl.classList.add('hidden'); });
-        document.getElementById('save-pg-confirm').addEventListener('click', confirmSaveToPlayground);
-        document.getElementById('save-pg-cancel').addEventListener('click', function() { savePlaygroundModalEl.classList.add('hidden'); });
-        document.getElementById('close-save-playground').addEventListener('click', function() { savePlaygroundModalEl.classList.add('hidden'); });
-        // Close playground modals on backdrop click
-        [openPlaygroundModalEl, savePlaygroundModalEl].forEach(function(modal) {
-            modal.addEventListener('click', function(e) { if (e.target === modal) modal.classList.add('hidden'); });
+          if (selectedText) {
+            var wrapEncoded = escapeHtml(selectedText);
+            var wrapPos = html.indexOf(wrapEncoded);
+            if (wrapPos !== -1) {
+              html =
+                html.substring(0, wrapPos) +
+                '<span class="highlight-accepted">' +
+                wrapDisplay +
+                "</span>" +
+                html.substring(wrapPos + wrapEncoded.length);
+            }
+          }
+        } else if (!selectedText && s._isManual) {
+          // Insert mode: no selected text — locate the run and replace its full text
+          var insertRun = state.runs.find(function (r) {
+            return r[0] === s.paragraph && r[1] === s.run;
+          });
+          if (insertRun && insertRun[2]) {
+            var insertOrig = escapeHtml(String(insertRun[2]));
+            var insertPos = html.indexOf(insertOrig);
+            if (insertPos !== -1) {
+              html =
+                html.substring(0, insertPos) +
+                '<span class="highlight-accepted">' +
+                escapeHtml(s.text) +
+                "</span>" +
+                html.substring(insertPos + insertOrig.length);
+            }
+          }
+        } else {
+          var displayLabel = s._displayLabel || s.text;
+          if (selectedText) {
+            var encoded = escapeHtml(selectedText);
+            var pos = html.indexOf(encoded);
+            if (pos !== -1) {
+              html =
+                html.substring(0, pos) +
+                '<span class="highlight-accepted">' +
+                escapeHtml(displayLabel) +
+                "</span>" +
+                html.substring(pos + encoded.length);
+            }
+          }
+        }
+      }
+    });
+
+    // --- Single-run AI suggestions (no group) ---
+    const acceptedByKey = {};
+    state.suggestions.forEach(function (s) {
+      if (s.status === "accepted" && s.new_paragraph === 0 && !s.group) {
+        acceptedByKey[s.paragraph + "," + s.run] = s;
+      }
+    });
+
+    const replacements = [];
+    for (const key of Object.keys(acceptedByKey)) {
+      const s = acceptedByKey[key];
+      const run = state.runs.find(function (r) {
+        return r[0] === s.paragraph && r[1] === s.run;
+      });
+      if (run && run[2] && run[2].trim()) {
+        replacements.push({ original: run[2], replacement: s.text });
+      }
+    }
+    replacements.sort(function (a, b) {
+      return b.original.length - a.original.length;
+    });
+
+    for (const r of replacements) {
+      const encoded = escapeHtml(r.original);
+      const pos = html.indexOf(encoded);
+      if (pos !== -1) {
+        html =
+          html.substring(0, pos) +
+          '<span class="highlight-accepted">' +
+          escapeHtml(r.replacement) +
+          "</span>" +
+          html.substring(pos + encoded.length);
+      }
+    }
+
+    // Highlight existing labels (with any renames applied) — per-occurrence
+    if (previewUtils && previewUtils.applyExistingLabelHighlightsByOccurrence) {
+      html = previewUtils.applyExistingLabelHighlightsByOccurrence(
+        html,
+        state.existingLabels,
+        escapeHtml,
+      );
+    } else {
+      var existingByOriginal = {};
+      state.existingLabels.forEach(function (label) {
+        if (!existingByOriginal[label.original])
+          existingByOriginal[label.original] = [];
+        existingByOriginal[label.original].push(label);
+      });
+      Object.keys(existingByOriginal).forEach(function (original) {
+        var entries = existingByOriginal[original];
+        var encoded = escapeHtml(original);
+        var offset = 0;
+        entries.forEach(function (label) {
+          var cls =
+            label.current !== label.original
+              ? "highlight-accepted"
+              : "highlight-existing";
+          var span =
+            '<span class="' +
+            cls +
+            ' existing-inline-label" data-label-id="' +
+            escapeHtml(label.id) +
+            '">' +
+            escapeHtml(label.current) +
+            "</span>";
+          var pos = html.indexOf(encoded, offset);
+          if (pos === -1) return;
+          html =
+            html.substring(0, pos) +
+            span +
+            html.substring(pos + encoded.length);
+          offset = pos + span.length;
         });
-        utilitiesBtn.addEventListener('click', function() {
-            updateModalSourceStatus();
-            utilitiesResult.innerHTML = '';
-            utilitiesModal.classList.remove('hidden');
+      });
+    }
+
+    previewContent.innerHTML = html;
+    previewContent
+      .querySelectorAll(".existing-inline-label")
+      .forEach(function (node) {
+        node.addEventListener("click", function (evt) {
+          evt.preventDefault();
+          evt.stopPropagation();
+          var labelId = node.getAttribute("data-label-id");
+          var label = state.existingLabels.find(function (item) {
+            return item.id === labelId;
+          });
+          if (label) openEditLabelModal(label);
         });
-        repairBtn.addEventListener('click', function() {
-            updateModalSourceStatus();
-            repairResult.innerHTML = '';
-            repairModal.classList.remove('hidden');
+      });
+  }
+
+  // ================================================================
+  // Existing-labels tree
+  // ================================================================
+  function renderExistingLabelsTree() {
+    existingLabelsTree.innerHTML = "";
+    // Build unique-entry list and occurrence counts from per-occurrence data
+    var seenOriginals = {};
+    var uniqueEntries = [];
+    var occurrenceCounts = {};
+    state.existingLabels.forEach(function (label) {
+      occurrenceCounts[label.original] =
+        (occurrenceCounts[label.original] || 0) + 1;
+      if (!seenOriginals[label.original]) {
+        seenOriginals[label.original] = true;
+        uniqueEntries.push(label);
+      }
+    });
+    existingCount.textContent = uniqueEntries.length;
+    if (uniqueEntries.length === 0) {
+      existingLabelsTree.innerHTML =
+        '<div class="text-center py-5 text-muted"><p>No existing labels found.</p><p class="small mt-1">Use the AI Suggestions tab to add labels.</p></div>';
+      return;
+    }
+    const groups = {};
+    uniqueEntries.forEach(function (label) {
+      const inner = label.current
+        .replace(/^\{\{\s*|\s*\}\}$/g, "")
+        .replace(/^\{%\s*|\s*%\}$/g, "")
+        .trim();
+      const base = inner.split(".")[0].split("[")[0];
+      if (!groups[base]) groups[base] = [];
+      groups[base].push(label);
+    });
+    Object.keys(groups)
+      .sort()
+      .forEach(function (groupName) {
+        const groupDiv = document.createElement("div");
+        groupDiv.className = "mb-3";
+        const header = document.createElement("div");
+        header.className =
+          "tree-item d-flex align-items-center gap-2 px-2 py-1 rounded fw-medium";
+        header.innerHTML =
+          '<span class="tree-toggle">\u25BC</span><span>' +
+          escapeHtml(groupName) +
+          '</span><span class="badge bg-secondary">' +
+          groups[groupName].length +
+          "</span>";
+        const children = document.createElement("div");
+        children.className = "tree-children mt-1";
+        groups[groupName].forEach(function (label) {
+          var count = occurrenceCounts[label.original] || 1;
+          const item = document.createElement("div");
+          item.className = "existing-label p-2 rounded mb-1 cursor-pointer";
+          item.innerHTML =
+            '<div class="font-monospace small break-all' +
+            (label.original !== label.current ? " text-primary" : "") +
+            '">' +
+            escapeHtml(label.current) +
+            "</div>" +
+            (label.original !== label.current
+              ? '<div class="small text-muted mt-1 text-decoration-line-through">' +
+                escapeHtml(label.original) +
+                "</div>"
+              : "") +
+            '<div class="small text-muted mt-1">' +
+            count +
+            " occurrence" +
+            (count > 1 ? "s" : "") +
+            "</div>";
+          item.addEventListener("click", function () {
+            openEditLabelModal(label);
+          });
+          children.appendChild(item);
         });
-        document.getElementById('utilities-close').addEventListener('click', function() { utilitiesModal.classList.add('hidden'); });
-        document.getElementById('repair-close').addEventListener('click', function() { repairModal.classList.add('hidden'); });
-        [utilitySourceActive, utilitySourceUpload, repairSourceActive, repairSourceUpload].forEach(function(input) {
-            input.addEventListener('change', updateModalSourceStatus);
+        header.addEventListener("click", function () {
+          var toggle = header.querySelector(".tree-toggle");
+          if (children.style.display === "none") {
+            children.style.display = "block";
+            toggle.textContent = "\u25BC";
+          } else {
+            children.style.display = "none";
+            toggle.textContent = "\u25B6";
+          }
         });
-        utilityFileInput.addEventListener('change', updateModalSourceStatus);
-        repairFileInput.addEventListener('change', updateModalSourceStatus);
-        document.querySelectorAll('.utility-action-btn').forEach(function(button) {
-            button.addEventListener('click', function() {
-                runDocxOperation('utility', button.dataset.action, 'Running DOCX utility...');
-            });
+        groupDiv.appendChild(header);
+        groupDiv.appendChild(children);
+        existingLabelsTree.appendChild(groupDiv);
+      });
+    updateDownloadButton();
+  }
+
+  // ================================================================
+  // Variable-picker tree
+  // ================================================================
+  function renderVariableTree(
+    tree,
+    prefix,
+    container,
+    filter,
+    onSelectVariable,
+  ) {
+    tree = tree || getEffectiveVariableTree();
+    prefix = prefix || "";
+    container = container || variableTree;
+    filter = filter || "";
+    onSelectVariable = onSelectVariable || insertVariable;
+    if (container === variableTree) container.innerHTML = "";
+    Object.keys(tree).forEach(function (key) {
+      if (key.startsWith("_")) return;
+      var value = tree[key];
+      var isSelectedInterviewGroup =
+        !prefix && key === "Selected interview variables";
+      var fullPath = prefix ? prefix + "." + key : key;
+      var displayPath = fullPath.replace(/\.\[/g, "[");
+      var singletonListChild = getSingletonListChild(value);
+      var renderTarget = singletonListChild || value;
+      var childKeys =
+        renderTarget && typeof renderTarget === "object"
+          ? Object.keys(renderTarget).filter(function (childKey) {
+              return !childKey.startsWith("_");
+            })
+          : [];
+      var hasChildren = childKeys.length > 0;
+      var directSelectPath = singletonListChild ? displayPath + "[0]" : null;
+      var labelPath = directSelectPath || displayPath;
+      if (filter && !labelPath.toLowerCase().includes(filter.toLowerCase())) {
+        if (typeof renderTarget !== "object") return;
+        var hasMatch = JSON.stringify(renderTarget)
+          .toLowerCase()
+          .includes(filter.toLowerCase());
+        if (!hasMatch) return;
+      }
+      var item = document.createElement("div");
+      item.className = "mb-1";
+      var header = document.createElement("div");
+      header.className =
+        "tree-item d-flex align-items-center gap-1 px-2 py-1 rounded small";
+      var leafValue = renderTarget;
+      var leafDescription =
+        typeof leafValue === "string"
+          ? leafValue
+          : leafValue && leafValue._description
+            ? leafValue._description
+            : "";
+      var isSelectableLeaf =
+        typeof value === "string" ||
+        (value !== null && typeof value === "object" && !!value._variable) ||
+        (directSelectPath && !hasChildren);
+      if (value === null) {
+        return; // Skip null values completely, they are effectively deleted keys
+      }
+      if (isSelectableLeaf) {
+        header.innerHTML =
+          '<span class="tree-toggle text-muted">\u00B7</span><span class="font-monospace text-primary cursor-pointer" data-var="' +
+          labelPath +
+          '">' +
+          labelPath +
+          '</span><span class="text-muted small ms-1 text-truncate">' +
+          leafDescription +
+          "</span>";
+        header
+          .querySelector("[data-var]")
+          .addEventListener("click", function (e) {
+            e.stopPropagation();
+            onSelectVariable(labelPath);
+          });
+      } else if (directSelectPath) {
+        header.innerHTML =
+          '<span class="tree-toggle cursor-pointer">\u25B6</span><span class="font-monospace text-primary cursor-pointer" data-var="' +
+          directSelectPath +
+          '">' +
+          directSelectPath +
+          "</span>" +
+          (leafDescription
+            ? '<span class="text-muted small ms-1">' +
+              leafDescription +
+              "</span>"
+            : "");
+        header
+          .querySelector("[data-var]")
+          .addEventListener("click", function (e) {
+            e.stopPropagation();
+            onSelectVariable(directSelectPath);
+          });
+      } else {
+        header.innerHTML =
+          '<span class="tree-toggle cursor-pointer">\u25B6</span><span class="fw-medium">' +
+          key +
+          "</span>" +
+          (leafDescription
+            ? '<span class="text-muted small ms-1">' +
+              leafDescription +
+              "</span>"
+            : "");
+      }
+      item.appendChild(header);
+      if (hasChildren) {
+        var children = document.createElement("div");
+        children.className = "tree-children hidden";
+        renderVariableTree(
+          renderTarget,
+          isSelectedInterviewGroup ? prefix : directSelectPath || fullPath,
+          children,
+          filter,
+          onSelectVariable,
+        );
+        item.appendChild(children);
+        header.addEventListener("click", function (e) {
+          var clicked = /** @type {any} */ (e.target);
+          if (clicked.dataset && clicked.dataset.var) return;
+          var toggle = header.querySelector(".tree-toggle");
+          if (children.classList.contains("hidden")) {
+            children.classList.remove("hidden");
+            toggle.textContent = "\u25BC";
+          } else {
+            children.classList.add("hidden");
+            toggle.textContent = "\u25B6";
+          }
         });
-        document.querySelectorAll('.repair-action-btn').forEach(function(button) {
-            button.addEventListener('click', function() {
-                runDocxOperation('repair', button.dataset.action, 'Running DOCX repair...');
-            });
+      }
+      container.appendChild(item);
+    });
+  }
+
+  function insertVariable(varPath) {
+    var input = document.getElementById("edit-label-input");
+    if (input) {
+      input.value = "{{ " + varPath + " }}";
+      input.focus();
+    }
+  }
+
+  // ================================================================
+  // File processing
+  // ================================================================
+  async function processFile(file) {
+    if (!file) return;
+    state.file = file;
+    savePlaygroundBtn.classList.remove("hidden");
+    updateModalSourceStatus();
+    fileName.textContent = file.name;
+    fileName.classList.remove("hidden");
+    showLoading("Reading document...");
+    try {
+      var arrayBuffer = await file.arrayBuffer();
+      state.fileContent = new Uint8Array(arrayBuffer);
+
+      // Step 1: mammoth HTML preview
+      showLoading("Converting document to HTML...");
+      var result = await mammoth.convertToHtml({ arrayBuffer: arrayBuffer });
+      state.originalHtml = result.value;
+      previewContent.innerHTML = state.originalHtml;
+      previewContent.classList.remove("hidden");
+      previewEmpty.classList.add("hidden");
+
+      // Step 2: extract runs via API (for preview mapping)
+      showLoading("Extracting document structure...");
+      var runsFormData = new FormData();
+      runsFormData.append("file", file);
+      runsFormData.append(
+        "defragment_runs",
+        state.settings.defragmentRuns ? "true" : "false",
+      );
+      try {
+        var runsResp = await fetch("/al/docx-labeler/api/extract-runs", {
+          method: "POST",
+          body: runsFormData,
         });
-        tabExisting.addEventListener('click', function() { switchTab('existing'); });
-        tabManual.addEventListener('click', function() { switchTab('manual'); });
-        tabSuggestions.addEventListener('click', function() { switchTab('suggestions'); });
-        document.getElementById('accept-all-btn').addEventListener('click', function() {
-            state.suggestions.forEach(function(s) { if (s.status === 'pending') s.status = 'accepted'; });
-            renderSuggestions();
-            updatePreview();
-        });
-        document.getElementById('regenerate-btn').addEventListener('click', async function() {
-            if (!state.auth.aiEnabled) {
-                showError('AI suggestions require login.');
-                return;
-            }
-            if (state.file) { showLoading('Regenerating suggestions...'); await fetchSuggestions(); hideLoading(); showMainPanel(); }
-        });
-        document.getElementById('bulk-replace-btn').addEventListener('click', function() {
-            document.getElementById('bulk-find').value = '';
-            document.getElementById('bulk-replace').value = '';
-            document.getElementById('bulk-preview').classList.add('hidden');
-            bulkReplaceModal.classList.remove('hidden');
-        });
-        document.getElementById('ai-relabel-btn').addEventListener('click', function() {
-            alert('AI Relabeling coming soon! This will use AI to suggest better AssemblyLine-compatible names for your existing labels.');
-        });
-        document.getElementById('bulk-preview-btn').addEventListener('click', previewBulkReplace);
-        document.getElementById('bulk-apply').addEventListener('click', applyBulkReplace);
-        document.getElementById('bulk-cancel').addEventListener('click', function() { bulkReplaceModal.classList.add('hidden'); });
-        document.getElementById('edit-save').addEventListener('click', saveEditLabel);
-        document.getElementById('edit-cancel').addEventListener('click', function() { editLabelModal.classList.add('hidden'); state.editingLabelId = null; });
-        document.getElementById('edit-close').addEventListener('click', function() { editLabelModal.classList.add('hidden'); state.editingLabelId = null; });
-        variableSearch.addEventListener('input', function(e) { renderVariableTree(getEffectiveVariableTree(), '', variableTree, e.target.value); });
-        downloadBtn.addEventListener('click', function() { downloadDocument(); });
-        applyHighlightsBtn.addEventListener('click', function() { downloadDocument({ forceHighlights: true }); });
-        document.getElementById('settings-btn').addEventListener('click', function() {
-            document.getElementById('additional-instructions').value = state.settings.additionalInstructions;
-            document.getElementById('context-text').value = state.settings.contextText || '';
-            document.getElementById('custom-people').value = state.settings.customPeople;
-            promptProfileInput.value = state.settings.promptProfile || 'standard';
-            generationMethodInput.value = state.settings.generationMethod || 'multi_run';
-            generatorModelsInput.value = state.settings.generatorModels || '';
-            judgeModelInput.value = state.settings.judgeModel || '';
-            document.getElementById('defragment-runs').checked = !!state.settings.defragmentRuns;
-            usePlaygroundVariablesInput.checked = !!state.settings.usePlaygroundVariables;
-            aiModelInput.value = state.settings.model;
-            state.ui.editInterviewSourceInSettings = false;
-            renderGenerationMethodFields();
-            renderInterviewPicker();
-            renderModelSuggestions('');
-            settingsModal.classList.remove('hidden');
-        });
-        document.getElementById('close-settings').addEventListener('click', function() {
-            state.ui.editInterviewSourceInSettings = false;
-            renderInterviewPicker();
-            settingsModal.classList.add('hidden');
-        });
-        document.getElementById('save-settings').addEventListener('click', function() {
-            state.settings.additionalInstructions = document.getElementById('additional-instructions').value;
-            state.settings.contextText = document.getElementById('context-text').value;
-            state.settings.customPeople = document.getElementById('custom-people').value;
-            state.settings.promptProfile = promptProfileInput.value || 'standard';
-            state.settings.generationMethod = generationMethodInput.value || 'multi_run';
-            state.settings.generatorModels = generatorModelsInput.value;
-            state.settings.judgeModel = judgeModelInput.value.trim();
-            state.settings.defragmentRuns = !!document.getElementById('defragment-runs').checked;
-            state.settings.usePlaygroundVariables = !!usePlaygroundVariablesInput.checked;
-            state.settings.model = aiModelInput.value.trim() || state.defaultModel;
-            state.ui.editInterviewSourceInSettings = false;
-            renderInterviewPicker();
-            settingsModal.classList.add('hidden');
-        });
-        document.getElementById('reset-settings').addEventListener('click', function() {
-            document.getElementById('additional-instructions').value = '';
-            document.getElementById('context-text').value = '';
-            document.getElementById('custom-people').value = '';
-            promptProfileInput.value = 'standard';
-            generationMethodInput.value = 'multi_run';
-            generatorModelsInput.value = '';
-            judgeModelInput.value = '';
-            document.getElementById('defragment-runs').checked = true;
-            usePlaygroundVariablesInput.checked = false;
-            aiModelInput.value = state.defaultModel;
-            renderGenerationMethodFields();
-            renderInterviewPicker();
-            renderModelSuggestions('');
-        });
-        if (changeInterviewSourceBtn) {
-            changeInterviewSourceBtn.addEventListener('click', function() {
-                state.ui.editInterviewSourceInSettings = !state.ui.editInterviewSourceInSettings;
-                renderInterviewPicker();
-            });
+        var runsData = await runsResp.json();
+        if (runsData.success) {
+          state.runs = runsData.data.runs;
         }
-        generationMethodInput.addEventListener('change', renderGenerationMethodFields);
-        aiModelInput.addEventListener('input', function() { renderModelSuggestions(aiModelInput.value); });
-        aiModelInput.addEventListener('change', function() {
-            state.settings.model = aiModelInput.value.trim() || state.defaultModel;
+      } catch (runErr) {
+        console.warn("Could not extract runs for preview mapping:", runErr);
+      }
+
+      state.existingLabels = extractExistingLabelsFromRuns(state.runs);
+      if (state.existingLabels.length === 0) {
+        state.existingLabels = extractExistingLabels(state.originalHtml);
+      }
+      state.labelRenames = {};
+      state.suggestions = [];
+      state.validation = null;
+      state.syntaxValidation = null;
+      state.syntaxValidationPending = false;
+      renderSyntaxValidation();
+
+      hideLoading();
+      showMainPanel();
+
+      if (state.existingLabels.length > 0) {
+        switchTab("existing");
+        renderExistingLabelsTree();
+        updatePreview();
+      } else {
+        switchTab("suggestions");
+        if (state.auth.aiEnabled) {
+          showLoading("Generating AI suggestions...");
+          await fetchSuggestions();
+        } else {
+          suggestionsList.innerHTML =
+            '<div class="alert alert-warning">AI suggestions are unavailable until you log in.</div>';
+        }
+        hideLoading();
+        showMainPanel(); // <-- was missing; caused the "spin forever" bug
+      }
+    } catch (error) {
+      console.error("Error processing file:", error);
+      showError("Failed to process document: " + error.message);
+    } finally {
+      hideLoading();
+    }
+  }
+
+  // ================================================================
+  // Tab switching
+  // ================================================================
+  function switchTab(tab, options) {
+    state.activeTab = tab;
+    TAB_ORDER.forEach(function (entry) {
+      var selected = entry.name === tab;
+      entry.tab.classList.toggle("tab-active", selected);
+      entry.tab.setAttribute("aria-selected", selected ? "true" : "false");
+      // Roving tabindex: only the selected tab is in the tab sequence, so Tab
+      // moves out of the tablist rather than through every tab.
+      entry.tab.setAttribute("tabindex", selected ? "0" : "-1");
+      entry.panel.classList.toggle("hidden", !selected);
+    });
+    if (options && options.focusTab) {
+      var active = TAB_ORDER.filter(function (entry) {
+        return entry.name === tab;
+      })[0];
+      if (active) active.tab.focus();
+    }
+  }
+
+  function renderManualLabels() {
+    var manualLabels = getManualLabelGroups();
+    var hasManualLabels = manualLabels.length > 0;
+    tabManual.classList.toggle("hidden", !hasManualLabels);
+    manualCount.textContent = manualLabels.length;
+
+    if (!hasManualLabels) {
+      manualLabelsList.innerHTML =
+        '<div class="text-center py-5 text-muted"><p>No manual labels yet.</p><p class="small mt-1">Select text in the preview to add one.</p></div>';
+      if (state.activeTab === "manual") {
+        switchTab(state.existingLabels.length > 0 ? "existing" : "suggestions");
+      }
+      return;
+    }
+
+    manualLabelsList.innerHTML = "";
+    manualLabels.forEach(function (label) {
+      var div = document.createElement("div");
+      div.className = "p-3 rounded border border-2 mb-2 suggestion-accepted";
+      div.innerHTML =
+        '<div class="d-flex align-items-start justify-content-between gap-2 mb-2">' +
+        '<span class="small text-muted">Selection</span>' +
+        '<button class="manual-remove-btn btn btn-sm btn-outline-danger" data-group="' +
+        escapeHtml(label.group) +
+        '" title="Remove">\u2716</button>' +
+        "</div>" +
+        '<div class="small text-muted mb-2">\u201C' +
+        escapeHtml(label._selectedText || "") +
+        "\u201D</div>" +
+        '<label class="form-label small fw-medium mb-1">Label</label>' +
+        '<input type="text" class="manual-edit-input form-control form-control-sm font-monospace mb-2" value="' +
+        escapeHtml(label._displayLabel || label.text || "") +
+        '" data-group="' +
+        escapeHtml(label.group) +
+        '">' +
+        '<div class="small text-muted">Para ' +
+        escapeHtml(String(label.paragraph)) +
+        ", Run " +
+        escapeHtml(String(label.run)) +
+        "</div>";
+      manualLabelsList.appendChild(div);
+    });
+
+    manualLabelsList
+      .querySelectorAll(".manual-edit-input")
+      .forEach(function (input) {
+        input.addEventListener("input", function () {
+          var value = input.value.trim();
+          if (!value) return;
+          applyManualLabelText(input.dataset.group, value);
+          updatePreview();
+          scheduleSyntaxValidation(500);
         });
-        interviewSourceModeInputs.forEach(function(input) {
-            input.addEventListener('change', async function() {
-                if (!input.checked) return;
-                state.interviewSourceMode = input.value === 'installed' ? 'installed' : 'playground';
-                renderInterviewPicker();
-                if (state.interviewSourceMode === 'installed') {
-                    if (!state.installed.packages.length) {
-                        await fetchInstalledPackages();
-                    } else if (state.installed.selectedFile) {
-                        await fetchInstalledVariables();
-                    }
-                } else {
-                    if (!state.playground.projects.length) {
-                        await fetchPlaygroundProjects();
-                    } else if (state.playground.selectedFile) {
-                        await fetchPlaygroundVariables();
-                    }
-                }
+      });
+
+    manualLabelsList
+      .querySelectorAll(".manual-remove-btn")
+      .forEach(function (button) {
+        button.addEventListener("click", function () {
+          var groupId = button.dataset.group;
+          state.suggestions = state.suggestions.filter(function (suggestion) {
+            return suggestion.group !== groupId;
+          });
+          renderSuggestions();
+          updatePreview();
+          updateDownloadButton();
+          scheduleSyntaxValidation();
+        });
+      });
+  }
+
+  // ================================================================
+  // Edit label modal
+  // ================================================================
+  function openEditLabelModal(label) {
+    state.editingLabelId = label.id;
+    document.getElementById("edit-label-original").textContent = label.original;
+    document.getElementById("edit-label-input").value = label.current;
+    document.getElementById("variable-search").value = "";
+    renderVariableTree(getEffectiveVariableTree());
+    // Show occurrence position in title when multiple exist
+    var allSameOriginal = state.existingLabels.filter(function (l) {
+      return l.original === label.original;
+    });
+    var occurrenceIndex = allSameOriginal.indexOf(label) + 1;
+    var totalCount = allSameOriginal.length;
+    document.getElementById("edit-label-title").textContent =
+      totalCount > 1
+        ? "Edit Label (occurrence " +
+          occurrenceIndex +
+          " of " +
+          totalCount +
+          ")"
+        : "Edit Label";
+    if (!document.getElementById("edit-catchall-btn")) {
+      var footer = editLabelModal.querySelector(".dl-modal-footer");
+      if (footer) {
+        var catchallBtn = document.createElement("button");
+        catchallBtn.id = "edit-catchall-btn";
+        catchallBtn.type = "button";
+        catchallBtn.className = "btn btn-outline-primary me-auto";
+        catchallBtn.textContent = "Catchall / Request Filters";
+        catchallBtn.addEventListener("click", function () {
+          openCatchallDialog(document.getElementById("edit-label-input"));
+        });
+        footer.insertBefore(catchallBtn, footer.firstChild);
+      }
+    }
+    // Add/update "Replace all" button depending on occurrence count
+    var replaceAllBtn = document.getElementById("edit-replace-all-btn");
+    if (totalCount > 1) {
+      if (!replaceAllBtn) {
+        replaceAllBtn = document.createElement("button");
+        replaceAllBtn.id = "edit-replace-all-btn";
+        replaceAllBtn.type = "button";
+        replaceAllBtn.className = "btn btn-outline-secondary";
+        replaceAllBtn.addEventListener("click", function () {
+          saveEditLabel(true);
+        });
+        var saveBtn = document.getElementById("edit-save");
+        var modalFooter = editLabelModal.querySelector(".dl-modal-footer");
+        if (saveBtn && modalFooter)
+          modalFooter.insertBefore(replaceAllBtn, saveBtn);
+        else if (modalFooter) modalFooter.appendChild(replaceAllBtn);
+      }
+      replaceAllBtn.textContent = "Save for all " + totalCount + " occurrences";
+    } else if (replaceAllBtn) {
+      replaceAllBtn.remove();
+    }
+    editLabelModal.classList.remove("hidden");
+    document.getElementById("edit-label-input").focus();
+  }
+
+  function saveEditLabel(replaceAll) {
+    var input = document.getElementById("edit-label-input").value.trim();
+    if (!input || !state.editingLabelId) return;
+    var replaceAllMode = replaceAll === true;
+    var label = state.existingLabels.find(function (l) {
+      return l.id === state.editingLabelId;
+    });
+    if (label) {
+      if (replaceAllMode) {
+        var orig = label.original;
+        state.existingLabels.forEach(function (l) {
+          if (l.original === orig) l.current = input;
+        });
+      } else {
+        label.current = input;
+      }
+    }
+    editLabelModal.classList.add("hidden");
+    state.editingLabelId = null;
+    renderExistingLabelsTree();
+    updatePreview();
+    scheduleSyntaxValidation();
+  }
+
+  function quoteFilterArg(value) {
+    return (
+      '"' +
+      String(value || "")
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"') +
+      '"'
+    );
+  }
+
+  function expressionInsideBraces(rawValue) {
+    var text = String(rawValue || "").trim();
+    if (text.startsWith("{{") && text.endsWith("}}")) {
+      return text
+        .replace(/^\{\{\s*/, "")
+        .replace(/\s*\}\}$/, "")
+        .trim();
+    }
+    return text;
+  }
+
+  function splitExpressionFilters(expression) {
+    var parts = String(expression || "")
+      .split("|")
+      .map(function (part) {
+        return part.trim();
+      })
+      .filter(Boolean);
+    return {
+      base: parts.shift() || "",
+      filters: parts,
+    };
+  }
+
+  function normalizeFilterSnippet(snippet) {
+    var text = String(snippet || "").trim();
+    if (!text) return "";
+    if (text.startsWith("|")) text = text.slice(1).trim();
+    return text;
+  }
+
+  function parseFilterChain(rawChain) {
+    return String(rawChain || "")
+      .split(/[\n|]/)
+      .map(function (part) {
+        return normalizeFilterSnippet(part);
+      })
+      .filter(Boolean);
+  }
+
+  function parseQuotedFilterValue(rawValue) {
+    var text = String(rawValue || "").trim();
+    if (!text) return "";
+    if (
+      (text.startsWith('"') && text.endsWith('"')) ||
+      (text.startsWith("'") && text.endsWith("'"))
+    ) {
+      text = text.slice(1, -1);
+    }
+    return text
+      .replace(/\\"/g, '"')
+      .replace(/\\'/g, "'")
+      .replace(/\\\\/g, "\\");
+  }
+
+  function parseCatchallInvocation(filterText) {
+    var match = String(filterText || "")
+      .trim()
+      .match(
+        /^catchall_(complete|question|subquestion|label|datatype|options)\s*\((.*)\)$/i,
+      );
+    if (!match) return null;
+
+    var kind = match[1].toLowerCase();
+    var argsText = match[2].trim();
+    var result = {};
+
+    if (kind === "complete") {
+      var argPattern =
+        /(question|subquestion|label|datatype|options)\s*=\s*((?:\[[\s\S]*?\])|(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'))/gi;
+      var argMatch;
+      while ((argMatch = argPattern.exec(argsText))) {
+        var argName = argMatch[1].toLowerCase();
+        var argValue = argMatch[2].trim();
+        if (argName === "options") {
+          var optionText = argValue;
+          if (optionText.startsWith("[") && optionText.endsWith("]")) {
+            optionText = optionText.slice(1, -1);
+          }
+          result.options = optionText
+            .split(",")
+            .map(function (item) {
+              return parseQuotedFilterValue(item.trim());
+            })
+            .filter(Boolean)
+            .join(", ");
+        } else {
+          result[argName] = parseQuotedFilterValue(argValue);
+        }
+      }
+      return result;
+    }
+
+    result[kind] = parseQuotedFilterValue(argsText);
+    return result;
+  }
+
+  function getCatchallEditorState(rawExpression) {
+    var parts = splitExpressionFilters(rawExpression);
+    var base = parts.base;
+    var catchall = {
+      question: "",
+      subquestion: "",
+      label: "",
+      datatype: "",
+      options: "",
+    };
+    var extraFilters = [];
+
+    parts.filters.forEach(function (filterText) {
+      var normalized = normalizeFilterSnippet(filterText);
+      if (!normalized) return;
+      if (normalized.toLowerCase().startsWith("catchall_")) {
+        var parsed = parseCatchallInvocation(normalized);
+        if (parsed) {
+          Object.keys(parsed).forEach(function (key) {
+            if (
+              Object.prototype.hasOwnProperty.call(catchall, key) &&
+              parsed[key]
+            ) {
+              catchall[key] = parsed[key];
+            }
+          });
+        }
+        return;
+      }
+      extraFilters.push(normalized);
+    });
+
+    return {
+      base: base,
+      catchall: catchall,
+      extraFilters: extraFilters,
+    };
+  }
+
+  const COMMON_FILTER_SNIPPETS = [
+    { label: "Docassemble: currency", value: "currency" },
+    { label: "Docassemble: comma_and_list", value: "comma_and_list" },
+    { label: "Docassemble: comma_list", value: "comma_list" },
+    { label: "Docassemble: add_separators", value: "add_separators" },
+    {
+      label: "Docassemble: phone_number_formatted",
+      value: "phone_number_formatted",
+    },
+    {
+      label: "Docassemble: phone_number_in_e164",
+      value: "phone_number_in_e164",
+    },
+    { label: "Docassemble: manual_line_breaks", value: "manual_line_breaks" },
+    { label: "Docassemble: inline_markdown", value: "inline_markdown" },
+    { label: "Docassemble: markdown", value: "markdown" },
+    { label: "Docassemble: paragraphs", value: "paragraphs" },
+    { label: "Docassemble: fix_punctuation", value: "fix_punctuation" },
+    { label: "Docassemble: nice_number", value: "nice_number" },
+    { label: "Docassemble: ordinal", value: "ordinal" },
+    { label: "Docassemble: ordinal_number", value: "ordinal_number" },
+    { label: "Docassemble: title_case", value: "title_case" },
+    { label: "Docassemble: verbatim", value: "verbatim" },
+    { label: "Docassemble: country_name", value: "country_name" },
+    { label: "Docassemble: redact", value: "redact" },
+    { label: 'Jinja2: default("")', value: 'default("")' },
+    { label: "Jinja2: length", value: "length" },
+    { label: "Jinja2: lower", value: "lower" },
+    { label: "Jinja2: upper", value: "upper" },
+    { label: "Jinja2: capitalize", value: "capitalize" },
+    { label: "Jinja2: title", value: "title" },
+    { label: "Jinja2: trim", value: "trim" },
+    { label: 'Jinja2: replace("", "")', value: 'replace("", "")' },
+    { label: 'Jinja2: join(", ")', value: 'join(", ")' },
+    { label: "Jinja2: round", value: "round" },
+    { label: "Jinja2: int", value: "int" },
+    { label: "Jinja2: float", value: "float" },
+    { label: "Jinja2: list", value: "list" },
+    { label: "Jinja2: safe", value: "safe" },
+    { label: "Jinja2: escape", value: "escape" },
+    { label: "Jinja2: urlize", value: "urlize" },
+    { label: 'Jinja2: selectattr("attr")', value: 'selectattr("attr")' },
+    { label: 'Jinja2: rejectattr("attr")', value: 'rejectattr("attr")' },
+    { label: 'Jinja2: map(attribute="attr")', value: 'map(attribute="attr")' },
+    {
+      label: 'Jinja2: sort(attribute="attr")',
+      value: 'sort(attribute="attr")',
+    },
+    { label: 'Jinja2: sum(attribute="attr")', value: 'sum(attribute="attr")' },
+  ];
+
+  function insertFilterSnippet(target, snippet) {
+    if (!target) return;
+    var text = normalizeFilterSnippet(snippet);
+    if (!text) return;
+    var prefix = target.value && target.value.trim() ? " | " : "| ";
+    var insertText = prefix + text;
+    if (
+      typeof target.selectionStart === "number" &&
+      typeof target.selectionEnd === "number"
+    ) {
+      var start = target.selectionStart;
+      var end = target.selectionEnd;
+      var current = target.value || "";
+      var before = current.slice(0, start);
+      var after = current.slice(end);
+      target.value = before + insertText + after;
+      var caret = before.length + insertText.length;
+      target.selectionStart = caret;
+      target.selectionEnd = caret;
+    } else {
+      target.value = (target.value || "").trim();
+      target.value += insertText;
+    }
+    target.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  function buildCatchallExpression(baseExpression, config) {
+    var expression = String(baseExpression || "").trim();
+    if (!expression) return "";
+    var filters = [];
+    var catchallArgs = [];
+    if (config.question)
+      catchallArgs.push("question=" + quoteFilterArg(config.question));
+    if (config.subquestion)
+      catchallArgs.push("subquestion=" + quoteFilterArg(config.subquestion));
+    if (config.label)
+      catchallArgs.push("label=" + quoteFilterArg(config.label));
+    if (config.datatype)
+      catchallArgs.push("datatype=" + quoteFilterArg(config.datatype));
+    if (config.options) {
+      var list = config.options
+        .split("\n")
+        .join(",")
+        .split(",")
+        .map(function (item) {
+          return item.trim();
+        })
+        .filter(Boolean)
+        .map(function (item) {
+          return quoteFilterArg(item);
+        });
+      if (list.length) catchallArgs.push("options=[" + list.join(", ") + "]");
+    }
+    if (catchallArgs.length) {
+      filters.push("catchall_complete(" + catchallArgs.join(", ") + ")");
+    }
+    parseFilterChain(config.additionalFilters).forEach(function (filterText) {
+      if (filterText) filters.push(filterText);
+    });
+    if (filters.length) {
+      expression += " | " + filters.join(" | ");
+    }
+    return "{{ " + expression + " }}";
+  }
+
+  function ensureCatchallDialog() {
+    var existing = document.getElementById("catchall-filter-modal");
+    if (existing) return existing;
+    var modal = document.createElement("div");
+    modal.id = "catchall-filter-modal";
+    modal.className = "hidden dl-modal-overlay";
+    modal.innerHTML =
+      '<div class="dl-modal dl-modal-md">' +
+      '<div class="dl-modal-header">' +
+      '<h2 class="h5 fw-semibold mb-0">Catchall / Request Filters</h2>' +
+      '<button type="button" id="catchall-close" class="btn btn-sm btn-light rounded">Close</button>' +
+      "</div>" +
+      '<div class="dl-modal-body">' +
+      '<div class="mb-2"><label class="form-label small mb-1" for="catchall-question">Question</label><input id="catchall-question" class="form-control form-control-sm" type="text"></div>' +
+      '<div class="mb-2"><label class="form-label small mb-1" for="catchall-subquestion">Subquestion</label><textarea id="catchall-subquestion" class="form-control form-control-sm" rows="2"></textarea></div>' +
+      '<div class="mb-2"><label class="form-label small mb-1" for="catchall-label">Label</label><input id="catchall-label" class="form-control form-control-sm" type="text"></div>' +
+      '<div class="mb-2"><label class="form-label small mb-1" for="catchall-datatype">Datatype</label><select id="catchall-datatype" class="form-select form-select-sm"><option value="">(none)</option><option value="text">text</option><option value="area">area</option><option value="yesno">yesno</option><option value="radio">radio</option><option value="checkboxes">checkboxes</option><option value="date">date</option><option value="email">email</option><option value="currency">currency</option><option value="integer">integer</option><option value="number">number</option></select></div>' +
+      '<div><label class="form-label small mb-1" for="catchall-options">Options (comma or one per line)</label><textarea id="catchall-options" class="form-control form-control-sm" rows="2"></textarea></div>' +
+      '<div class="mt-3 pt-2 border-top"><label class="form-label small mb-1" for="catchall-extra-filters">Additional filters</label><textarea id="catchall-extra-filters" class="form-control form-control-sm font-monospace" rows="4" placeholder="| default(&quot;&quot;) | title"></textarea><div class="d-flex gap-2 mt-2"><select id="catchall-filter-pick" class="form-select form-select-sm flex-grow-1"><option value="">Common filters</option></select><button type="button" id="catchall-filter-add" class="btn btn-sm btn-outline-secondary">Add</button></div><div class="form-text mt-1">Add filters in order. Example: <span class="font-monospace">| default("") | upper</span></div></div>' +
+      "</div>" +
+      '<div class="dl-modal-footer d-flex justify-content-end gap-2">' +
+      '<button type="button" id="catchall-cancel" class="btn btn-outline-secondary">Cancel</button>' +
+      '<button type="button" id="catchall-apply" class="btn btn-primary">Apply Catchall</button>' +
+      "</div>" +
+      "</div>";
+    document.body.appendChild(modal);
+    modal.addEventListener("click", function (evt) {
+      if (evt.target === modal) modal.classList.add("hidden");
+    });
+    document
+      .getElementById("catchall-close")
+      .addEventListener("click", function () {
+        modal.classList.add("hidden");
+      });
+    document
+      .getElementById("catchall-cancel")
+      .addEventListener("click", function () {
+        modal.classList.add("hidden");
+      });
+    return modal;
+  }
+
+  function openCatchallDialog(targetInput) {
+    var input = targetInput;
+    if (!input) return;
+    var raw = String(input.value || "").trim();
+    var innerExpression = expressionInsideBraces(raw);
+    if (!innerExpression || raw.startsWith("{%")) {
+      showError(
+        "Catchall filters apply to variable expressions like {{ variable_name }}.",
+      );
+      return;
+    }
+    var parsed = getCatchallEditorState(innerExpression);
+    var modal = ensureCatchallDialog();
+    modal.classList.remove("hidden");
+    document.getElementById("catchall-question").value =
+      parsed.catchall.question || "";
+    document.getElementById("catchall-subquestion").value =
+      parsed.catchall.subquestion || "";
+    document.getElementById("catchall-label").value =
+      parsed.catchall.label || "";
+    document.getElementById("catchall-datatype").value =
+      parsed.catchall.datatype || "";
+    document.getElementById("catchall-options").value =
+      parsed.catchall.options || "";
+    document.getElementById("catchall-extra-filters").value =
+      parsed.extraFilters.join(" | ");
+    var pick = document.getElementById("catchall-filter-pick");
+    if (pick) {
+      pick.innerHTML = '<option value="">Common filters</option>';
+      COMMON_FILTER_SNIPPETS.forEach(function (item) {
+        var option = document.createElement("option");
+        option.value = item.value;
+        option.textContent = item.label;
+        pick.appendChild(option);
+      });
+      pick.value = "";
+    }
+    var addBtn = document.getElementById("catchall-filter-add");
+    if (addBtn && pick) {
+      addBtn.onclick = function () {
+        insertFilterSnippet(
+          document.getElementById("catchall-extra-filters"),
+          pick.value,
+        );
+        pick.value = "";
+      };
+    }
+    document.getElementById("catchall-apply").onclick = function () {
+      var updated = buildCatchallExpression(parsed.base, {
+        question: document.getElementById("catchall-question").value.trim(),
+        subquestion: document
+          .getElementById("catchall-subquestion")
+          .value.trim(),
+        label: document.getElementById("catchall-label").value.trim(),
+        datatype: document.getElementById("catchall-datatype").value.trim(),
+        options: document.getElementById("catchall-options").value.trim(),
+        additionalFilters: document
+          .getElementById("catchall-extra-filters")
+          .value.trim(),
+      });
+      if (!updated) return;
+      input.value = updated;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      modal.classList.add("hidden");
+      input.focus();
+    };
+  }
+
+  // ================================================================
+  // Bulk find & replace
+  // ================================================================
+  function previewBulkReplace() {
+    var find = document.getElementById("bulk-find").value;
+    var replace = document.getElementById("bulk-replace").value;
+    if (!find) {
+      document.getElementById("bulk-preview").classList.add("hidden");
+      return;
+    }
+    try {
+      var regex = new RegExp(find, "g");
+      var previewList = document.getElementById("bulk-preview-list");
+      previewList.innerHTML = "";
+      var matchCount = 0;
+      state.existingLabels.forEach(function (label) {
+        var inner = label.current.replace(/^\{\{\s*|\s*\}\}$/g, "");
+        if (regex.test(inner)) {
+          regex.lastIndex = 0;
+          var newInner = inner.replace(regex, replace);
+          var newLabel = "{{ " + newInner + " }}";
+          var div = document.createElement("div");
+          div.className = "font-monospace";
+          div.innerHTML =
+            '<span class="text-danger text-decoration-line-through">' +
+            escapeHtml(label.current) +
+            '</span><span class="text-muted mx-1">\u2192</span><span class="text-success">' +
+            escapeHtml(newLabel) +
+            "</span>";
+          previewList.appendChild(div);
+          matchCount++;
+        }
+      });
+      if (matchCount > 0) {
+        document.getElementById("bulk-preview").classList.remove("hidden");
+      } else {
+        previewList.innerHTML =
+          '<span class="text-muted">No matches found</span>';
+        document.getElementById("bulk-preview").classList.remove("hidden");
+      }
+    } catch (e) {
+      document.getElementById("bulk-preview-list").innerHTML =
+        '<span class="text-danger">Invalid regex: ' + e.message + "</span>";
+      document.getElementById("bulk-preview").classList.remove("hidden");
+    }
+  }
+
+  function applyBulkReplace() {
+    var find = document.getElementById("bulk-find").value;
+    var replace = document.getElementById("bulk-replace").value;
+    if (!find) return;
+    try {
+      var regex = new RegExp(find, "g");
+      state.existingLabels.forEach(function (label) {
+        var inner = label.current.replace(/^\{\{\s*|\s*\}\}$/g, "");
+        if (regex.test(inner)) {
+          regex.lastIndex = 0;
+          var newInner = inner.replace(regex, replace);
+          label.current = "{{ " + newInner + " }}";
+        }
+      });
+      bulkReplaceModal.classList.add("hidden");
+      renderExistingLabelsTree();
+      updatePreview();
+      scheduleSyntaxValidation();
+    } catch (e) {
+      alert("Invalid regex: " + e.message);
+    }
+  }
+
+  // ================================================================
+  // AI suggestions
+  // ================================================================
+  async function fetchSuggestions() {
+    if (!state.auth.aiEnabled) {
+      suggestionsList.innerHTML =
+        '<div class="alert alert-warning">AI suggestions require login.</div>';
+      return;
+    }
+    var selectedSourceState = getActiveInterviewSourceState();
+    if (
+      state.settings.usePlaygroundVariables &&
+      !selectedSourceState.selectedFile
+    ) {
+      suggestionsList.innerHTML =
+        '<div class="alert alert-warning">Select an interview before using interview variable names.</div>';
+      return;
+    }
+    var formData = new FormData();
+    formData.append("file", state.file);
+    formData.append(
+      "defragment_runs",
+      state.settings.defragmentRuns ? "true" : "false",
+    );
+    if (state.settings.additionalInstructions)
+      formData.append(
+        "additional_instructions",
+        state.settings.additionalInstructions,
+      );
+    if (state.settings.contextText)
+      formData.append("context_text", state.settings.contextText);
+    if (state.settings.customPeople)
+      formData.append("custom_people_names", state.settings.customPeople);
+    if (state.settings.primaryPersonVariable)
+      formData.append(
+        "primary_person_variable",
+        state.settings.primaryPersonVariable,
+      );
+    formData.append(
+      "prompt_profile",
+      state.settings.promptProfile || "standard",
+    );
+    formData.append("model", state.settings.model);
+    if (state.settings.judgeModel)
+      formData.append("judge_model", state.settings.judgeModel);
+    if (state.settings.usePlaygroundVariables) {
+      if (!selectedSourceState.variables.length) {
+        suggestionsList.innerHTML =
+          '<div class="alert alert-warning">No interview variables were found for the selected interview.</div>';
+        return;
+      }
+      formData.append("use_playground_variables", "true");
+      formData.append("interview_source_mode", state.interviewSourceMode);
+      formData.append(
+        "preferred_variable_names",
+        JSON.stringify(selectedSourceState.variables),
+      );
+      if (state.interviewSourceMode === "installed") {
+        formData.append("installed_package", state.installed.selectedPackage);
+        formData.append("installed_yaml_file", state.installed.selectedFile);
+        formData.append(
+          "installed_interview_path",
+          state.installed.selectedPackage + ":" + state.installed.selectedFile,
+        );
+      } else {
+        formData.append("playground_project", state.playground.selectedProject);
+        formData.append("playground_yaml_file", state.playground.selectedFile);
+      }
+    }
+    if (state.settings.generationMethod === "single") {
+      formData.append(
+        "generator_models",
+        JSON.stringify([state.settings.model]),
+      );
+    } else if (state.settings.generationMethod === "multi_model") {
+      var generatorModels = parseGeneratorModelsInput(
+        state.settings.generatorModels,
+      );
+      if (generatorModels.length === 0)
+        generatorModels = [state.settings.model];
+      formData.append("generator_models", JSON.stringify(generatorModels));
+    }
+    try {
+      var manualSuggestions = state.suggestions.filter(function (suggestion) {
+        return isManualSuggestion(suggestion);
+      });
+      var data = await requestAsyncLabelerAction(
+        "/al/docx-labeler/api/suggest-labels",
+        formData,
+        "AI labeling is running in the background...",
+      );
+      state.suggestions = manualSuggestions.concat(
+        (data.suggestions || []).map(function (s) {
+          return Object.assign({}, s, {
+            id: s.id || generateId(),
+            status: "pending",
+          });
+        }),
+      );
+      state.validation = data.validation || null;
+      suggestionsCount.textContent = state.suggestions.length;
+      renderSuggestions();
+    } catch (error) {
+      console.error("Error fetching suggestions:", error);
+      state.validation = null;
+      suggestionsList.innerHTML =
+        '<div class="alert alert-danger">' +
+        escapeHtml(error.message) +
+        "</div>";
+    }
+  }
+
+  function renderSuggestions() {
+    suggestionsList.innerHTML = "";
+    renderManualLabels();
+    var deterministic =
+      state.validation && state.validation.deterministic
+        ? state.validation.deterministic
+        : null;
+    var syntaxValidation =
+      deterministic && deterministic.syntax_validation
+        ? deterministic.syntax_validation
+        : null;
+    var documentWarnings =
+      state.validation && Array.isArray(state.validation.document_warnings)
+        ? state.validation.document_warnings
+        : [];
+    var aggregation =
+      state.validation && state.validation.aggregation
+        ? state.validation.aggregation
+        : null;
+    var aiSuggestions = state.suggestions.filter(function (suggestion) {
+      return !isManualSuggestion(suggestion);
+    });
+    if (
+      (deterministic && deterministic.flagged_count > 0) ||
+      documentWarnings.length > 0 ||
+      aggregation ||
+      (syntaxValidation &&
+        ((syntaxValidation.error_count || 0) > 0 ||
+          (syntaxValidation.warning_count || 0) > 0))
+    ) {
+      var aiReview =
+        state.validation && state.validation.ai_review
+          ? state.validation.ai_review
+          : {};
+      var reviewedCount = Array.isArray(aiReview.reviews)
+        ? aiReview.reviews.length
+        : 0;
+      suggestionsValidation.classList.remove("hidden");
+      var summaryHtml = "";
+      if (aggregation) {
+        var confidenceCounts = aggregation.confidence_counts || {};
+        summaryHtml +=
+          "<div><strong>Aggregated " +
+          aiSuggestions.length +
+          "</strong> ranked suggestion" +
+          (aiSuggestions.length === 1 ? "" : "s") +
+          " from " +
+          escapeHtml(String(aggregation.generator_runs || 0)) +
+          " generation run" +
+          ((aggregation.generator_runs || 0) === 1 ? "" : "s") +
+          ".</div>" +
+          '<div class="mt-1">Confidence tiers: ' +
+          '<span class="badge bg-success-subtle text-success-emphasis border border-success-subtle me-1">High ' +
+          escapeHtml(String(confidenceCounts.high || 0)) +
+          "</span>" +
+          '<span class="badge bg-warning-subtle text-warning-emphasis border border-warning-subtle me-1">Medium ' +
+          escapeHtml(String(confidenceCounts.medium || 0)) +
+          "</span>" +
+          '<span class="badge bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle">Low ' +
+          escapeHtml(String(confidenceCounts.low || 0)) +
+          "</span>" +
+          "</div>";
+        if (aggregation.ambiguous_group_count) {
+          summaryHtml +=
+            '<div class="mt-1">Judge reviewed ' +
+            escapeHtml(String(reviewedCount)) +
+            " ambiguous group" +
+            (reviewedCount === 1 ? "" : "s") +
+            ".</div>";
+        }
+      }
+      if (deterministic && deterministic.flagged_count > 0) {
+        summaryHtml +=
+          '<div class="mt-1"><strong>Validator flagged ' +
+          deterministic.flagged_count +
+          "</strong> selected suggestion" +
+          (deterministic.flagged_count === 1 ? "" : "s") +
+          ".</div>";
+      }
+      if (syntaxValidation && (syntaxValidation.error_count || 0) > 0) {
+        summaryHtml +=
+          '<div class="mt-1"><strong>Final template syntax errors:</strong></div>';
+        syntaxValidation.errors.forEach(function (issue) {
+          summaryHtml +=
+            "<div>" +
+            escapeHtml(issue.message || issue.code || "Syntax error") +
+            "</div>";
+        });
+      } else if (
+        syntaxValidation &&
+        (syntaxValidation.warning_count || 0) > 0
+      ) {
+        summaryHtml +=
+          '<div class="mt-1"><strong>Final template warnings:</strong></div>';
+        syntaxValidation.warnings.forEach(function (issue) {
+          summaryHtml +=
+            "<div>" +
+            escapeHtml(issue.message || issue.code || "Warning") +
+            "</div>";
+        });
+      }
+      if (documentWarnings.length > 0) {
+        summaryHtml +=
+          '<div class="mt-1"><strong>Source document warnings:</strong></div>';
+        documentWarnings.forEach(function (warning) {
+          summaryHtml +=
+            "<div>" +
+            escapeHtml(warning.message || warning.code || "Document warning") +
+            "</div>";
+        });
+      }
+      suggestionsValidation.innerHTML = summaryHtml;
+    } else {
+      suggestionsValidation.classList.add("hidden");
+      suggestionsValidation.textContent = "";
+    }
+    var hiddenLowConfidenceCount = 0;
+    // Count only visible (non-companion) suggestions
+    var visibleCount = aiSuggestions.filter(function (s) {
+      if (s._isCompanion) return false;
+      if (
+        !state.settings.showLowConfidence &&
+        (s.confidence || "low") === "low"
+      ) {
+        hiddenLowConfidenceCount += 1;
+        return false;
+      }
+      return true;
+    }).length;
+    suggestionsCount.textContent = visibleCount;
+    lowConfidenceSummary.textContent =
+      hiddenLowConfidenceCount > 0
+        ? hiddenLowConfidenceCount +
+          " low confidence suggestion" +
+          (hiddenLowConfidenceCount === 1 ? "" : "s") +
+          " hidden"
+        : "";
+    if (visibleCount === 0) {
+      suggestionsList.innerHTML =
+        hiddenLowConfidenceCount > 0
+          ? '<p class="text-muted text-center py-5">Only low confidence suggestions are available. Turn on “Show low confidence” to review them.</p>'
+          : '<p class="text-muted text-center py-5">No suggestions available.</p>';
+      return;
+    }
+    state.suggestions.forEach(function (suggestion, index) {
+      // Skip companion entries – they’re part of a multi-run group
+      if (suggestion._isCompanion) return;
+      if (isManualSuggestion(suggestion)) return;
+      if (
+        !state.settings.showLowConfidence &&
+        (suggestion.confidence || "low") === "low"
+      )
+        return;
+
+      var div = document.createElement("div");
+      var stateClass =
+        suggestion.status === "accepted"
+          ? "suggestion-accepted"
+          : suggestion.status === "rejected"
+            ? "suggestion-rejected"
+            : "suggestion-pending";
+      div.className = "p-3 rounded border border-2 mb-2 " + stateClass;
+
+      var locationLabel = suggestion.group
+        ? '<span class="small text-muted">Selection \u2192 ' +
+          escapeHtml(suggestion._displayLabel || suggestion.text) +
+          "</span>"
+        : '<span class="small text-muted">Para ' +
+          suggestion.paragraph +
+          ", Run " +
+          suggestion.run +
+          "</span>";
+      var validationFlags = Array.isArray(suggestion.validation_flags)
+        ? suggestion.validation_flags
+        : [];
+      var judgeReview = suggestion.judge_review || null;
+      var confidenceMeta = getConfidenceMeta(suggestion.confidence || "low");
+      var supportHtml = "";
+      if (!suggestion.group && suggestion.vote_total) {
+        supportHtml =
+          '<span class="badge ' +
+          confidenceMeta.badge +
+          '">' +
+          escapeHtml(confidenceMeta.label) +
+          "</span>" +
+          '<span class="badge text-bg-light border ms-1">' +
+          escapeHtml(String(suggestion.clean_vote_count || 0)) +
+          "/" +
+          escapeHtml(String(suggestion.vote_total || 0)) +
+          " clean votes</span>";
+        var sourceSummary = summarizeSuggestionSources(suggestion);
+        if (sourceSummary) {
+          supportHtml +=
+            '<div class="small text-muted mt-1">Sources: ' +
+            escapeHtml(sourceSummary) +
+            "</div>";
+        }
+      }
+      var reviewHtml = "";
+      if (validationFlags.length > 0) {
+        reviewHtml += '<div class="alert alert-warning small mt-2 mb-2 py-2">';
+        reviewHtml += '<div class="fw-semibold mb-1">Validator flags</div>';
+        validationFlags.forEach(function (flag) {
+          reviewHtml +=
+            "<div>" +
+            escapeHtml(flag.message || flag.code || "Flagged") +
+            "</div>";
+        });
+        if (judgeReview && judgeReview.reason) {
+          reviewHtml +=
+            '<div class="mt-2"><span class="fw-semibold">Judge:</span> ' +
+            escapeHtml(judgeReview.reason) +
+            "</div>";
+        }
+        reviewHtml += "</div>";
+      } else if (judgeReview && judgeReview.reason) {
+        reviewHtml +=
+          '<div class="small text-muted mt-2">Judge note: ' +
+          escapeHtml(judgeReview.reason) +
+          "</div>";
+      }
+
+      var alternates = Array.isArray(suggestion.alternates)
+        ? suggestion.alternates
+        : [];
+      var alternatesHtml = "";
+      if (!suggestion.group && alternates.length > 0) {
+        alternatesHtml +=
+          '<details class="mt-2"><summary class="small fw-semibold">Alternates (' +
+          alternates.length +
+          ")</summary>";
+        alternates.forEach(function (alternate, altIndex) {
+          var alternateMeta = getConfidenceMeta(alternate.confidence || "low");
+          var alternateFlags = Array.isArray(alternate.validation_flags)
+            ? alternate.validation_flags
+            : [];
+          alternatesHtml +=
+            '<div class="border rounded p-2 mt-2 bg-light-subtle">' +
+            '<div class="d-flex justify-content-between align-items-start gap-2">' +
+            '<div class="font-monospace small break-all flex-grow-1">' +
+            escapeHtml(alternate.text || "") +
+            "</div>" +
+            '<button type="button" class="btn btn-sm btn-outline-primary use-alternate-btn" data-index="' +
+            index +
+            '" data-alt-index="' +
+            altIndex +
+            '">Use</button>' +
+            "</div>" +
+            '<div class="mt-2">' +
+            '<span class="badge ' +
+            alternateMeta.badge +
+            '">' +
+            escapeHtml(alternateMeta.label) +
+            "</span>" +
+            '<span class="badge text-bg-light border ms-1">' +
+            escapeHtml(String(alternate.clean_vote_count || 0)) +
+            "/" +
+            escapeHtml(
+              String(alternate.vote_total || suggestion.vote_total || 0),
+            ) +
+            " clean votes</span>" +
+            "</div>";
+          if (alternateFlags.length > 0) {
+            alternatesHtml += '<div class="small text-warning-emphasis mt-1">';
+            alternateFlags.forEach(function (flag) {
+              alternatesHtml +=
+                "<div>" +
+                escapeHtml(flag.message || flag.code || "Flagged") +
+                "</div>";
             });
+            alternatesHtml += "</div>";
+          }
+          alternatesHtml += "</div>";
         });
-        playgroundProjectSelect.addEventListener('change', async function() {
-            state.playground.selectedProject = playgroundProjectSelect.value || 'default';
-            state.playground.selectedFile = '';
-            await fetchPlaygroundFiles();
-        });
-        playgroundYamlFileSelect.addEventListener('change', async function() {
-            state.playground.selectedFile = playgroundYamlFileSelect.value || '';
-            await fetchPlaygroundVariables();
-        });
-        installedPackageSelect.addEventListener('change', async function() {
-            state.installed.selectedPackage = installedPackageSelect.value || '';
-            state.installed.selectedFile = '';
-            await fetchInstalledFiles();
-        });
-        installedYamlFileSelect.addEventListener('change', async function() {
-            state.installed.selectedFile = installedYamlFileSelect.value || '';
-            await fetchInstalledVariables();
-        });
-        usePlaygroundVariablesInput.addEventListener('change', function() {
-            state.settings.usePlaygroundVariables = !!usePlaygroundVariablesInput.checked;
-        });
-        toggleLowConfidence.checked = !!state.settings.showLowConfidence;
-        toggleLowConfidence.addEventListener('change', function() {
-            state.settings.showLowConfidence = !!toggleLowConfidence.checked;
-            renderSuggestions();
-        });
-        [settingsModal, bulkReplaceModal, editLabelModal, utilitiesModal, repairModal].forEach(function(modal) {
-            modal.addEventListener('click', function(e) {
-                if (e.target === modal) {
-                    if (modal === settingsModal) {
-                        state.ui.editInterviewSourceInSettings = false;
-                        renderInterviewPicker();
-                    }
-                    modal.classList.add('hidden');
-                }
-            });
-        });
+        alternatesHtml += "</details>";
+      }
 
-        // Selection popover events
-        previewContent.addEventListener('mouseup', onPreviewMouseUp);
-        document.getElementById('sel-close').addEventListener('click', hideSelectionPopover);
-        document.getElementById('sel-cancel').addEventListener('click', hideSelectionPopover);
-        document.getElementById('sel-save').addEventListener('click', saveSelectionLabel);
-        selVarInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); saveSelectionLabel(); } });
-        document.getElementById('sel-tree-toggle').addEventListener('click', function() {
-            if (selVarPanel.classList.contains('hidden')) {
-                selVarPanel.classList.remove('hidden');
-                renderSelPopoverTree();
-            } else {
-                selVarPanel.classList.add('hidden');
-            }
+      div.innerHTML =
+        '<div class="d-flex align-items-start justify-content-between gap-2 mb-2">' +
+        locationLabel +
+        '<div class="d-flex gap-1">' +
+        '<button class="accept-btn btn btn-sm ' +
+        (suggestion.status === "accepted"
+          ? "btn-success"
+          : "btn-outline-secondary") +
+        '" data-index="' +
+        index +
+        '">\u2713</button>' +
+        '<button class="reject-btn btn btn-sm ' +
+        (suggestion.status === "rejected"
+          ? "btn-danger"
+          : "btn-outline-secondary") +
+        '" data-index="' +
+        index +
+        '">\u2717</button>' +
+        (suggestion.group
+          ? '<button class="remove-btn btn btn-sm btn-outline-danger" data-index="' +
+            index +
+            '" title="Remove">\u2716</button>'
+          : "") +
+        "</div>" +
+        "</div>" +
+        (suggestion._selectedText
+          ? '<div class="small text-muted mb-1">\u201C' +
+            escapeHtml(suggestion._selectedText) +
+            "\u201D</div>"
+          : "") +
+        (supportHtml ? '<div class="mb-2">' + supportHtml + "</div>" : "") +
+        '<div class="font-monospace small break-all">' +
+        escapeHtml(suggestion._displayLabel || suggestion.text) +
+        "</div>" +
+        reviewHtml +
+        alternatesHtml +
+        (suggestion.group
+          ? ""
+          : '<input type="text" class="edit-input form-control form-control-sm font-monospace mt-2' +
+            (suggestion.status === "rejected" ? " hidden" : "") +
+            '" value="' +
+            escapeHtml(suggestion.text) +
+            '" data-index="' +
+            index +
+            '">');
+      suggestionsList.appendChild(div);
+    });
+    suggestionsList.querySelectorAll(".accept-btn").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var index = parseInt(btn.dataset.index);
+        var s = state.suggestions[index];
+        var newStatus = s.status === "accepted" ? "pending" : "accepted";
+        s.status = newStatus;
+        // Propagate to companions in same group
+        if (s.group) {
+          state.suggestions.forEach(function (c) {
+            if (c.group === s.group) c.status = newStatus;
+          });
+        }
+        renderSuggestions();
+        updatePreview();
+        updateDownloadButton();
+        scheduleSyntaxValidation();
+      });
+    });
+    suggestionsList.querySelectorAll(".reject-btn").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var index = parseInt(btn.dataset.index);
+        var s = state.suggestions[index];
+        var newStatus = s.status === "rejected" ? "pending" : "rejected";
+        s.status = newStatus;
+        if (s.group) {
+          state.suggestions.forEach(function (c) {
+            if (c.group === s.group) c.status = newStatus;
+          });
+        }
+        renderSuggestions();
+        updatePreview();
+        updateDownloadButton();
+        scheduleSyntaxValidation();
+      });
+    });
+    // Remove button deletes grouped selection labels entirely
+    suggestionsList.querySelectorAll(".remove-btn").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var index = parseInt(btn.dataset.index);
+        var grp = state.suggestions[index].group;
+        if (grp) {
+          state.suggestions = state.suggestions.filter(function (c) {
+            return c.group !== grp;
+          });
+        } else {
+          state.suggestions.splice(index, 1);
+        }
+        renderSuggestions();
+        updatePreview();
+        updateDownloadButton();
+        scheduleSyntaxValidation();
+      });
+    });
+    suggestionsList.querySelectorAll(".edit-input").forEach(function (input) {
+      input.addEventListener("input", function () {
+        var index = parseInt(input.dataset.index);
+        state.suggestions[index].text = input.value;
+        updatePreview();
+        scheduleSyntaxValidation(500);
+      });
+    });
+    suggestionsList
+      .querySelectorAll(".use-alternate-btn")
+      .forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var index = parseInt(btn.dataset.index);
+          var altIndex = parseInt(btn.dataset.altIndex);
+          swapSuggestionWithAlternate(state.suggestions[index], altIndex);
+          renderSuggestions();
+          updatePreview();
+          updateDownloadButton();
+          scheduleSyntaxValidation();
         });
-        selVarSearch.addEventListener('input', function(e) { renderSelPopoverTree(e.target.value); });
-        // Close popover on outside click
-        document.addEventListener('mousedown', function(e) {
-            if (!selPopover.classList.contains('hidden') && !selPopover.contains(e.target) && !previewContent.contains(e.target)) {
-                hideSelectionPopover();
-            }
-            var authMenu = document.getElementById('auth-menu');
-            var authMenuBtn = document.getElementById('auth-menu-btn');
-            if (authMenu && authMenuBtn && !authControls.contains(e.target)) {
-                authMenu.classList.remove('show');
-            }
-        });
+      });
+    updateDownloadButton();
+  }
 
-        // Drag & drop
-        var dropZone = document.querySelector('aside');
-        dropZone.addEventListener('dragover', function(e) { e.preventDefault(); dropZone.classList.add('drag-over'); });
-        dropZone.addEventListener('dragleave', function() { dropZone.classList.remove('drag-over'); });
-        dropZone.addEventListener('drop', function(e) {
-            e.preventDefault();
-            dropZone.classList.remove('drag-over');
-            var file = e.dataTransfer.files[0];
-            if (file && file.name.endsWith('.docx')) processFile(file);
+  // ================================================================
+  // Playground open / save
+  // ================================================================
+  async function openDocxPlaygroundModal() {
+    if (!state.auth.isAuthenticated) {
+      showError("Login required to access Playground.");
+      return;
+    }
+    // Show modal immediately with loading states
+    var openPgProject = document.getElementById("open-pg-project");
+    var openPgTemplate = document.getElementById("open-pg-template");
+    openPgProject.innerHTML = '<option value="">Loading projects...</option>';
+    openPgTemplate.innerHTML =
+      '<option value="">Waiting for projects...</option>';
+    openPlaygroundModalEl.classList.remove("hidden");
+    // Load data in background
+    (async function () {
+      try {
+        await fetchPlaygroundProjects();
+        openPgProject.innerHTML = "";
+        state.playground.projects.forEach(function (proj) {
+          var opt = document.createElement("option");
+          opt.value = proj;
+          opt.textContent = proj;
+          opt.selected = proj === state.playground.selectedProject;
+          openPgProject.appendChild(opt);
         });
-
-        fetchModelCatalog();
-        fetchAuthStatus();
-        renderGenerationMethodFields();
-        updateModalSourceStatus();
+        await fetchDocxOpenPlaygroundTemplates();
+      } catch (e) {
+        console.error("Error loading playground data:", e);
+        openPgProject.innerHTML =
+          '<option value="">(error loading projects)</option>';
+        openPgTemplate.innerHTML =
+          '<option value="">(error loading templates)</option>';
+      }
     })();
+  }
+
+  async function fetchDocxOpenPlaygroundTemplates() {
+    var openPgProject = document.getElementById("open-pg-project");
+    var openPgTemplate = document.getElementById("open-pg-template");
+    var project = openPgProject.value || "default";
+    openPgTemplate.innerHTML = '<option value="">Loading...</option>';
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath(
+          "playgroundTemplates",
+          "/al/labeler/api/playground-templates",
+        ) +
+          "?project=" +
+          encodeURIComponent(project) +
+          "&type=docx",
+      );
+      var templates =
+        data && data.success && data.data && Array.isArray(data.data.templates)
+          ? data.data.templates
+          : [];
+      openPgTemplate.innerHTML = "";
+      if (templates.length === 0) {
+        var opt = document.createElement("option");
+        opt.value = "";
+        opt.textContent = "(no DOCX templates found)";
+        openPgTemplate.appendChild(opt);
+        return;
+      }
+      templates.forEach(function (t) {
+        var opt = document.createElement("option");
+        opt.value = t.filename;
+        opt.textContent =
+          t.filename +
+          (t.size ? " (" + Math.round(t.size / 1024) + " KB)" : "");
+        openPgTemplate.appendChild(opt);
+      });
+    } catch (_e) {
+      openPgTemplate.innerHTML =
+        '<option value="">(error loading templates)</option>';
+    }
+  }
+
+  async function maybeOpenInitialPlaygroundTemplate() {
+    if (!state.auth.isAuthenticated) return;
+    if (state.initialPlaygroundSource.attempted) return;
+    var project = state.initialPlaygroundSource.project;
+    var filename = state.initialPlaygroundSource.filename;
+    if (!project || !filename) {
+      state.initialPlaygroundSource.attempted = true;
+      return;
+    }
+    state.initialPlaygroundSource.attempted = true;
+    if (state.playground.projects.indexOf(project) === -1) return;
+    state.playground.selectedProject = project;
+    renderInterviewPicker();
+    await openDocxTemplateFromPlayground(project, filename, {
+      showSuccess: false,
+    });
+  }
+
+  async function confirmOpenFromPlayground() {
+    var openPgProject = document.getElementById("open-pg-project");
+    var openPgTemplate = document.getElementById("open-pg-template");
+    var project = openPgProject.value || "default";
+    var filename = openPgTemplate.value;
+    if (!filename) {
+      showError("Select a template file.");
+      return;
+    }
+    openPlaygroundModalEl.classList.add("hidden");
+    await openDocxTemplateFromPlayground(project, filename);
+  }
+
+  async function openDocxTemplateFromPlayground(project, filename, options) {
+    options = options || {};
+    showLoading("Loading " + filename + " from Playground...");
+    try {
+      var data = await fetchJsonOrThrow(
+        endpointPath(
+          "playgroundTemplatesLoad",
+          "/al/labeler/api/playground-templates/load",
+        ) +
+          "?project=" +
+          encodeURIComponent(project) +
+          "&filename=" +
+          encodeURIComponent(filename),
+      );
+      if (!data.success || !data.data || !data.data.file_content_base64) {
+        throw new Error(
+          (data.error && data.error.message) || "Failed to load template.",
+        );
+      }
+      var binaryString = atob(data.data.file_content_base64);
+      var bytes = new Uint8Array(binaryString.length);
+      for (var i = 0; i < binaryString.length; i++)
+        bytes[i] = binaryString.charCodeAt(i);
+      var blob = new Blob([bytes], {
+        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+      var file = new File([blob], filename, { type: blob.type });
+      state.playgroundSource = { project: project, filename: filename };
+      savePlaygroundBtn.classList.remove("hidden");
+      await processFile(file);
+    } catch (error) {
+      showError(
+        "Failed to load from Playground: " +
+          (error.message || "Unknown error."),
+      );
+    } finally {
+      hideLoading();
+    }
+  }
+
+  async function openSavePlaygroundModal() {
+    if (!state.auth.isAuthenticated) {
+      showError("Login required to save to Playground.");
+      return;
+    }
+    if (!state.file) {
+      showError("No DOCX file loaded.");
+      return;
+    }
+    // Show modal immediately
+    var savePgProject = document.getElementById("save-pg-project");
+    var savePgFilename = document.getElementById("save-pg-filename");
+    var savePgStatus = document.getElementById("save-pg-status");
+    savePgProject.innerHTML = '<option value="">Loading projects...</option>';
+    savePgFilename.value =
+      (state.playgroundSource && state.playgroundSource.filename) ||
+      (state.file && state.file.name) ||
+      "template.docx";
+    if (!savePgFilename.value.toLowerCase().endsWith(".docx"))
+      savePgFilename.value += ".docx";
+    savePgStatus.classList.add("hidden");
+    savePlaygroundModalEl.classList.remove("hidden");
+    // Load projects in background
+    (async function () {
+      try {
+        await fetchPlaygroundProjects();
+        savePgProject.innerHTML = "";
+        state.playground.projects.forEach(function (proj) {
+          var opt = document.createElement("option");
+          opt.value = proj;
+          opt.textContent = proj;
+          opt.selected =
+            proj ===
+            ((state.playgroundSource && state.playgroundSource.project) ||
+              state.playground.selectedProject);
+          savePgProject.appendChild(opt);
+        });
+      } catch (e) {
+        console.error("Error loading projects:", e);
+        savePgProject.innerHTML =
+          '<option value="">(error loading projects)</option>';
+      }
+    })();
+  }
+
+  async function confirmSaveToPlayground() {
+    var savePgProject = document.getElementById("save-pg-project");
+    var savePgFilename = document.getElementById("save-pg-filename");
+    var savePgStatus = document.getElementById("save-pg-status");
+    var project = savePgProject.value || "default";
+    var filename = savePgFilename.value.trim();
+    if (!filename || !filename.toLowerCase().endsWith(".docx")) {
+      savePgStatus.textContent = "Filename must end with .docx";
+      savePgStatus.classList.remove("hidden");
+      return;
+    }
+    savePlaygroundModalEl.classList.add("hidden");
+    showLoading("Saving to Playground...");
+    try {
+      var syntaxCheck = await ensureSyntaxValidationBeforeWrite(
+        "saving to Playground",
+      );
+      if (!syntaxCheck.allowed) {
+        hideLoading();
+        return;
+      }
+      // First apply any pending changes via the apply-labels endpoint
+      var renames = collectRenamePayload();
+      var acceptedLabels = collectAcceptedLabels();
+
+      var docxBase64;
+      var applyHighlights = acceptedLabels.length > 0;
+      if (renames.length > 0 || acceptedLabels.length > 0) {
+        var formData = new FormData();
+        formData.append("file", state.file);
+        formData.append(
+          "defragment_runs",
+          state.settings.defragmentRuns ? "true" : "false",
+        );
+        if (renames.length > 0)
+          formData.append("renames", JSON.stringify(renames));
+        if (acceptedLabels.length > 0)
+          formData.append("labels", JSON.stringify(acceptedLabels));
+        if (applyHighlights) formData.append("apply_highlights", "true");
+        if (syntaxCheck.allowInvalidSyntax)
+          formData.append("allow_invalid_syntax", "true");
+        var applyResponse = await fetch("/al/docx-labeler/api/apply-labels", {
+          method: "POST",
+          body: formData,
+        });
+        var applyData = await parseApiResponse(applyResponse);
+        docxBase64 = applyData.data.docx_base64;
+      } else {
+        // No changes - send the original file as base64
+        var arrayBuffer = await state.file.arrayBuffer();
+        var bytes = new Uint8Array(arrayBuffer);
+        var raw = "";
+        for (var i = 0; i < bytes.length; i++)
+          raw += String.fromCharCode(bytes[i]);
+        docxBase64 = window.btoa(raw);
+      }
+
+      var response = await fetch(
+        endpointPath(
+          "playgroundTemplatesSave",
+          "/al/labeler/api/playground-templates/save",
+        ),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "X-WFD-Action": "1",
+          },
+          body: JSON.stringify({
+            project: project,
+            filename: filename,
+            file_content_base64: docxBase64,
+          }),
+          credentials: "same-origin",
+        },
+      );
+      var data = await response.json();
+      if (!data.success)
+        throw new Error((data.error && data.error.message) || "Save failed.");
+      state.playgroundSource = { project: project, filename: filename };
+      savePlaygroundBtn.classList.remove("hidden");
+      downloadStatus.textContent =
+        (data.data && data.data.created ? "Created" : "Updated") +
+        " " +
+        filename +
+        " in Playground.";
+      downloadStatus.classList.remove("hidden");
+    } catch (error) {
+      showError(
+        "Save to Playground failed: " + (error.message || "Unknown error."),
+      );
+    } finally {
+      hideLoading();
+    }
+  }
+
+  // ================================================================
+  // Download
+  // ================================================================
+  function updateDownloadButton() {
+    var hasChanges =
+      collectRenamePayload().length > 0 || collectAcceptedLabels().length > 0;
+    downloadBtn.disabled = !hasChanges;
+    applyHighlightsBtn.disabled = !state.file;
+    // Save to Playground is enabled when a file is loaded (changes or not, the user may want to save the original)
+    savePlaygroundBtn.disabled = !state.file;
+  }
+
+  async function downloadDocument(options) {
+    options = options || {};
+    if (!state.file) return;
+    var renames = collectRenamePayload();
+    var acceptedLabels = collectAcceptedLabels();
+    var applyHighlights =
+      !!options.forceHighlights || acceptedLabels.length > 0;
+    if (
+      renames.length === 0 &&
+      acceptedLabels.length === 0 &&
+      !applyHighlights
+    ) {
+      alert("No changes to apply.");
+      return;
+    }
+    downloadStatus.textContent = "Processing...";
+    downloadStatus.classList.remove("hidden");
+    downloadBtn.disabled = true;
+    applyHighlightsBtn.disabled = true;
+    try {
+      var syntaxCheck = await ensureSyntaxValidationBeforeWrite(
+        "downloading this DOCX",
+      );
+      if (!syntaxCheck.allowed) {
+        downloadStatus.classList.add("hidden");
+        return;
+      }
+      var formData = new FormData();
+      formData.append("file", state.file);
+      formData.append(
+        "defragment_runs",
+        state.settings.defragmentRuns ? "true" : "false",
+      );
+      if (renames.length > 0)
+        formData.append("renames", JSON.stringify(renames));
+      if (acceptedLabels.length > 0)
+        formData.append("labels", JSON.stringify(acceptedLabels));
+      if (applyHighlights) formData.append("apply_highlights", "true");
+      if (syntaxCheck.allowInvalidSyntax)
+        formData.append("allow_invalid_syntax", "true");
+      var response = await fetch("/al/docx-labeler/api/apply-labels", {
+        method: "POST",
+        body: formData,
+      });
+      var data = await parseApiResponse(response);
+      var binaryString = atob(data.data.docx_base64);
+      var bytes = new Uint8Array(binaryString.length);
+      for (var i = 0; i < binaryString.length; i++)
+        bytes[i] = binaryString.charCodeAt(i);
+      var blob = new Blob([bytes], {
+        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement("a");
+      a.href = url;
+      a.download = data.data.filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      if (data.data.defragmented_before_apply && data.data.defragmentation) {
+        var paragraphCount =
+          data.data.defragmentation.paragraphs_defragmented || 0;
+        var runsRemoved = data.data.defragmentation.runs_removed || 0;
+        downloadStatus.textContent =
+          "Download complete. Consolidated fragmented runs in " +
+          paragraphCount +
+          " paragraph" +
+          (paragraphCount === 1 ? "" : "s") +
+          " before applying labels (" +
+          runsRemoved +
+          " runs merged).";
+      } else if (data.data.apply_highlights) {
+        downloadStatus.textContent = "Download complete with Jinja highlights.";
+      } else {
+        downloadStatus.textContent = "Download complete!";
+        setTimeout(function () {
+          downloadStatus.classList.add("hidden");
+        }, 2000);
+      }
+    } catch (error) {
+      console.error("Error downloading:", error);
+      downloadStatus.textContent = "Error: " + error.message;
+    } finally {
+      updateDownloadButton();
+    }
+  }
+
+  // ================================================================
+  // Event listeners
+  // ================================================================
+  fileInput.addEventListener("change", function (e) {
+    var file = e.target.files[0];
+    if (file) processFile(file);
+  });
+
+  // Playground open / save listeners
+  openPlaygroundBtn.addEventListener("click", openDocxPlaygroundModal);
+  savePlaygroundBtn.addEventListener("click", openSavePlaygroundModal);
+  document
+    .getElementById("open-pg-project")
+    .addEventListener("change", fetchDocxOpenPlaygroundTemplates);
+  document
+    .getElementById("open-pg-confirm")
+    .addEventListener("click", confirmOpenFromPlayground);
+  document
+    .getElementById("open-pg-cancel")
+    .addEventListener("click", function () {
+      openPlaygroundModalEl.classList.add("hidden");
+    });
+  document
+    .getElementById("close-open-playground")
+    .addEventListener("click", function () {
+      openPlaygroundModalEl.classList.add("hidden");
+    });
+  document
+    .getElementById("save-pg-confirm")
+    .addEventListener("click", confirmSaveToPlayground);
+  document
+    .getElementById("save-pg-cancel")
+    .addEventListener("click", function () {
+      savePlaygroundModalEl.classList.add("hidden");
+    });
+  document
+    .getElementById("close-save-playground")
+    .addEventListener("click", function () {
+      savePlaygroundModalEl.classList.add("hidden");
+    });
+  // Close playground modals on backdrop click
+  [openPlaygroundModalEl, savePlaygroundModalEl].forEach(function (modal) {
+    modal.addEventListener("click", function (e) {
+      if (e.target === modal) modal.classList.add("hidden");
+    });
+  });
+  utilitiesBtn.addEventListener("click", function () {
+    updateModalSourceStatus();
+    utilitiesResult.innerHTML = "";
+    utilitiesModal.classList.remove("hidden");
+  });
+  repairBtn.addEventListener("click", function () {
+    updateModalSourceStatus();
+    repairResult.innerHTML = "";
+    repairModal.classList.remove("hidden");
+  });
+  document
+    .getElementById("utilities-close")
+    .addEventListener("click", function () {
+      utilitiesModal.classList.add("hidden");
+    });
+  document
+    .getElementById("repair-close")
+    .addEventListener("click", function () {
+      repairModal.classList.add("hidden");
+    });
+  [
+    utilitySourceActive,
+    utilitySourceUpload,
+    repairSourceActive,
+    repairSourceUpload,
+  ].forEach(function (input) {
+    input.addEventListener("change", updateModalSourceStatus);
+  });
+  utilityFileInput.addEventListener("change", updateModalSourceStatus);
+  repairFileInput.addEventListener("change", updateModalSourceStatus);
+  document.querySelectorAll(".utility-action-btn").forEach(function (button) {
+    button.addEventListener("click", function () {
+      runDocxOperation(
+        "utility",
+        button.dataset.action,
+        "Running DOCX utility...",
+      );
+    });
+  });
+  document.querySelectorAll(".repair-action-btn").forEach(function (button) {
+    button.addEventListener("click", function () {
+      runDocxOperation(
+        "repair",
+        button.dataset.action,
+        "Running DOCX repair...",
+      );
+    });
+  });
+  tabExisting.addEventListener("click", function () {
+    switchTab("existing");
+  });
+  tabManual.addEventListener("click", function () {
+    switchTab("manual");
+  });
+  tabSuggestions.addEventListener("click", function () {
+    switchTab("suggestions");
+  });
+  document
+    .getElementById("accept-all-btn")
+    .addEventListener("click", function () {
+      state.suggestions.forEach(function (s) {
+        if (s.status === "pending") s.status = "accepted";
+      });
+      renderSuggestions();
+      updatePreview();
+    });
+  document
+    .getElementById("regenerate-btn")
+    .addEventListener("click", async function () {
+      if (!state.auth.aiEnabled) {
+        showError("AI suggestions require login.");
+        return;
+      }
+      if (state.file) {
+        showLoading("Regenerating suggestions...");
+        await fetchSuggestions();
+        hideLoading();
+        showMainPanel();
+      }
+    });
+  document
+    .getElementById("bulk-replace-btn")
+    .addEventListener("click", function () {
+      document.getElementById("bulk-find").value = "";
+      document.getElementById("bulk-replace").value = "";
+      document.getElementById("bulk-preview").classList.add("hidden");
+      bulkReplaceModal.classList.remove("hidden");
+    });
+  document
+    .getElementById("ai-relabel-btn")
+    .addEventListener("click", function () {
+      alert(
+        "AI Relabeling coming soon! This will use AI to suggest better AssemblyLine-compatible names for your existing labels.",
+      );
+    });
+  document
+    .getElementById("bulk-preview-btn")
+    .addEventListener("click", previewBulkReplace);
+  document
+    .getElementById("bulk-apply")
+    .addEventListener("click", applyBulkReplace);
+  document.getElementById("bulk-cancel").addEventListener("click", function () {
+    bulkReplaceModal.classList.add("hidden");
+  });
+  document.getElementById("edit-save").addEventListener("click", saveEditLabel);
+  document.getElementById("edit-cancel").addEventListener("click", function () {
+    editLabelModal.classList.add("hidden");
+    state.editingLabelId = null;
+  });
+  document.getElementById("edit-close").addEventListener("click", function () {
+    editLabelModal.classList.add("hidden");
+    state.editingLabelId = null;
+  });
+  variableSearch.addEventListener("input", function (e) {
+    renderVariableTree(
+      getEffectiveVariableTree(),
+      "",
+      variableTree,
+      e.target.value,
+    );
+  });
+  downloadBtn.addEventListener("click", function () {
+    downloadDocument();
+  });
+  applyHighlightsBtn.addEventListener("click", function () {
+    downloadDocument({ forceHighlights: true });
+  });
+  document
+    .getElementById("settings-btn")
+    .addEventListener("click", function () {
+      document.getElementById("additional-instructions").value =
+        state.settings.additionalInstructions;
+      document.getElementById("context-text").value =
+        state.settings.contextText || "";
+      document.getElementById("custom-people").value =
+        state.settings.customPeople;
+      promptProfileInput.value = state.settings.promptProfile || "standard";
+      generationMethodInput.value =
+        state.settings.generationMethod || "multi_run";
+      generatorModelsInput.value = state.settings.generatorModels || "";
+      judgeModelInput.value = state.settings.judgeModel || "";
+      document.getElementById("defragment-runs").checked =
+        !!state.settings.defragmentRuns;
+      usePlaygroundVariablesInput.checked =
+        !!state.settings.usePlaygroundVariables;
+      aiModelInput.value = state.settings.model;
+      state.ui.editInterviewSourceInSettings = false;
+      renderGenerationMethodFields();
+      renderInterviewPicker();
+      renderModelSuggestions("");
+      settingsModal.classList.remove("hidden");
+    });
+  document
+    .getElementById("close-settings")
+    .addEventListener("click", function () {
+      state.ui.editInterviewSourceInSettings = false;
+      renderInterviewPicker();
+      settingsModal.classList.add("hidden");
+    });
+  document
+    .getElementById("save-settings")
+    .addEventListener("click", function () {
+      state.settings.additionalInstructions = document.getElementById(
+        "additional-instructions",
+      ).value;
+      state.settings.contextText =
+        document.getElementById("context-text").value;
+      state.settings.customPeople =
+        document.getElementById("custom-people").value;
+      state.settings.promptProfile = promptProfileInput.value || "standard";
+      state.settings.generationMethod =
+        generationMethodInput.value || "multi_run";
+      state.settings.generatorModels = generatorModelsInput.value;
+      state.settings.judgeModel = judgeModelInput.value.trim();
+      state.settings.defragmentRuns =
+        !!document.getElementById("defragment-runs").checked;
+      state.settings.usePlaygroundVariables =
+        !!usePlaygroundVariablesInput.checked;
+      state.settings.model = aiModelInput.value.trim() || state.defaultModel;
+      state.ui.editInterviewSourceInSettings = false;
+      renderInterviewPicker();
+      settingsModal.classList.add("hidden");
+    });
+  document
+    .getElementById("reset-settings")
+    .addEventListener("click", function () {
+      document.getElementById("additional-instructions").value = "";
+      document.getElementById("context-text").value = "";
+      document.getElementById("custom-people").value = "";
+      promptProfileInput.value = "standard";
+      generationMethodInput.value = "multi_run";
+      generatorModelsInput.value = "";
+      judgeModelInput.value = "";
+      document.getElementById("defragment-runs").checked = true;
+      usePlaygroundVariablesInput.checked = false;
+      aiModelInput.value = state.defaultModel;
+      renderGenerationMethodFields();
+      renderInterviewPicker();
+      renderModelSuggestions("");
+    });
+  if (changeInterviewSourceBtn) {
+    changeInterviewSourceBtn.addEventListener("click", function () {
+      state.ui.editInterviewSourceInSettings =
+        !state.ui.editInterviewSourceInSettings;
+      renderInterviewPicker();
+    });
+  }
+  generationMethodInput.addEventListener(
+    "change",
+    renderGenerationMethodFields,
+  );
+  aiModelInput.addEventListener("input", function () {
+    renderModelSuggestions(aiModelInput.value);
+  });
+  aiModelInput.addEventListener("change", function () {
+    state.settings.model = aiModelInput.value.trim() || state.defaultModel;
+  });
+  interviewSourceModeInputs.forEach(function (input) {
+    input.addEventListener("change", async function () {
+      if (!input.checked) return;
+      state.interviewSourceMode =
+        input.value === "installed" ? "installed" : "playground";
+      renderInterviewPicker();
+      if (state.interviewSourceMode === "installed") {
+        if (!state.installed.packages.length) {
+          await fetchInstalledPackages();
+        } else if (state.installed.selectedFile) {
+          await fetchInstalledVariables();
+        }
+      } else {
+        if (!state.playground.projects.length) {
+          await fetchPlaygroundProjects();
+        } else if (state.playground.selectedFile) {
+          await fetchPlaygroundVariables();
+        }
+      }
+    });
+  });
+  playgroundProjectSelect.addEventListener("change", async function () {
+    state.playground.selectedProject =
+      playgroundProjectSelect.value || "default";
+    state.playground.selectedFile = "";
+    await fetchPlaygroundFiles();
+  });
+  playgroundYamlFileSelect.addEventListener("change", async function () {
+    state.playground.selectedFile = playgroundYamlFileSelect.value || "";
+    await fetchPlaygroundVariables();
+  });
+  installedPackageSelect.addEventListener("change", async function () {
+    state.installed.selectedPackage = installedPackageSelect.value || "";
+    state.installed.selectedFile = "";
+    await fetchInstalledFiles();
+  });
+  installedYamlFileSelect.addEventListener("change", async function () {
+    state.installed.selectedFile = installedYamlFileSelect.value || "";
+    await fetchInstalledVariables();
+  });
+  usePlaygroundVariablesInput.addEventListener("change", function () {
+    state.settings.usePlaygroundVariables =
+      !!usePlaygroundVariablesInput.checked;
+  });
+  toggleLowConfidence.checked = !!state.settings.showLowConfidence;
+  toggleLowConfidence.addEventListener("change", function () {
+    state.settings.showLowConfidence = !!toggleLowConfidence.checked;
+    renderSuggestions();
+  });
+  [
+    settingsModal,
+    bulkReplaceModal,
+    editLabelModal,
+    utilitiesModal,
+    repairModal,
+  ].forEach(function (modal) {
+    modal.addEventListener("click", function (e) {
+      if (e.target === modal) {
+        if (modal === settingsModal) {
+          state.ui.editInterviewSourceInSettings = false;
+          renderInterviewPicker();
+        }
+        modal.classList.add("hidden");
+      }
+    });
+  });
+
+  // Selection popover events
+  previewContent.addEventListener("mouseup", onPreviewMouseUp);
+  document
+    .getElementById("sel-close")
+    .addEventListener("click", hideSelectionPopover);
+  document
+    .getElementById("sel-cancel")
+    .addEventListener("click", hideSelectionPopover);
+  document
+    .getElementById("sel-save")
+    .addEventListener("click", saveSelectionLabel);
+  selVarInput.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveSelectionLabel();
+    }
+  });
+  document
+    .getElementById("sel-tree-toggle")
+    .addEventListener("click", function () {
+      if (selVarPanel.classList.contains("hidden")) {
+        selVarPanel.classList.remove("hidden");
+        renderSelPopoverTree();
+      } else {
+        selVarPanel.classList.add("hidden");
+      }
+    });
+  selVarSearch.addEventListener("input", function (e) {
+    renderSelPopoverTree(e.target.value);
+  });
+  // Close popover on outside click
+  document.addEventListener("mousedown", function (e) {
+    if (
+      !selPopover.classList.contains("hidden") &&
+      !selPopover.contains(e.target) &&
+      !previewContent.contains(e.target)
+    ) {
+      hideSelectionPopover();
+    }
+    var authMenu = document.getElementById("auth-menu");
+    var authMenuBtn = document.getElementById("auth-menu-btn");
+    if (authMenu && authMenuBtn && !authControls.contains(e.target)) {
+      authMenu.classList.remove("show");
+    }
+  });
+
+  // Drag & drop
+  var dropZone = document.querySelector("aside");
+  dropZone.addEventListener("dragover", function (e) {
+    e.preventDefault();
+    dropZone.classList.add("drag-over");
+  });
+  dropZone.addEventListener("dragleave", function () {
+    dropZone.classList.remove("drag-over");
+  });
+  dropZone.addEventListener("drop", function (e) {
+    e.preventDefault();
+    dropZone.classList.remove("drag-over");
+    var file = e.dataTransfer.files[0];
+    if (file && file.name.endsWith(".docx")) processFile(file);
+  });
+
+  fetchModelCatalog();
+  fetchAuthStatus();
+  renderGenerationMethodFields();
+  updateModalSourceStatus();
+})();

--- a/docassemble/ALDashboard/data/static/docx_labeler_preview_utils.js
+++ b/docassemble/ALDashboard/data/static/docx_labeler_preview_utils.js
@@ -1,324 +1,405 @@
-(function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
-        module.exports = factory();
-    } else {
-        root.DocxLabelerPreviewUtils = factory();
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    const target = /** @type {any} */ (root);
+    target.DocxLabelerPreviewUtils = factory();
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  function defaultEscapeHtml(str) {
+    return String(str || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function applyExistingLabelHighlightsByOccurrence(
+    html,
+    existingLabels,
+    escapeHtmlFn,
+  ) {
+    var esc = escapeHtmlFn || defaultEscapeHtml;
+    var output = String(html || "");
+    var byOriginal = {};
+    (existingLabels || []).forEach(function (label) {
+      if (!label || typeof label.original !== "string") return;
+      if (!byOriginal[label.original]) byOriginal[label.original] = [];
+      byOriginal[label.original].push(label);
+    });
+    Object.keys(byOriginal).forEach(function (original) {
+      var labels = byOriginal[original];
+      var encoded = esc(original);
+      var offset = 0;
+      labels.forEach(function (label) {
+        var cls =
+          label.current !== label.original
+            ? "highlight-accepted"
+            : "highlight-existing";
+        var span =
+          '<span class="' +
+          cls +
+          ' existing-inline-label" data-label-id="' +
+          esc(label.id) +
+          '">' +
+          esc(label.current) +
+          "</span>";
+        var pos = output.indexOf(encoded, offset);
+        if (pos === -1) return;
+        output =
+          output.substring(0, pos) +
+          span +
+          output.substring(pos + encoded.length);
+        offset = pos + span.length;
+      });
+    });
+    return output;
+  }
+
+  function shouldSuppressSelectionPopoverFromTarget(target) {
+    if (!target) return false;
+    var element = null;
+    if (typeof target.closest === "function") {
+      element = target;
+    } else if (
+      target.parentElement &&
+      typeof target.parentElement.closest === "function"
+    ) {
+      // Mouse events can target a text node inside the highlighted span.
+      element = target.parentElement;
     }
-}(typeof self !== 'undefined' ? self : this, function() {
-    function defaultEscapeHtml(str) {
-        return String(str || '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+    if (!element) return false;
+    return !!element.closest(".existing-inline-label");
+  }
+
+  function normalizeReplaceAllFlag(value) {
+    return value === true;
+  }
+
+  function formatManualWrapPreviewDisplay(
+    manualKind,
+    conditionExpression,
+    selectedText,
+    escapeHtmlFn,
+  ) {
+    var esc = escapeHtmlFn || defaultEscapeHtml;
+    var condition = String(conditionExpression || "").trim();
+    var content = String(selectedText || "");
+    var openTag =
+      manualKind === "ifp_wrap"
+        ? "{%p if " + condition + " %}"
+        : "{% if " + condition + " %}";
+    var closeTag = manualKind === "ifp_wrap" ? "{%p endif %}" : "{% endif %}";
+
+    if (manualKind === "ifp_wrap") {
+      return (
+        '<span class="dl-p-wrap-line">' +
+        esc(openTag) +
+        "</span>" +
+        '<span class="dl-p-wrap-line">' +
+        esc(content) +
+        "</span>" +
+        '<span class="dl-p-wrap-line">' +
+        esc(closeTag) +
+        "</span>"
+      );
     }
 
-    function applyExistingLabelHighlightsByOccurrence(html, existingLabels, escapeHtmlFn) {
-        var esc = escapeHtmlFn || defaultEscapeHtml;
-        var output = String(html || '');
-        var byOriginal = {};
-        (existingLabels || []).forEach(function(label) {
-            if (!label || typeof label.original !== 'string') return;
-            if (!byOriginal[label.original]) byOriginal[label.original] = [];
-            byOriginal[label.original].push(label);
-        });
-        Object.keys(byOriginal).forEach(function(original) {
-            var labels = byOriginal[original];
-            var encoded = esc(original);
-            var offset = 0;
-            labels.forEach(function(label) {
-                var cls = label.current !== label.original ? 'highlight-accepted' : 'highlight-existing';
-                var span = '<span class="' + cls + ' existing-inline-label" data-label-id="' + esc(label.id) + '">' + esc(label.current) + '</span>';
-                var pos = output.indexOf(encoded, offset);
-                if (pos === -1) return;
-                output = output.substring(0, pos) + span + output.substring(pos + encoded.length);
-                offset = pos + span.length;
+    return esc(openTag + content + closeTag);
+  }
+
+  function extractLabelsFromRuns(runs, createIdFn) {
+    var labels = [];
+    var pattern = /\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}/g;
+    var nextId =
+      typeof createIdFn === "function"
+        ? createIdFn
+        : function () {
+            return "label-" + Math.random().toString(36).slice(2);
+          };
+    var paragraphs = {};
+
+    (runs || []).forEach(function (run) {
+      var paragraph = Number(run[0]);
+      if (!paragraphs[paragraph]) paragraphs[paragraph] = [];
+      paragraphs[paragraph].push(run);
+    });
+
+    Object.keys(paragraphs)
+      .sort(function (a, b) {
+        return Number(a) - Number(b);
+      })
+      .forEach(function (paragraphKey) {
+        var paragraph = Number(paragraphKey);
+        var fullText = "";
+        var entries = [];
+        paragraphs[paragraph]
+          .slice()
+          .sort(function (a, b) {
+            return Number(a[1]) - Number(b[1]);
+          })
+          .forEach(function (run) {
+            var text = String(run[2] || "");
+            entries.push({
+              paragraph: paragraph,
+              run: Number(run[1]),
+              text: text,
+              start: fullText.length,
+              end: fullText.length + text.length,
             });
-        });
-        return output;
-    }
+            fullText += text;
+          });
 
-    function shouldSuppressSelectionPopoverFromTarget(target) {
-        if (!target) return false;
-        var element = null;
-        if (typeof target.closest === 'function') {
-            element = target;
-        } else if (target.parentElement && typeof target.parentElement.closest === 'function') {
-            // Mouse events can target a text node inside the highlighted span.
-            element = target.parentElement;
-        }
-        if (!element) return false;
-        return !!element.closest('.existing-inline-label');
-    }
+        pattern.lastIndex = 0;
+        var match;
+        while ((match = pattern.exec(fullText)) !== null) {
+          var labelText = match[0];
+          var labelStart = match.index;
+          var labelEnd = labelStart + labelText.length;
+          var overlapping = entries.filter(function (entry) {
+            return entry.end > labelStart && entry.start < labelEnd;
+          });
+          if (!overlapping.length) continue;
 
-    function normalizeReplaceAllFlag(value) {
-        return value === true;
-    }
+          var label = {
+            id: nextId(),
+            original: labelText,
+            current: labelText,
+            isControl: labelText.startsWith("{%"),
+          };
 
-    function formatManualWrapPreviewDisplay(manualKind, conditionExpression, selectedText, escapeHtmlFn) {
-        var esc = escapeHtmlFn || defaultEscapeHtml;
-        var condition = String(conditionExpression || '').trim();
-        var content = String(selectedText || '');
-        var openTag = manualKind === 'ifp_wrap'
-            ? '{%p if ' + condition + ' %}'
-            : '{% if ' + condition + ' %}';
-        var closeTag = manualKind === 'ifp_wrap'
-            ? '{%p endif %}'
-            : '{% endif %}';
-
-        if (manualKind === 'ifp_wrap') {
-            return '<span class="dl-p-wrap-line">' + esc(openTag) + '</span>'
-                + '<span class="dl-p-wrap-line">' + esc(content) + '</span>'
-                + '<span class="dl-p-wrap-line">' + esc(closeTag) + '</span>';
-        }
-
-        return esc(openTag + content + closeTag);
-    }
-
-    function extractLabelsFromRuns(runs, createIdFn) {
-        var labels = [];
-        var pattern = /\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}/g;
-        var nextId = typeof createIdFn === 'function'
-            ? createIdFn
-            : function() {
-                return 'label-' + Math.random().toString(36).slice(2);
-            };
-        var paragraphs = {};
-
-        (runs || []).forEach(function(run) {
-            var paragraph = Number(run[0]);
-            if (!paragraphs[paragraph]) paragraphs[paragraph] = [];
-            paragraphs[paragraph].push(run);
-        });
-
-        Object.keys(paragraphs).sort(function(a, b) {
-            return Number(a) - Number(b);
-        }).forEach(function(paragraphKey) {
-            var paragraph = Number(paragraphKey);
-            var fullText = '';
-            var entries = [];
-            paragraphs[paragraph].slice().sort(function(a, b) {
-                return Number(a[1]) - Number(b[1]);
-            }).forEach(function(run) {
-                var text = String(run[2] || '');
-                entries.push({
-                    paragraph: paragraph,
-                    run: Number(run[1]),
-                    text: text,
-                    start: fullText.length,
-                    end: fullText.length + text.length,
-                });
-                fullText += text;
+          if (overlapping.length === 1) {
+            label.paragraph = paragraph;
+            label.run = overlapping[0].run;
+            label.start = labelStart - overlapping[0].start;
+            label.end = labelEnd - overlapping[0].start;
+          } else {
+            label.paragraph = paragraph;
+            label.segments = overlapping.map(function (entry) {
+              return {
+                paragraph: paragraph,
+                run: entry.run,
+                start: Math.max(0, labelStart - entry.start),
+                end: Math.min(entry.text.length, labelEnd - entry.start),
+              };
             });
+          }
 
-            pattern.lastIndex = 0;
-            var match;
-            while ((match = pattern.exec(fullText)) !== null) {
-                var labelText = match[0];
-                var labelStart = match.index;
-                var labelEnd = labelStart + labelText.length;
-                var overlapping = entries.filter(function(entry) {
-                    return entry.end > labelStart && entry.start < labelEnd;
-                });
-                if (!overlapping.length) continue;
-
-                var label = {
-                    id: nextId(),
-                    original: labelText,
-                    current: labelText,
-                    isControl: labelText.startsWith('{%'),
-                };
-
-                if (overlapping.length === 1) {
-                    label.paragraph = paragraph;
-                    label.run = overlapping[0].run;
-                    label.start = labelStart - overlapping[0].start;
-                    label.end = labelEnd - overlapping[0].start;
-                } else {
-                    label.paragraph = paragraph;
-                    label.segments = overlapping.map(function(entry) {
-                        return {
-                            paragraph: paragraph,
-                            run: entry.run,
-                            start: Math.max(0, labelStart - entry.start),
-                            end: Math.min(entry.text.length, labelEnd - entry.start),
-                        };
-                    });
-                }
-
-                labels.push(label);
-            }
-        });
-
-        return labels;
-    }
-
-    function getOccurrenceIndex(text, original, start) {
-        if (typeof text !== 'string' || typeof original !== 'string' || !original) {
-            return 0;
+          labels.push(label);
         }
-        var occurrence = 0;
+      });
+
+    return labels;
+  }
+
+  function getOccurrenceIndex(text, original, start) {
+    if (typeof text !== "string" || typeof original !== "string" || !original) {
+      return 0;
+    }
+    var occurrence = 0;
+    var searchFrom = 0;
+    var foundAt;
+    while ((foundAt = text.indexOf(original, searchFrom)) !== -1) {
+      if (foundAt === start) return occurrence;
+      occurrence += 1;
+      searchFrom = foundAt + Math.max(original.length, 1);
+    }
+    return 0;
+  }
+
+  function applyRunPatchEdits(baseText, edits) {
+    var output = String(baseText || "");
+    (edits || [])
+      .slice()
+      .sort(function (a, b) {
+        if (a.start !== b.start) return b.start - a.start;
+        return b.end - a.end;
+      })
+      .forEach(function (edit) {
+        if (!edit || typeof edit.replacement !== "string") return;
+        var start = typeof edit.start === "number" ? edit.start : null;
+        var end = typeof edit.end === "number" ? edit.end : null;
+
+        if (
+          start !== null &&
+          end !== null &&
+          start >= 0 &&
+          end >= start &&
+          end <= output.length
+        ) {
+          var currentSlice = output.substring(start, end);
+          if (
+            typeof edit.original === "string" &&
+            currentSlice === edit.original
+          ) {
+            output =
+              output.substring(0, start) +
+              edit.replacement +
+              output.substring(end);
+            return;
+          }
+        }
+
+        if (typeof edit.original !== "string" || !edit.original) return;
+
+        var desiredOccurrence =
+          typeof edit.occurrenceIndex === "number" ? edit.occurrenceIndex : 0;
         var searchFrom = 0;
-        var foundAt;
-        while ((foundAt = text.indexOf(original, searchFrom)) !== -1) {
-            if (foundAt === start) return occurrence;
-            occurrence += 1;
-            searchFrom = foundAt + Math.max(original.length, 1);
+        var foundAt = -1;
+        var seen = 0;
+        while ((foundAt = output.indexOf(edit.original, searchFrom)) !== -1) {
+          if (seen === desiredOccurrence) break;
+          seen += 1;
+          searchFrom = foundAt + Math.max(edit.original.length, 1);
         }
-        return 0;
+        if (foundAt === -1) return;
+        output =
+          output.substring(0, foundAt) +
+          edit.replacement +
+          output.substring(foundAt + edit.original.length);
+      });
+    return output;
+  }
+
+  function buildRunPatchLabelsFromExistingEdits(existingLabels, runs) {
+    var runByKey = {};
+    (runs || []).forEach(function (run) {
+      runByKey[run[0] + "," + run[1]] = String(run[2] || "");
+    });
+
+    var editedByRun = {};
+    function pushEdit(runKey, edit) {
+      if (!editedByRun[runKey]) editedByRun[runKey] = [];
+      editedByRun[runKey].push(edit);
     }
 
-    function applyRunPatchEdits(baseText, edits) {
-        var output = String(baseText || '');
-        (edits || []).slice().sort(function(a, b) {
-            if (a.start !== b.start) return b.start - a.start;
-            return b.end - a.end;
-        }).forEach(function(edit) {
-            if (!edit || typeof edit.replacement !== 'string') return;
-            var start = typeof edit.start === 'number' ? edit.start : null;
-            var end = typeof edit.end === 'number' ? edit.end : null;
-
-            if (start !== null && end !== null && start >= 0 && end >= start && end <= output.length) {
-                var currentSlice = output.substring(start, end);
-                if (typeof edit.original === 'string' && currentSlice === edit.original) {
-                    output = output.substring(0, start) + edit.replacement + output.substring(end);
-                    return;
-                }
-            }
-
-            if (typeof edit.original !== 'string' || !edit.original) return;
-
-            var desiredOccurrence = typeof edit.occurrenceIndex === 'number' ? edit.occurrenceIndex : 0;
-            var searchFrom = 0;
-            var foundAt = -1;
-            var seen = 0;
-            while ((foundAt = output.indexOf(edit.original, searchFrom)) !== -1) {
-                if (seen === desiredOccurrence) break;
-                seen += 1;
-                searchFrom = foundAt + Math.max(edit.original.length, 1);
-            }
-            if (foundAt === -1) return;
-            output = output.substring(0, foundAt) + edit.replacement + output.substring(foundAt + edit.original.length);
+    (existingLabels || []).forEach(function (label) {
+      if (!label || label.current === label.original) return;
+      if (Array.isArray(label.segments) && label.segments.length > 0) {
+        label.segments.forEach(function (segment, segmentIndex) {
+          if (
+            typeof segment.paragraph !== "number" ||
+            typeof segment.run !== "number"
+          )
+            return;
+          if (
+            typeof segment.start !== "number" ||
+            typeof segment.end !== "number"
+          )
+            return;
+          var segmentKey = segment.paragraph + "," + segment.run;
+          var runText = runByKey[segmentKey];
+          if (typeof runText !== "string") return;
+          var originalSlice = runText.substring(segment.start, segment.end);
+          pushEdit(segmentKey, {
+            paragraph: segment.paragraph,
+            run: segment.run,
+            start: segment.start,
+            end: segment.end,
+            original: originalSlice,
+            replacement: segmentIndex === 0 ? String(label.current || "") : "",
+            occurrenceIndex: getOccurrenceIndex(
+              runText,
+              originalSlice,
+              segment.start,
+            ),
+          });
         });
-        return output;
-    }
+        return;
+      }
+      if (typeof label.paragraph !== "number" || typeof label.run !== "number")
+        return;
+      if (typeof label.start !== "number" || typeof label.end !== "number")
+        return;
+      var key = label.paragraph + "," + label.run;
+      var originalRunText = runByKey[key];
+      if (typeof originalRunText !== "string") return;
+      var originalSlice = originalRunText.substring(label.start, label.end);
+      pushEdit(key, {
+        paragraph: label.paragraph,
+        run: label.run,
+        start: label.start,
+        end: label.end,
+        original: originalSlice,
+        replacement: String(label.current || ""),
+        occurrenceIndex: getOccurrenceIndex(
+          originalRunText,
+          originalSlice,
+          label.start,
+        ),
+      });
+    });
 
-    function buildRunPatchLabelsFromExistingEdits(existingLabels, runs) {
-        var runByKey = {};
-        (runs || []).forEach(function(run) {
-            runByKey[run[0] + ',' + run[1]] = String(run[2] || '');
-        });
+    var patches = [];
+    Object.keys(editedByRun).forEach(function (key) {
+      var edits = editedByRun[key].slice();
+      var originalRunText = runByKey[key];
+      if (typeof originalRunText !== "string") return;
+      var patched = applyRunPatchEdits(originalRunText, edits);
+      var first = edits[0];
+      patches.push({
+        paragraph: first.paragraph,
+        run: first.run,
+        text: patched,
+        new_paragraph: 0,
+        _edits: edits,
+      });
+    });
 
-        var editedByRun = {};
-        function pushEdit(runKey, edit) {
-            if (!editedByRun[runKey]) editedByRun[runKey] = [];
-            editedByRun[runKey].push(edit);
+    return patches;
+  }
+
+  function buildAcceptedRunPatchLookup(runs, existingLabels, suggestions) {
+    var acceptedByKey = {};
+
+    (suggestions || []).forEach(function (suggestion) {
+      if (!suggestion || suggestion.status !== "accepted") return;
+      var newParagraph = suggestion.new_paragraph || 0;
+      var key =
+        suggestion.paragraph + "," + suggestion.run + "," + newParagraph;
+      acceptedByKey[key] = {
+        paragraph: suggestion.paragraph,
+        run: suggestion.run,
+        text: String(suggestion.text || ""),
+        new_paragraph: newParagraph,
+      };
+    });
+
+    buildRunPatchLabelsFromExistingEdits(existingLabels, runs).forEach(
+      function (patch) {
+        var key = patch.paragraph + "," + patch.run + ",0";
+        if (acceptedByKey[key] && Array.isArray(patch._edits)) {
+          acceptedByKey[key].text = applyRunPatchEdits(
+            acceptedByKey[key].text,
+            patch._edits,
+          );
+          return;
         }
+        if (!acceptedByKey[key]) {
+          acceptedByKey[key] = {
+            paragraph: patch.paragraph,
+            run: patch.run,
+            text: String(patch.text || ""),
+            new_paragraph: patch.new_paragraph || 0,
+          };
+        }
+      },
+    );
 
-        (existingLabels || []).forEach(function(label) {
-            if (!label || label.current === label.original) return;
-            if (Array.isArray(label.segments) && label.segments.length > 0) {
-                label.segments.forEach(function(segment, segmentIndex) {
-                    if (typeof segment.paragraph !== 'number' || typeof segment.run !== 'number') return;
-                    if (typeof segment.start !== 'number' || typeof segment.end !== 'number') return;
-                    var segmentKey = segment.paragraph + ',' + segment.run;
-                    var runText = runByKey[segmentKey];
-                    if (typeof runText !== 'string') return;
-                    var originalSlice = runText.substring(segment.start, segment.end);
-                    pushEdit(segmentKey, {
-                        paragraph: segment.paragraph,
-                        run: segment.run,
-                        start: segment.start,
-                        end: segment.end,
-                        original: originalSlice,
-                        replacement: segmentIndex === 0 ? String(label.current || '') : '',
-                        occurrenceIndex: getOccurrenceIndex(runText, originalSlice, segment.start),
-                    });
-                });
-                return;
-            }
-            if (typeof label.paragraph !== 'number' || typeof label.run !== 'number') return;
-            if (typeof label.start !== 'number' || typeof label.end !== 'number') return;
-            var key = label.paragraph + ',' + label.run;
-            var originalRunText = runByKey[key];
-            if (typeof originalRunText !== 'string') return;
-            var originalSlice = originalRunText.substring(label.start, label.end);
-            pushEdit(key, {
-                paragraph: label.paragraph,
-                run: label.run,
-                start: label.start,
-                end: label.end,
-                original: originalSlice,
-                replacement: String(label.current || ''),
-                occurrenceIndex: getOccurrenceIndex(originalRunText, originalSlice, label.start),
-            });
-        });
+    return acceptedByKey;
+  }
 
-        var patches = [];
-        Object.keys(editedByRun).forEach(function(key) {
-            var edits = editedByRun[key].slice();
-            var originalRunText = runByKey[key];
-            if (typeof originalRunText !== 'string') return;
-            var patched = applyRunPatchEdits(originalRunText, edits);
-            var first = edits[0];
-            patches.push({
-                paragraph: first.paragraph,
-                run: first.run,
-                text: patched,
-                new_paragraph: 0,
-                _edits: edits,
-            });
-        });
-
-        return patches;
-    }
-
-    function buildAcceptedRunPatchLookup(runs, existingLabels, suggestions) {
-        var acceptedByKey = {};
-
-        (suggestions || []).forEach(function(suggestion) {
-            if (!suggestion || suggestion.status !== 'accepted') return;
-            var newParagraph = suggestion.new_paragraph || 0;
-            var key = suggestion.paragraph + ',' + suggestion.run + ',' + newParagraph;
-            acceptedByKey[key] = {
-                paragraph: suggestion.paragraph,
-                run: suggestion.run,
-                text: String(suggestion.text || ''),
-                new_paragraph: newParagraph,
-            };
-        });
-
-        buildRunPatchLabelsFromExistingEdits(existingLabels, runs).forEach(function(patch) {
-            var key = patch.paragraph + ',' + patch.run + ',0';
-            if (acceptedByKey[key] && Array.isArray(patch._edits)) {
-                acceptedByKey[key].text = applyRunPatchEdits(
-                    acceptedByKey[key].text,
-                    patch._edits
-                );
-                return;
-            }
-            if (!acceptedByKey[key]) {
-                acceptedByKey[key] = {
-                    paragraph: patch.paragraph,
-                    run: patch.run,
-                    text: String(patch.text || ''),
-                    new_paragraph: patch.new_paragraph || 0,
-                };
-            }
-        });
-
-        return acceptedByKey;
-    }
-
-    return {
-        applyExistingLabelHighlightsByOccurrence: applyExistingLabelHighlightsByOccurrence,
-        applyRunPatchEdits: applyRunPatchEdits,
-        extractLabelsFromRuns: extractLabelsFromRuns,
-        shouldSuppressSelectionPopoverFromTarget: shouldSuppressSelectionPopoverFromTarget,
-        formatManualWrapPreviewDisplay: formatManualWrapPreviewDisplay,
-        buildRunPatchLabelsFromExistingEdits: buildRunPatchLabelsFromExistingEdits,
-        buildAcceptedRunPatchLookup: buildAcceptedRunPatchLookup,
-        normalizeReplaceAllFlag: normalizeReplaceAllFlag
-    };
-}));
+  return {
+    applyExistingLabelHighlightsByOccurrence:
+      applyExistingLabelHighlightsByOccurrence,
+    applyRunPatchEdits: applyRunPatchEdits,
+    extractLabelsFromRuns: extractLabelsFromRuns,
+    shouldSuppressSelectionPopoverFromTarget:
+      shouldSuppressSelectionPopoverFromTarget,
+    formatManualWrapPreviewDisplay: formatManualWrapPreviewDisplay,
+    buildRunPatchLabelsFromExistingEdits: buildRunPatchLabelsFromExistingEdits,
+    buildAcceptedRunPatchLookup: buildAcceptedRunPatchLookup,
+    normalizeReplaceAllFlag: normalizeReplaceAllFlag,
+  };
+});

--- a/docassemble/ALDashboard/data/static/interview_linter.js
+++ b/docassemble/ALDashboard/data/static/interview_linter.js
@@ -6,13 +6,15 @@
       body.classList.contains("question-show-results") ||
       body.classList.contains("question-show_results");
     if (!isResultsScreen) return;
-    const container = document.querySelector("div.container");
+    const container = /** @type {any} */ (
+      document.querySelector("div.container")
+    );
     if (!container) return;
     container.style.maxWidth = "96vw";
   }
 
   document.addEventListener("click", function (event) {
-    const tag = event.target.closest(".al-lint-screen-id");
+    const tag = /** @type {any} */ (event.target).closest(".al-lint-screen-id");
     if (!tag) return;
     if (event.detail === 3) {
       tag.classList.toggle("is-highlighted");

--- a/docassemble/ALDashboard/data/static/labeler_dialogs.js
+++ b/docassemble/ALDashboard/data/static/labeler_dialogs.js
@@ -1,0 +1,177 @@
+/*  labeler_dialogs.js
+    Keyboard and screen reader behaviour for the labelers' custom modals.
+
+    Both labelers show and hide dialogs by toggling a `hidden` class on an
+    overlay element rather than by using Bootstrap's modal JS, so none of the
+    usual dialog behaviour comes for free. Instead of hooking every open/close
+    call site, this watches the `class` attribute of every `[role="dialog"]`
+    and reacts when one becomes visible or hidden. New dialogs added to the
+    templates are picked up automatically as long as they carry the role.
+
+    Provides, per the ARIA dialog pattern:
+      - focus moves into the dialog when it opens
+      - focus returns to whatever opened it when it closes
+      - Tab and Shift+Tab stay inside the open dialog
+      - Escape closes it, reusing the dialog's own close/cancel button so any
+        existing cleanup still runs
+*/
+(function () {
+  "use strict";
+
+  var FOCUSABLE = [
+    "a[href]",
+    "button:not([disabled])",
+    "input:not([disabled]):not([type='hidden'])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    "[tabindex]:not([tabindex='-1'])",
+  ].join(", ");
+
+  // Dialogs opened, in order, so Escape and the focus trap act on the topmost.
+  var openDialogs = [];
+  var returnFocusTo = new WeakMap();
+
+  function isVisible(element) {
+    return !!(
+      element.offsetWidth ||
+      element.offsetHeight ||
+      element.getClientRects().length
+    );
+  }
+
+  function focusableWithin(dialog) {
+    return Array.prototype.filter.call(
+      dialog.querySelectorAll(FOCUSABLE),
+      isVisible,
+    );
+  }
+
+  function isOpen(dialog) {
+    return !dialog.classList.contains("hidden") && isVisible(dialog);
+  }
+
+  function handleOpened(dialog) {
+    if (openDialogs.indexOf(dialog) !== -1) return;
+    openDialogs.push(dialog);
+
+    var previous = document.activeElement;
+    if (previous && previous !== document.body) {
+      returnFocusTo.set(dialog, previous);
+    }
+
+    var targets = focusableWithin(dialog);
+    if (targets.length) {
+      targets[0].focus();
+    } else {
+      // Nothing focusable inside, so make the dialog itself the focus target
+      // rather than leaving focus behind on the page underneath.
+      if (!dialog.hasAttribute("tabindex"))
+        dialog.setAttribute("tabindex", "-1");
+      dialog.focus();
+    }
+  }
+
+  function handleClosed(dialog) {
+    var index = openDialogs.indexOf(dialog);
+    if (index === -1) return;
+    openDialogs.splice(index, 1);
+
+    var previous = returnFocusTo.get(dialog);
+    returnFocusTo.delete(dialog);
+    // Only restore if the opener is still around and reachable.
+    if (previous && document.contains(previous) && isVisible(previous)) {
+      previous.focus();
+    }
+  }
+
+  function topDialog() {
+    return openDialogs.length ? openDialogs[openDialogs.length - 1] : null;
+  }
+
+  function trapTab(event) {
+    var dialog = topDialog();
+    if (!dialog) return;
+    var targets = focusableWithin(dialog);
+    if (!targets.length) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+    var first = targets[0];
+    var last = targets[targets.length - 1];
+    var active = document.activeElement;
+
+    if (!dialog.contains(active)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function closeTopDialog() {
+    var dialog = topDialog();
+    if (!dialog) return;
+    // Prefer the dialog's own dismiss control so its existing click handler
+    // runs any cleanup (resetting forms, clearing state, and so on).
+    var dismiss = Array.prototype.filter.call(
+      dialog.querySelectorAll(
+        '.btn-close, [data-dismiss-dialog], button[id*="close"], button[id*="cancel"]',
+      ),
+      isVisible,
+    )[0];
+    if (dismiss) {
+      dismiss.click();
+      return;
+    }
+    dialog.classList.add("hidden");
+  }
+
+  document.addEventListener(
+    "keydown",
+    function (event) {
+      if (!openDialogs.length) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeTopDialog();
+      } else if (event.key === "Tab") {
+        trapTab(event);
+      }
+    },
+    true,
+  );
+
+  function watch(dialog) {
+    var observer = new MutationObserver(function () {
+      if (isOpen(dialog)) {
+        handleOpened(dialog);
+      } else {
+        handleClosed(dialog);
+      }
+    });
+    observer.observe(dialog, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+    if (isOpen(dialog)) handleOpened(dialog);
+  }
+
+  function init() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll('[role="dialog"]'),
+      watch,
+    );
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docassemble/ALDashboard/data/static/pdf_labeler.css
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.css
@@ -682,8 +682,21 @@
 .field-count-inline {
     font-size: 0.75rem;
     font-weight: 400;
-    color: #7589a1;
+    color: #4f647d;
     margin-left: 0.3rem;
+}
+
+.pdf-labeler-app .btn-outline-danger {
+    color: #8a1c28;
+    border-color: #8a1c28;
+}
+
+/* Same reasoning as .btn-outline-danger above: Bootstrap's default
+   secondary (#6c757d) falls under 4.5:1 on this app's light modal/panel
+   backgrounds. Darkened to Bootstrap's own secondary-hover shade. */
+.pdf-labeler-app .btn-outline-secondary {
+    color: #565e64;
+    border-color: #565e64;
 }
 .fields-mode-toggle .btn {
     font-size: 0.72rem;

--- a/docassemble/ALDashboard/data/static/pdf_labeler.js
+++ b/docassemble/ALDashboard/data/static/pdf_labeler.js
@@ -1,5906 +1,7398 @@
-    import * as pdfjsLib from 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.min.mjs';
+// @ts-expect-error pdf.js is loaded from its CDN URL in the browser.
+import * as pdfjsLib from "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.min.mjs";
 
-    pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.worker.min.mjs';
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.worker.min.mjs";
 
-    function parseBootstrapJson() {
-        const bootstrapEl = document.getElementById('labeler-bootstrap');
-        if (!bootstrapEl) return {};
-        try {
-            return JSON.parse(bootstrapEl.textContent || '{}');
-        } catch (_error) {
-            return {};
+function parseBootstrapJson() {
+  const bootstrapEl = document.getElementById("labeler-bootstrap");
+  if (!bootstrapEl) return {};
+  try {
+    return JSON.parse(bootstrapEl.textContent || "{}");
+  } catch (_error) {
+    return {};
+  }
+}
+
+const LABELER_BOOTSTRAP = parseBootstrapJson();
+const API_BASE_PATH = LABELER_BOOTSTRAP.apiBasePath || "/al";
+const INITIAL_PLAYGROUND_SOURCE =
+  LABELER_BOOTSTRAP.initialPlaygroundSource || {};
+const BRANDING = LABELER_BOOTSTRAP.branding || {};
+const PDF_CONFIG = LABELER_BOOTSTRAP.pdf || {};
+const PDFLibGlobal = window.PDFLib || {};
+const JSZipGlobal = window.JSZip || null;
+
+const FIELD_TYPES = [
+  "text",
+  "multiline",
+  "checkbox",
+  "signature",
+  "radio",
+  "dropdown",
+  "listbox",
+];
+const POINT_INSERT_TYPES = new Set(["checkbox", "radio"]);
+const OPTION_TYPES = new Set(["radio", "dropdown", "listbox"]);
+const DEFAULT_OPTION_LIST = ["Option 1", "Option 2"];
+const FONT_OPTIONS = [
+  "Helvetica",
+  "Helvetica-Bold",
+  "Courier",
+  "Courier-Bold",
+  "Times-Roman",
+  "Times-Bold",
+];
+
+const FIELD_TYPE_META = {
+  text: {
+    label: "Single-line Text",
+    shortLabel: "Text",
+    createMode: "draw",
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7V4h16v3M9 20h6M12 4v16"></path></svg>',
+  },
+  multiline: {
+    label: "Multi-line Text",
+    shortLabel: "Multi",
+    createMode: "draw",
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 10h18M3 14h18M3 18h10"></path></svg>',
+  },
+  checkbox: {
+    label: "Checkbox",
+    shortLabel: "Check",
+    createMode: "point",
+    defaultWidth: 0.032,
+    defaultHeight: 0.032,
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><path d="m9 12 2 2 4-4"></path></svg>',
+  },
+  signature: {
+    label: "Signature",
+    shortLabel: "Sign",
+    createMode: "draw",
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m14.5 3.5 6 6-11 11H3v-6.5l11-11Z"></path></svg>',
+  },
+  radio: {
+    label: "Radio Group",
+    shortLabel: "Radio",
+    createMode: "point",
+    defaultWidth: 0.032,
+    defaultHeight: 0.032,
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="3" fill="currentColor"></circle></svg>',
+  },
+  dropdown: {
+    label: "Dropdown",
+    shortLabel: "Drop",
+    createMode: "draw",
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2" ry="2"></rect><path d="m7 10 5 5 5-5"></path></svg>',
+  },
+  listbox: {
+    label: "List Box",
+    shortLabel: "List",
+    createMode: "draw",
+    icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2" ry="2"></rect><path d="M7 8h10M7 12h10M7 16h4"></path></svg>',
+  },
+};
+
+const DEFAULT_FIELD_NAME_LIBRARY = {
+  text: [
+    "users1_name_first",
+    "users1_name_last",
+    "users1_name_full",
+    "users1_address_address",
+    "users1_address_city",
+    "users1_address_state",
+    "users1_address_zip",
+    "users1_phone_number",
+    "users1_email",
+    "other_parties1_name_full",
+    "docket_number",
+    "case_name",
+  ],
+  multiline: [
+    "users1_mailing_address",
+    "special_instructions",
+    "facts_summary",
+  ],
+  signature: [
+    "users1_signature",
+    "other_parties1_signature",
+    "attorney_signature",
+  ],
+  checkbox: ["user_agrees", "is_plaintiff", "is_defendant", "has_children"],
+  dropdown: ["court_division", "selected_claim_type"],
+  listbox: ["requested_relief", "selected_issues"],
+  radio: ["service_method"],
+};
+
+const FIELD_NAME_LIBRARY =
+  PDF_CONFIG.fieldNameLibrary && Object.keys(PDF_CONFIG.fieldNameLibrary).length
+    ? PDF_CONFIG.fieldNameLibrary
+    : PDF_CONFIG.field_name_library &&
+        Object.keys(PDF_CONFIG.field_name_library).length
+      ? PDF_CONFIG.field_name_library
+      : DEFAULT_FIELD_NAME_LIBRARY;
+
+const state = {
+  fileName: "",
+  pdfBytes: null,
+  requestPdfFile: null,
+  quickEditFieldId: null,
+  quickEditFocusPending: false,
+  pdfDoc: null,
+  pageCount: 0,
+  pageSizes: [],
+  pageTextBoxes: [],
+  fields: [],
+  selectedFieldId: null,
+  selectedTool: null,
+  previewMode: false,
+  renderScale: 1.35,
+  viewerZoom: 1,
+  defaultModel: "gpt-5-mini",
+  recommendedModels: ["gpt-5-mini"],
+  availableModels: [],
+  model: "gpt-5-mini",
+  hasUnsavedChanges: false,
+  fieldSearch: "",
+  fieldTypeFilter: "",
+  fieldSort: "position",
+  fieldsPanelMode: "filter",
+  bulkRenameType: "pattern",
+  bulkRenamePattern: "",
+  bulkRenameReplacement: "",
+  fieldNamesVersion: 0,
+  bulkRenamePreviewCache: null,
+  auth: {
+    isAuthenticated: false,
+    email: "",
+    loginUrl: "/user/sign-in",
+    logoutUrl: "/user/sign-out",
+    aiEnabled: false,
+    menuItems: [],
+  },
+  playgroundSource: {
+    project: "",
+    filename: "",
+  },
+  initialPlaygroundSource: {
+    project: INITIAL_PLAYGROUND_SOURCE.project || "",
+    filename: INITIAL_PLAYGROUND_SOURCE.filename || "",
+    attempted: false,
+  },
+  interviewSourceMode: "playground",
+  playground: {
+    projects: [],
+    files: [],
+    selectedProject: INITIAL_PLAYGROUND_SOURCE.project || "default",
+    selectedFile: "",
+    variables: [],
+    topLevelNames: [],
+  },
+  installed: {
+    packages: [],
+    files: [],
+    selectedPackage: "",
+    selectedFile: "",
+    variables: [],
+    topLevelNames: [],
+  },
+  usePlaygroundVariables: false,
+  accessibility: {
+    enabled: true,
+    fieldOrder: [],
+    metadata: {
+      language: "",
+      title: "",
+      author: "",
+      subject: "",
+    },
+    images: [],
+    imageMode: false,
+    tagStructure: null,
+    inspected: false,
+  },
+};
+
+// --- Session-persisted defaults for font, fontSize, checkboxStyle ---
+const SESSION_DEFAULTS_KEY = "pdfLabeler_sessionDefaults";
+const HARD_DEFAULTS = {
+  font: "Helvetica",
+  fontSize: 10,
+  checkboxStyle: "cross",
+  checkboxExportValue: "Yes",
+};
+
+function _loadSessionDefaults() {
+  try {
+    const raw = sessionStorage.getItem(SESSION_DEFAULTS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      return Object.assign({}, HARD_DEFAULTS, parsed);
+    }
+  } catch (_e) {
+    /* ignore */
+  }
+  return Object.assign({}, HARD_DEFAULTS);
+}
+function _saveSessionDefaults(defaults) {
+  try {
+    sessionStorage.setItem(SESSION_DEFAULTS_KEY, JSON.stringify(defaults));
+  } catch (_e) {
+    /* ignore */
+  }
+}
+function getSessionDefault(key) {
+  return _loadSessionDefaults()[key] || HARD_DEFAULTS[key];
+}
+function setSessionDefault(key, value) {
+  const defaults = _loadSessionDefaults();
+  defaults[key] = value;
+  _saveSessionDefaults(defaults);
+}
+
+function looksLikeSingleLineAutoSizeField(fieldName) {
+  return /(name|address|street|city|state|zip|postal|phone|phone_number|email|cell)/i.test(
+    String(fieldName || ""),
+  );
+}
+
+let draftState = null;
+let dragState = null;
+let resizeState = null;
+let currentVisiblePageIndex = 0;
+let fieldsListProgrammaticScroll = false;
+let pageManagerState = null;
+let pageManagerDragPageId = null;
+let a11yDragFieldId = null;
+
+const fileInput = document.getElementById("file-input");
+const pdfContainer = document.getElementById("pdf-container");
+const pdfEmpty = document.getElementById("pdf-empty");
+const pdfLoading = document.getElementById("pdf-loading");
+const loadingMessage = document.getElementById("loading-message");
+const managePagesBtn = document.getElementById("manage-pages-btn");
+const pdfZoomOutBtn = document.getElementById("pdf-zoom-out");
+const pdfZoomInBtn = document.getElementById("pdf-zoom-in");
+const pdfZoomResetBtn = document.getElementById("pdf-zoom-reset");
+const pdfZoomLabel = document.getElementById("pdf-zoom-label");
+const floatingToolPicker = document.getElementById("floating-tool-picker");
+const pdfPages = document.getElementById("pdf-pages");
+const fieldsEmpty = document.getElementById("fields-empty");
+const fieldsList = document.getElementById("fields-list");
+const fieldCount = document.getElementById("field-count");
+const fieldSearchInput = document.getElementById("field-search");
+const fieldTypeFilterInput = document.getElementById("field-type-filter");
+const fieldSortInput = document.getElementById("field-sort");
+const fieldsPanel = document.getElementById("fields-panel");
+const fieldsFilterControls = document.getElementById("fields-filter-controls");
+const bulkRenameControls = document.getElementById("bulk-rename-controls");
+const fieldsModeInputs = Array.from(
+  document.querySelectorAll('input[name="fields-panel-mode"]'),
+);
+const bulkRenameTypeInput = document.getElementById("bulk-rename-type");
+const bulkRenamePatternInput = document.getElementById("bulk-rename-pattern");
+const bulkRenameReplacementInput = document.getElementById(
+  "bulk-rename-replacement",
+);
+const bulkRenameStatus = document.getElementById("bulk-rename-status");
+const bulkRenameApplyBtn = document.getElementById("bulk-rename-apply");
+const autoDetectBtn = document.getElementById("auto-detect-btn");
+const relabelBtn = document.getElementById("relabel-btn");
+const sidebarRelabelBtn = document.getElementById("sidebar-relabel-btn");
+const exportDeduplicateFieldNamesInput = document.getElementById(
+  "export-deduplicate-field-names",
+);
+const duplicateFieldWarning = document.getElementById(
+  "duplicate-field-warning",
+);
+const exportBtn = document.getElementById("export-btn");
+const testFillingBtn = document.getElementById("test-filling-btn");
+const normalizePassBtn = document.getElementById("normalize-pass-btn");
+const errorToast = document.getElementById("error-toast");
+const errorToastMessage = document.getElementById("error-toast-message");
+const successToast = document.getElementById("success-toast");
+const successToastMessage = document.getElementById("success-toast-message");
+const aiAuthNotice = document.getElementById("ai-auth-notice");
+const authControls = document.getElementById("auth-controls");
+const settingsBtn = document.getElementById("settings-btn");
+const settingsModal = document.getElementById("settings-modal");
+const closeSettingsBtn = document.getElementById("close-settings");
+const saveSettingsBtn = document.getElementById("save-settings");
+const resetSettingsBtn = document.getElementById("reset-settings");
+const normalizationModal = document.getElementById("normalization-modal");
+const closeNormalizationBtn = document.getElementById("close-normalization");
+const applyNormalizationBtn = document.getElementById("apply-normalization");
+const repairBtn = document.getElementById("repair-btn");
+const repairModal = document.getElementById("repair-modal");
+const closeRepairBtn = document.getElementById("close-repair");
+const repairStatus = document.getElementById("repair-status");
+const repairStatusText = document.getElementById("repair-status-text");
+const utilitiesBtn = document.getElementById("utilities-btn");
+const accessibilityBtn = document.getElementById("accessibility-btn");
+const previewBtn = document.getElementById("preview-btn");
+const accessibilityModal = document.getElementById("accessibility-modal");
+const closeAccessibilityBtn = document.getElementById("close-accessibility");
+const a11yEnableInput = document.getElementById("a11y-enable");
+const a11yAutofillTooltipsBtn = document.getElementById(
+  "a11y-autofill-tooltips",
+);
+const a11yFieldList = document.getElementById("a11y-field-list");
+const a11yMetaLanguage = document.getElementById("a11y-meta-language");
+const a11yMetaTitle = document.getElementById("a11y-meta-title");
+const a11yMetaAuthor = document.getElementById("a11y-meta-author");
+const a11yMetaSubject = document.getElementById("a11y-meta-subject");
+const a11yImageModeInput = document.getElementById("a11y-image-mode");
+const a11yImageList = document.getElementById("a11y-image-list");
+const a11yTagStructure = document.getElementById("a11y-tag-structure");
+const utilitiesModal = document.getElementById("utilities-modal");
+const utilitiesCloseBtn = document.getElementById("utilities-close");
+const fieldRenameSummaryModal = document.getElementById(
+  "field-rename-summary-modal",
+);
+const fieldRenameSummaryContext = document.getElementById(
+  "field-rename-summary-context",
+);
+const fieldRenameSummaryList = document.getElementById(
+  "field-rename-summary-list",
+);
+const pageManagerModal = document.getElementById("page-manager-modal");
+const closePageManagerBtn = document.getElementById("close-page-manager");
+const pageManagerStatus = document.getElementById("page-manager-status");
+const pageManagerPages = document.getElementById("page-manager-pages");
+const pageManagerDropzone = document.getElementById("page-manager-dropzone");
+const pageManagerSummary = document.getElementById("page-manager-summary");
+const pageManagerInsertFileInput = document.getElementById(
+  "page-manager-insert-file",
+);
+const pageManagerInsertFileName = document.getElementById(
+  "page-manager-insert-file-name",
+);
+const pageManagerInsertPosition = document.getElementById(
+  "page-manager-insert-position",
+);
+const pageManagerInsertSelectionSummary = document.getElementById(
+  "page-manager-insert-selection-summary",
+);
+const pageManagerInsertPages = document.getElementById(
+  "page-manager-insert-pages",
+);
+const pageManagerInsertRunBtn = document.getElementById(
+  "page-manager-insert-run",
+);
+const pageManagerResetBtn = document.getElementById("page-manager-reset");
+const pageManagerDownloadSplitsBtn = document.getElementById(
+  "page-manager-download-splits",
+);
+const pageManagerApplyBtn = document.getElementById("page-manager-apply");
+const passwordModal = document.getElementById("password-modal");
+const passwordInput = document.getElementById("password-input");
+const passwordError = document.getElementById("password-error");
+const passwordSubmitBtn = document.getElementById("password-submit");
+const passwordCancelBtn = document.getElementById("password-cancel");
+const repairPromptModal = document.getElementById("repair-prompt-modal");
+const repairPromptMessage = document.getElementById("repair-prompt-message");
+const repairPromptFixBtn = document.getElementById("repair-prompt-fix");
+const repairPromptCancelBtn = document.getElementById("repair-prompt-cancel");
+const aiModelInput = document.getElementById("ai-model");
+const aiModelSuggestions = document.getElementById("ai-model-suggestions");
+const pageTitle = document.getElementById("page-title");
+const pageFavicon = document.getElementById("page-favicon");
+const brandLogo = document.getElementById("brand-logo");
+const brandPdfTitle = document.getElementById("brand-pdf-title");
+const brandPdfSubtitle = document.getElementById("brand-pdf-subtitle");
+const documentName = document.getElementById("document-name");
+const dirtyIndicator = document.getElementById("dirty-indicator");
+const openPlaygroundBtn = document.getElementById("open-playground-btn");
+const savePlaygroundBtn = document.getElementById("save-playground-btn");
+const openPlaygroundModalEl = document.getElementById("open-playground-modal");
+const savePlaygroundModalEl = document.getElementById("save-playground-modal");
+const usePlaygroundVariablesInput = document.getElementById(
+  "use-playground-variables",
+);
+const pdfInterviewPicker = document.getElementById("pdf-interview-picker");
+const pdfPlaygroundFields = document.getElementById("pdf-playground-fields");
+const pdfInstalledFields = document.getElementById("pdf-installed-fields");
+const pdfPlaygroundProjectSelect = document.getElementById(
+  "pdf-playground-project",
+);
+const pdfPlaygroundYamlFileSelect = document.getElementById(
+  "pdf-playground-yaml-file",
+);
+const pdfInstalledPackageSelect = document.getElementById(
+  "pdf-installed-package",
+);
+const pdfInstalledYamlFileSelect = document.getElementById(
+  "pdf-installed-yaml-file",
+);
+const pdfInterviewVariableSummary = document.getElementById(
+  "pdf-interview-variable-summary",
+);
+const pdfInterviewSourceModeInputs = Array.from(
+  document.querySelectorAll('input[name="pdf-interview-source-mode"]'),
+);
+const quickFieldEditor = document.getElementById("quick-field-editor");
+const quickFieldTypeBadge = document.getElementById("quick-field-type-badge");
+const quickFieldNameInput = document.getElementById("quick-field-name");
+const quickFieldDeleteBtn = document.getElementById("quick-field-delete");
+const quickFieldCloseBtn = document.getElementById("quick-field-close");
+const quickFieldSuggestions = document.getElementById(
+  "quick-field-suggestions",
+);
+
+const toolButtons = {
+  text: document.getElementById("tool-text"),
+  multiline: document.getElementById("tool-multiline"),
+  checkbox: document.getElementById("tool-checkbox"),
+  signature: document.getElementById("tool-signature"),
+  dropdown: document.getElementById("tool-dropdown"),
+  listbox: document.getElementById("tool-listbox"),
+};
+
+function generateId() {
+  if (window.crypto && typeof window.crypto.randomUUID === "function") {
+    return "field-" + window.crypto.randomUUID();
+  }
+  return "field-" + Math.random().toString(36).slice(2, 11);
+}
+
+function apiUrl(path) {
+  return API_BASE_PATH + path;
+}
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text == null ? "" : String(text);
+  return div.innerHTML;
+}
+
+/** Map PDF standard font names to CSS font-family + weight. */
+function pdfFontToCss(pdfFont) {
+  var f = String(pdfFont || "Helvetica");
+  if (f === "Helvetica-Bold")
+    return { family: "Helvetica, Arial, sans-serif", weight: "bold" };
+  if (f === "Courier")
+    return { family: '"Courier New", Courier, monospace', weight: "normal" };
+  if (f === "Courier-Bold")
+    return { family: '"Courier New", Courier, monospace', weight: "bold" };
+  if (f === "Times-Roman")
+    return { family: '"Times New Roman", Times, serif', weight: "normal" };
+  if (f === "Times-Bold")
+    return { family: '"Times New Roman", Times, serif', weight: "bold" };
+  return { family: "Helvetica, Arial, sans-serif", weight: "normal" };
+}
+
+var CHECKBOX_PREVIEW_GLYPHS = {
+  cross: "\u2717", // ✗
+  check: "\u2713", // ✓
+  circle: "\u25CF", // ●
+  star: "\u2605", // ★
+  diamond: "\u25C6", // ◆
+  square: "\u25A0", // ■
+};
+
+var _signatureDataUrl = null;
+(function preloadSignature() {
+  var img = new Image();
+  img.onload = function () {
+    var canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    canvas.getContext("2d").drawImage(img, 0, 0);
+    _signatureDataUrl = canvas.toDataURL("image/png");
+  };
+  img.src = "/packagestatic/docassemble.ALDashboard/placeholder_signature.png";
+})();
+
+function setDirty(value) {
+  state.hasUnsavedChanges = !!value;
+  dirtyIndicator.classList.toggle("hidden", !state.hasUnsavedChanges);
+}
+
+function updateDocumentName() {
+  documentName.textContent = state.fileName ? state.fileName : "";
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getViewerRenderScale() {
+  return state.renderScale * state.viewerZoom;
+}
+
+function updateZoomControls() {
+  const hasPdf = !!state.pdfBytes;
+  const zoomPercent = Math.round(state.viewerZoom * 100);
+  pdfZoomLabel.textContent = zoomPercent + "%";
+  pdfZoomOutBtn.disabled = !hasPdf || state.viewerZoom <= 0.6;
+  pdfZoomInBtn.disabled = !hasPdf || state.viewerZoom >= 2.4;
+  pdfZoomResetBtn.disabled = !hasPdf || Math.abs(state.viewerZoom - 1) < 0.001;
+}
+
+function captureViewerAnchor() {
+  const shell = document.querySelector(
+    '.pdf-page-shell[data-page-index="' + currentVisiblePageIndex + '"]',
+  );
+  if (!shell) {
+    return { pageIndex: currentVisiblePageIndex || 0, offsetRatio: 0 };
+  }
+  const pageHeight = Math.max(shell.offsetHeight, 1);
+  return {
+    pageIndex: Number(shell.dataset.pageIndex || 0),
+    offsetRatio: clamp(
+      (pdfContainer.scrollTop - shell.offsetTop) / pageHeight,
+      0,
+      1,
+    ),
+  };
+}
+
+function restoreViewerAnchor(anchor) {
+  if (!anchor) return;
+  const shell = document.querySelector(
+    '.pdf-page-shell[data-page-index="' + anchor.pageIndex + '"]',
+  );
+  if (!shell) return;
+  pdfContainer.scrollTop =
+    shell.offsetTop + shell.offsetHeight * clamp(anchor.offsetRatio || 0, 0, 1);
+  currentVisiblePageIndex = anchor.pageIndex;
+}
+
+async function updateViewerZoom(nextZoom) {
+  const clampedZoom = clamp(Number(nextZoom) || 1, 0.6, 2.4);
+  if (!state.pdfDoc || Math.abs(clampedZoom - state.viewerZoom) < 0.001) {
+    state.viewerZoom = clampedZoom;
+    updateZoomControls();
+    return;
+  }
+  const anchor = captureViewerAnchor();
+  state.viewerZoom = clampedZoom;
+  updateZoomControls();
+  await renderPages({ anchor: anchor });
+}
+
+function normalizeFieldType(rawType) {
+  const type = String(rawType || "text").toLowerCase();
+  return FIELD_TYPES.includes(type) ? type : "text";
+}
+
+function normalizeOptionalFieldType(rawType) {
+  const type = String(rawType || "")
+    .trim()
+    .toLowerCase();
+  return FIELD_TYPES.includes(type) ? type : "";
+}
+
+function normalizePdfFieldName(rawName) {
+  let name = String(rawName || "").trim();
+  if (!name) return "field";
+  name = name.replace(/\(\)/g, "");
+  name = name.replace(/['`’]/g, "");
+  name = name.replace(/\[(\d+)\]/g, function (_match, index) {
+    return String(Number(index) + 1);
+  });
+  name = name.replace(/\./g, "_");
+  name = name.replace(/\W+/g, "_");
+  name = name.replace(/_+/g, "_");
+  name = name.replace(/^_+|_+$/g, "");
+  if (!name) name = "field";
+  if (/^\d/.test(name)) {
+    name = "field_" + name;
+  }
+  return name;
+}
+
+function extractTextBoxesFromPage(pageProxy) {
+  return pageProxy
+    .getTextContent()
+    .then(function (textContent) {
+      const viewport = pageProxy.getViewport({ scale: 1 });
+      const textItems = [];
+      textContent.items.forEach(function (item) {
+        if (
+          !item ||
+          !("str" in item) ||
+          !item.str ||
+          !item.str.trim() ||
+          !("transform" in item)
+        ) {
+          return;
         }
+        const transform = item.transform;
+        const x = Number(transform[4] || 0);
+        const y = viewport.height - Number(transform[5] || 0);
+        const fontSize = Math.max(Math.abs(Number(transform[3] || 0)), 6);
+        const width = Math.max(
+          Number(item.width || 0),
+          item.str.trim().length * fontSize * 0.46,
+        );
+        textItems.push({
+          text: item.str.trim(),
+          x: x,
+          y: y,
+          width: width,
+          height: fontSize,
+          fontSize: fontSize,
+        });
+      });
+      return groupTextItemsIntoBoxes(textItems).map(function (box) {
+        return {
+          text: box.text,
+          x: clamp(box.x / viewport.width, 0, 1),
+          y: clamp(box.y / viewport.height, 0, 1),
+          width: clamp(box.width / viewport.width, 0, 1),
+          height: clamp(box.height / viewport.height, 0, 1),
+          fontSize: box.fontSize,
+        };
+      });
+    })
+    .catch(function (error) {
+      console.warn("Failed to extract PDF text for heuristic naming:", error);
+      return [];
+    });
+}
+
+function groupTextItemsIntoBoxes(textItems) {
+  if (!Array.isArray(textItems) || textItems.length === 0) return [];
+  const items = textItems.slice().sort(function (left, right) {
+    const yDiff = Math.abs(left.y - right.y);
+    if (yDiff < 3) {
+      return left.x - right.x;
+    }
+    return left.y - right.y;
+  });
+  const boxes = [];
+  let currentBox = null;
+  items.forEach(function (item) {
+    if (!currentBox) {
+      currentBox = {
+        text: item.text,
+        x: item.x,
+        y: item.y,
+        width: item.width,
+        height: item.height,
+        fontSize: item.fontSize,
+      };
+      return;
+    }
+    const sameLineThreshold = Math.max(currentBox.fontSize * 0.45, 4);
+    const gap = item.x - (currentBox.x + currentBox.width);
+    const maxGap = Math.max(currentBox.fontSize * 0.9, 12);
+    if (Math.abs(item.y - currentBox.y) <= sameLineThreshold && gap <= maxGap) {
+      currentBox.text += (gap > 2 ? " " : "") + item.text;
+      currentBox.width = Math.max(
+        currentBox.width,
+        item.x + item.width - currentBox.x,
+      );
+      currentBox.height = Math.max(currentBox.height, item.height);
+      currentBox.fontSize = Math.max(currentBox.fontSize, item.fontSize);
+      return;
+    }
+    boxes.push(currentBox);
+    currentBox = {
+      text: item.text,
+      x: item.x,
+      y: item.y,
+      width: item.width,
+      height: item.height,
+      fontSize: item.fontSize,
+    };
+  });
+  if (currentBox) {
+    boxes.push(currentBox);
+  }
+  return boxes.filter(function (box) {
+    return (
+      box.text && box.text.trim() && !/^[_\s.\-:]{1,4}$/.test(box.text.trim())
+    );
+  });
+}
+
+function getRectBounds(rect) {
+  return {
+    left: rect.x,
+    right: rect.x + rect.width,
+    top: rect.y,
+    bottom: rect.y + rect.height,
+    centerX: rect.x + rect.width / 2,
+    centerY: rect.y + rect.height / 2,
+  };
+}
+
+function getTextBoxBounds(box) {
+  return {
+    left: box.x,
+    right: box.x + box.width,
+    top: box.y,
+    bottom: box.y + box.height,
+    centerX: box.x + box.width / 2,
+    centerY: box.y + box.height / 2,
+  };
+}
+
+function cleanSuggestedLabelText(rawText) {
+  let text = String(rawText || "").trim();
+  if (!text) return "";
+  text = text.replace(/\s+/g, " ");
+  text = text.replace(/^[\s:;.,\-–—_]+|[\s:;.,\-–—_]+$/g, "");
+  if (!text) return "";
+  const parts = text.split(/\s+/);
+  if (parts.length > 10) {
+    text = parts.slice(0, 10).join(" ");
+  }
+  return text;
+}
+
+function getNearbyFieldNameBases(pageIndex, rect, excludeFieldId) {
+  const rectBounds = getRectBounds(rect);
+  const nearby = new Set();
+  state.fields.forEach(function (field) {
+    if (field.pageIndex !== pageIndex || field.id === excludeFieldId) return;
+    const fieldBounds = getRectBounds(field);
+    const verticalDistance = Math.abs(fieldBounds.centerY - rectBounds.centerY);
+    const horizontalGap = Math.min(
+      Math.abs(rectBounds.left - fieldBounds.right),
+      Math.abs(fieldBounds.left - rectBounds.right),
+    );
+    if (
+      verticalDistance <=
+        Math.max(rect.height * 1.6, field.height * 1.6, 0.05) &&
+      horizontalGap <= 0.1
+    ) {
+      nearby.add(normalizePdfFieldName(field.name));
+    }
+  });
+  return nearby;
+}
+
+// Contract: return up to 3 normalized field-name suggestions for a candidate
+// rect on a page, ordered by likely usefulness and already filtered against
+// immediate neighboring field names.
+function buildFieldNameSuggestions(pageIndex, rect, type, excludeFieldId) {
+  const textBoxes = Array.isArray(state.pageTextBoxes[pageIndex])
+    ? state.pageTextBoxes[pageIndex]
+    : [];
+  if (!textBoxes.length) return [];
+  const rectBounds = getRectBounds(rect);
+  const rowTolerance = Math.max(rect.height * 1.6, 0.045);
+  const sideGapLimit = Math.max(rect.width * 3.5, 0.22);
+  const belowGapLimit = Math.max(rect.height * 2.4, 0.12);
+  const nearbyNames = getNearbyFieldNameBases(pageIndex, rect, excludeFieldId);
+  const matches = [];
+
+  textBoxes.forEach(function (box) {
+    const text = cleanSuggestedLabelText(box.text);
+    if (!text) return;
+    const boxBounds = getTextBoxBounds(box);
+    const verticalDistance = Math.abs(boxBounds.centerY - rectBounds.centerY);
+    const overlapWidth =
+      Math.min(rectBounds.right, boxBounds.right) -
+      Math.max(rectBounds.left, boxBounds.left);
+    const overlapRatio =
+      overlapWidth > 0 ? overlapWidth / Math.min(rect.width, box.width) : 0;
+
+    if (
+      boxBounds.right <= rectBounds.left + 0.01 &&
+      verticalDistance <= rowTolerance
+    ) {
+      const gap = rectBounds.left - boxBounds.right;
+      if (gap <= sideGapLimit) {
+        matches.push({
+          text: text,
+          source: "left",
+          score: 320 - gap * 1000 - verticalDistance * 700,
+        });
+      }
     }
 
-    const LABELER_BOOTSTRAP = parseBootstrapJson();
-    const API_BASE_PATH = LABELER_BOOTSTRAP.apiBasePath || '/al';
-    const INITIAL_PLAYGROUND_SOURCE = LABELER_BOOTSTRAP.initialPlaygroundSource || {};
-    const BRANDING = LABELER_BOOTSTRAP.branding || {};
-    const PDF_CONFIG = LABELER_BOOTSTRAP.pdf || {};
-    const PDFLibGlobal = window.PDFLib || {};
-    const JSZipGlobal = window.JSZip || null;
+    if (
+      boxBounds.left >= rectBounds.right - 0.01 &&
+      verticalDistance <= rowTolerance
+    ) {
+      const gap = boxBounds.left - rectBounds.right;
+      if (gap <= sideGapLimit) {
+        matches.push({
+          text: text,
+          source: "right",
+          score: 220 - gap * 1000 - verticalDistance * 700,
+        });
+      }
+    }
 
-    const FIELD_TYPES = ['text', 'multiline', 'checkbox', 'signature', 'radio', 'dropdown', 'listbox'];
-    const POINT_INSERT_TYPES = new Set(['checkbox', 'radio']);
-    const OPTION_TYPES = new Set(['radio', 'dropdown', 'listbox']);
-    const DEFAULT_OPTION_LIST = ['Option 1', 'Option 2'];
-    const FONT_OPTIONS = [
-        'Helvetica',
-        'Helvetica-Bold',
-        'Courier',
-        'Courier-Bold',
-        'Times-Roman',
-        'Times-Bold'
-    ];
+    if (boxBounds.top >= rectBounds.bottom - 0.01) {
+      const gap = boxBounds.top - rectBounds.bottom;
+      if (gap <= belowGapLimit && overlapRatio >= 0.18) {
+        matches.push({
+          text: text,
+          source: "below",
+          score: 180 - gap * 1200 + overlapRatio * 100,
+        });
+      }
+    }
+  });
 
-    const FIELD_TYPE_META = {
-        text: {
-            label: 'Single-line Text',
-            shortLabel: 'Text',
-            createMode: 'draw',
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7V4h16v3M9 20h6M12 4v16"></path></svg>',
-        },
-        multiline: {
-            label: 'Multi-line Text',
-            shortLabel: 'Multi',
-            createMode: 'draw',
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M3 10h18M3 14h18M3 18h10"></path></svg>',
-        },
-        checkbox: {
-            label: 'Checkbox',
-            shortLabel: 'Check',
-            createMode: 'point',
-            defaultWidth: 0.032,
-            defaultHeight: 0.032,
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><path d="m9 12 2 2 4-4"></path></svg>',
-        },
-        signature: {
-            label: 'Signature',
-            shortLabel: 'Sign',
-            createMode: 'draw',
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m14.5 3.5 6 6-11 11H3v-6.5l11-11Z"></path></svg>',
-        },
-        radio: {
-            label: 'Radio Group',
-            shortLabel: 'Radio',
-            createMode: 'point',
-            defaultWidth: 0.032,
-            defaultHeight: 0.032,
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="3" fill="currentColor"></circle></svg>',
-        },
-        dropdown: {
-            label: 'Dropdown',
-            shortLabel: 'Drop',
-            createMode: 'draw',
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2" ry="2"></rect><path d="m7 10 5 5 5-5"></path></svg>',
-        },
-        listbox: {
-            label: 'List Box',
-            shortLabel: 'List',
-            createMode: 'draw',
-            icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2" ry="2"></rect><path d="M7 8h10M7 12h10M7 16h4"></path></svg>',
-        },
+  const leftMatches = matches
+    .filter(function (candidate) {
+      return candidate.source === "left";
+    })
+    .sort(function (left, right) {
+      return right.score - left.score;
+    });
+  const rightMatches = matches
+    .filter(function (candidate) {
+      return candidate.source === "right";
+    })
+    .sort(function (left, right) {
+      return right.score - left.score;
+    });
+  const belowMatches = matches
+    .filter(function (candidate) {
+      return candidate.source === "below";
+    })
+    .sort(function (left, right) {
+      return right.score - left.score;
+    });
+
+  const ordered = [];
+  if (leftMatches[0]) {
+    ordered.push(leftMatches[0]);
+    if (belowMatches[0]) ordered.push(belowMatches[0]);
+    if (rightMatches[0]) ordered.push(rightMatches[0]);
+  } else {
+    if (rightMatches[0]) ordered.push(rightMatches[0]);
+    if (belowMatches[0]) ordered.push(belowMatches[0]);
+  }
+
+  const seenNames = new Set();
+  const suggestions = [];
+  ordered.forEach(function (candidate) {
+    if (!candidate || suggestions.length >= 3) return;
+    const normalized = normalizePdfFieldName(candidate.text);
+    if (
+      !normalized ||
+      seenNames.has(normalized) ||
+      nearbyNames.has(normalized)
+    ) {
+      return;
+    }
+    seenNames.add(normalized);
+    suggestions.push({
+      name: ensureUniqueFieldName(normalized, excludeFieldId || null),
+      source: candidate.source,
+      text: candidate.text,
+    });
+  });
+
+  return suggestions.slice(0, 3);
+}
+
+function ensureUniqueFieldName(baseName, excludeFieldId) {
+  const used = new Set(
+    state.fields
+      .filter(function (field) {
+        return field.id !== excludeFieldId;
+      })
+      .map(function (field) {
+        return normalizePdfFieldName(field.name);
+      }),
+  );
+  const normalizedBase = normalizePdfFieldName(baseName);
+  let candidate = normalizedBase;
+  let suffix = 1;
+  while (used.has(candidate)) {
+    candidate = normalizedBase + "__" + suffix;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function getDefaultFieldName(type) {
+  const normalizedType = normalizeFieldType(type);
+  const library = Array.isArray(FIELD_NAME_LIBRARY[normalizedType])
+    ? FIELD_NAME_LIBRARY[normalizedType]
+    : normalizedType === "multiline"
+      ? FIELD_NAME_LIBRARY.text
+      : [];
+  for (let index = 0; index < library.length; index += 1) {
+    const candidate = normalizePdfFieldName(library[index]);
+    if (
+      !state.fields.some(function (field) {
+        return normalizePdfFieldName(field.name) === candidate;
+      })
+    ) {
+      return candidate;
+    }
+  }
+  const fallbackBase =
+    normalizedType === "checkbox"
+      ? "checkbox"
+      : normalizedType === "signature"
+        ? "signature"
+        : normalizedType === "dropdown"
+          ? "dropdown"
+          : normalizedType === "listbox"
+            ? "listbox"
+            : normalizedType === "radio"
+              ? "radio_group"
+              : normalizedType === "multiline"
+                ? "text_area"
+                : "text";
+  return ensureUniqueFieldName(fallbackBase, null);
+}
+
+function getFieldTypeMeta(type) {
+  return FIELD_TYPE_META[normalizeFieldType(type)] || FIELD_TYPE_META.text;
+}
+
+function getCurrentField() {
+  return (
+    state.fields.find(function (field) {
+      return field.id === state.selectedFieldId;
+    }) || null
+  );
+}
+
+function getQuickEditField() {
+  if (!state.quickEditFieldId) return null;
+  return (
+    state.fields.find(function (field) {
+      return field.id === state.quickEditFieldId;
+    }) || null
+  );
+}
+
+function getOverlayForPage(pageIndex) {
+  return document.querySelector(
+    '.page-overlay[data-page-index="' + pageIndex + '"]',
+  );
+}
+
+function showLoading(message) {
+  loadingMessage.textContent = message;
+  pdfEmpty.classList.add("hidden");
+  pdfLoading.classList.remove("hidden");
+  pdfPages.classList.add("hidden");
+}
+
+function hideLoading() {
+  pdfLoading.classList.add("hidden");
+}
+
+function showPdfWorkspace() {
+  if (state.pdfBytes) {
+    pdfPages.classList.remove("hidden");
+    pdfEmpty.classList.add("hidden");
+  }
+  updateZoomControls();
+}
+
+function getCurrentVisiblePageIndex() {
+  if (!state.pageCount) return 0;
+  const containerRect = pdfContainer.getBoundingClientRect();
+  const containerCenterY = containerRect.top + containerRect.height / 2;
+  let bestPageIndex = currentVisiblePageIndex || 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  document.querySelectorAll(".pdf-page-shell").forEach(function (shell) {
+    const rect = shell.getBoundingClientRect();
+    if (rect.bottom < containerRect.top || rect.top > containerRect.bottom) {
+      return;
+    }
+    const centerY = rect.top + rect.height / 2;
+    const distance = Math.abs(centerY - containerCenterY);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestPageIndex = Number(shell.dataset.pageIndex || 0);
+    }
+  });
+  return bestPageIndex;
+}
+
+function scrollFieldsListToElement(element, options) {
+  if (!element || fieldsList.classList.contains("hidden")) return;
+  const settings = options || {};
+  const behavior = settings.behavior || "smooth";
+  const mode = settings.mode || "nearest";
+  const listRect = fieldsList.getBoundingClientRect();
+  const itemRect = element.getBoundingClientRect();
+  const topWithinList = itemRect.top - listRect.top + fieldsList.scrollTop;
+  const bottomWithinList =
+    itemRect.bottom - listRect.top + fieldsList.scrollTop;
+  let targetTop = fieldsList.scrollTop;
+
+  if (mode === "start") {
+    targetTop = topWithinList;
+  } else if (mode === "center") {
+    targetTop = topWithinList - (fieldsList.clientHeight - itemRect.height) / 2;
+  } else {
+    const visibleTop = fieldsList.scrollTop;
+    const visibleBottom = visibleTop + fieldsList.clientHeight;
+    if (topWithinList < visibleTop) {
+      targetTop = topWithinList;
+    } else if (bottomWithinList > visibleBottom) {
+      targetTop = bottomWithinList - fieldsList.clientHeight;
+    }
+  }
+
+  fieldsListProgrammaticScroll = true;
+  fieldsList.scrollTo({
+    top: Math.max(0, targetTop),
+    behavior: behavior,
+  });
+  window.setTimeout(
+    function () {
+      fieldsListProgrammaticScroll = false;
+    },
+    behavior === "auto" ? 0 : 220,
+  );
+}
+
+function scrollSelectedFieldIntoView(fieldId) {
+  if (!fieldId || fieldsList.classList.contains("hidden")) return;
+  const item = fieldsList.querySelector(
+    '.field-list-item[data-field-id="' + fieldId + '"]',
+  );
+  if (!item) return;
+  scrollFieldsListToElement(item, { mode: "nearest", behavior: "smooth" });
+}
+
+function hideToasts() {
+  errorToast.classList.add("hidden");
+  successToast.classList.add("hidden");
+}
+
+function showError(message, timeoutMs) {
+  hideToasts();
+  errorToastMessage.textContent = message;
+  errorToast.classList.remove("hidden");
+  window.setTimeout(
+    function () {
+      errorToast.classList.add("hidden");
+    },
+    typeof timeoutMs === "number" ? timeoutMs : 6000,
+  );
+}
+
+function showSuccess(message, timeoutMs) {
+  hideToasts();
+  successToastMessage.textContent = message;
+  successToast.classList.remove("hidden");
+  window.setTimeout(
+    function () {
+      successToast.classList.add("hidden");
+    },
+    typeof timeoutMs === "number" ? timeoutMs : 3200,
+  );
+}
+
+function updateDuplicateFieldWarning() {
+  const duplicateNames = getDuplicateFieldNames();
+  if (duplicateFieldWarning) {
+    duplicateFieldWarning.classList.toggle(
+      "hidden",
+      duplicateNames.length === 0,
+    );
+    duplicateFieldWarning.title = duplicateNames.length
+      ? "Repeated names: " +
+        duplicateNames.slice(0, 5).join(", ") +
+        (duplicateNames.length > 5 ? " ..." : "")
+      : "";
+  }
+}
+
+function updateFieldCount() {
+  const totalCount = state.fields.length;
+  const filteredCount = totalCount === 0 ? 0 : getDisplayedFields().length;
+  const filtersActive =
+    state.fieldsPanelMode !== "rename" &&
+    Boolean(
+      String(state.fieldSearch || "").trim() ||
+      normalizeOptionalFieldType(state.fieldTypeFilter || ""),
+    );
+  if (totalCount === 0) {
+    fieldCount.textContent = "No fields";
+  } else if (filtersActive) {
+    fieldCount.textContent = filteredCount + " of " + totalCount + " fields";
+  } else {
+    fieldCount.textContent =
+      totalCount + " field" + (totalCount === 1 ? "" : "s");
+  }
+  fieldsEmpty.classList.toggle("hidden", totalCount !== 0);
+  fieldsList.classList.toggle("hidden", totalCount === 0);
+  floatingToolPicker.classList.toggle("hidden", !state.pdfBytes);
+  autoDetectBtn.disabled = !state.pdfBytes;
+  exportBtn.disabled = !state.pdfBytes || totalCount === 0;
+  if (testFillingBtn)
+    testFillingBtn.disabled = !state.pdfBytes || totalCount === 0;
+  savePlaygroundBtn.disabled = !state.pdfBytes || totalCount === 0;
+  normalizePassBtn.disabled = !state.pdfBytes || totalCount === 0;
+  repairBtn.disabled = !state.pdfBytes;
+  if (relabelBtn) {
+    relabelBtn.disabled =
+      !state.pdfBytes || totalCount === 0 || !state.auth.aiEnabled;
+  }
+  if (sidebarRelabelBtn) {
+    sidebarRelabelBtn.disabled =
+      !state.pdfBytes || totalCount === 0 || !state.auth.aiEnabled;
+  }
+  previewBtn.disabled = !state.pdfBytes || totalCount === 0;
+  accessibilityBtn.disabled = !state.pdfBytes;
+  managePagesBtn.disabled = !state.pdfBytes;
+  if (!state.pdfBytes || totalCount === 0) {
+    state.previewMode = false;
+    previewBtn.classList.remove("active");
+    document.getElementById("preview-icon-open").classList.remove("hidden");
+    document.getElementById("preview-icon-closed").classList.add("hidden");
+  }
+  updateDuplicateFieldWarning();
+  updateZoomControls();
+}
+
+function getDisplayedFields() {
+  const inRenameMode = state.fieldsPanelMode === "rename";
+  const search = inRenameMode
+    ? ""
+    : String(state.fieldSearch || "")
+        .trim()
+        .toLowerCase();
+  const typeFilter = inRenameMode
+    ? ""
+    : normalizeOptionalFieldType(state.fieldTypeFilter || "");
+  const hasTypeFilter = !inRenameMode && FIELD_TYPES.includes(typeFilter);
+  const filtered = state.fields.filter(function (field) {
+    if (hasTypeFilter && field.type !== typeFilter) {
+      return false;
+    }
+    if (
+      search &&
+      String(field.name || "")
+        .toLowerCase()
+        .indexOf(search) === -1
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const sorted = filtered.slice();
+  if (state.fieldSort === "name_asc") {
+    sorted.sort(function (left, right) {
+      return String(left.name || "").localeCompare(
+        String(right.name || ""),
+        undefined,
+        { sensitivity: "base" },
+      );
+    });
+    return sorted;
+  }
+  if (state.fieldSort === "name_desc") {
+    sorted.sort(function (left, right) {
+      return String(right.name || "").localeCompare(
+        String(left.name || ""),
+        undefined,
+        { sensitivity: "base" },
+      );
+    });
+    return sorted;
+  }
+  if (state.fieldSort === "type_name") {
+    sorted.sort(function (left, right) {
+      const leftMeta = getFieldTypeMeta(left.type);
+      const rightMeta = getFieldTypeMeta(right.type);
+      const typeCompare = leftMeta.label.localeCompare(
+        rightMeta.label,
+        undefined,
+        { sensitivity: "base" },
+      );
+      if (typeCompare !== 0) return typeCompare;
+      return String(left.name || "").localeCompare(
+        String(right.name || ""),
+        undefined,
+        { sensitivity: "base" },
+      );
+    });
+    return sorted;
+  }
+  sorted.sort(function (left, right) {
+    if (left.pageIndex !== right.pageIndex)
+      return left.pageIndex - right.pageIndex;
+    if (Math.abs(left.y - right.y) > 0.002) return left.y - right.y;
+    return left.x - right.x;
+  });
+  return sorted;
+}
+
+function defaultTooltipFromFieldName(name) {
+  const normalized = String(name || "")
+    .replace(/_/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized || "Field";
+}
+
+function sortedFieldIdsByDefaultOrder() {
+  return state.fields
+    .slice()
+    .sort(function (left, right) {
+      if (left.pageIndex !== right.pageIndex)
+        return left.pageIndex - right.pageIndex;
+      if (Math.abs(left.y - right.y) > 0.002) return left.y - right.y;
+      if (Math.abs(left.x - right.x) > 0.002) return left.x - right.x;
+      return String(left.name || "").localeCompare(
+        String(right.name || ""),
+        undefined,
+        { sensitivity: "base" },
+      );
+    })
+    .map(function (field) {
+      return field.id;
+    });
+}
+
+function reconcileAccessibilityFieldOrder() {
+  const knownIds = new Set(
+    state.fields.map(function (field) {
+      return field.id;
+    }),
+  );
+  const next = [];
+  (state.accessibility.fieldOrder || []).forEach(function (fieldId) {
+    if (knownIds.has(fieldId)) {
+      next.push(fieldId);
+      knownIds.delete(fieldId);
+    }
+  });
+  sortedFieldIdsByDefaultOrder().forEach(function (fieldId) {
+    if (knownIds.has(fieldId)) {
+      next.push(fieldId);
+      knownIds.delete(fieldId);
+    }
+  });
+  state.accessibility.fieldOrder = next;
+}
+
+function ensureFieldAccessibilityDefaults(field) {
+  if (!field) return;
+  if (!String(field.tooltip || "").trim()) {
+    field.tooltip = defaultTooltipFromFieldName(field.name);
+  }
+}
+
+function refreshAccessibilityFromFields() {
+  state.fields.forEach(ensureFieldAccessibilityDefaults);
+  reconcileAccessibilityFieldOrder();
+}
+
+function renderAccessibilityFieldList() {
+  if (!a11yFieldList) return;
+  a11yFieldList.innerHTML = "";
+  if (!state.fields.length) {
+    a11yFieldList.innerHTML =
+      '<div class="small text-muted">No fields detected yet.</div>';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  state.accessibility.fieldOrder.forEach(function (fieldId, index) {
+    const field = state.fields.find(function (candidate) {
+      return candidate.id === fieldId;
+    });
+    if (!field) return;
+    const row = document.createElement("div");
+    row.className = "a11y-field-row border rounded p-2";
+    row.dataset.fieldId = field.id;
+    row.innerHTML =
+      '<div class="d-flex align-items-center justify-content-between gap-2 mb-2">' +
+      '<div class="d-flex align-items-center gap-1">' +
+      '<span class="a11y-drag-handle" draggable="true" aria-hidden="true" title="Drag to reorder">⠿</span>' +
+      '<div class="small fw-semibold">' +
+      escapeHtml(field.name) +
+      "</div>" +
+      "</div>" +
+      '<div class="btn-group btn-group-sm">' +
+      '<button type="button" class="btn btn-outline-secondary" data-a11y-action="move-up" data-field-id="' +
+      escapeHtml(field.id) +
+      '"' +
+      (index === 0 ? " disabled" : "") +
+      ">Up</button>" +
+      '<button type="button" class="btn btn-outline-secondary" data-a11y-action="move-down" data-field-id="' +
+      escapeHtml(field.id) +
+      '"' +
+      (index === state.accessibility.fieldOrder.length - 1 ? " disabled" : "") +
+      ">Down</button>" +
+      "</div>" +
+      "</div>" +
+      '<label class="form-label small text-muted mb-1" for="a11y-tooltip-' +
+      escapeHtml(field.id) +
+      '">Tooltip</label>' +
+      '<input id="a11y-tooltip-' +
+      escapeHtml(field.id) +
+      '" type="text" class="form-control form-control-sm" data-a11y-action="tooltip" data-field-id="' +
+      escapeHtml(field.id) +
+      '" value="' +
+      escapeHtml(String(field.tooltip || "")) +
+      '">';
+    fragment.appendChild(row);
+  });
+  a11yFieldList.appendChild(fragment);
+}
+
+function renderAccessibilityImages() {
+  if (!a11yImageList) return;
+  a11yImageList.innerHTML = "";
+  const showImages = !!state.accessibility.imageMode;
+  a11yImageList.classList.toggle("hidden", !showImages);
+  if (!showImages) return;
+  if (!state.accessibility.images.length) {
+    a11yImageList.innerHTML =
+      '<div class="small text-muted">No embedded image assets were detected.</div>';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  state.accessibility.images.forEach(function (imageAsset) {
+    const row = document.createElement("div");
+    row.className = "border rounded p-2";
+    row.innerHTML =
+      '<div class="small fw-semibold mb-1">Page ' +
+      (Number(imageAsset.pageIndex || 0) + 1) +
+      " - " +
+      escapeHtml(String(imageAsset.name || imageAsset.assetId || "Image")) +
+      "</div>" +
+      '<div class="small text-muted mb-1">Asset ID: ' +
+      escapeHtml(String(imageAsset.assetId || "")) +
+      "</div>" +
+      '<input type="text" class="form-control form-control-sm" data-a11y-action="image-alt" data-asset-id="' +
+      escapeHtml(String(imageAsset.assetId || "")) +
+      '" value="' +
+      escapeHtml(String(imageAsset.altText || "")) +
+      '" placeholder="Alternative text">';
+    fragment.appendChild(row);
+  });
+  a11yImageList.appendChild(fragment);
+}
+
+function renderAccessibilityTagStructure() {
+  if (!a11yTagStructure) return;
+  const summary = state.accessibility.tagStructure;
+  if (!summary || !summary.present) {
+    a11yTagStructure.textContent = "No document tag tree detected.";
+    return;
+  }
+  const lines = [
+    "Tag tree present: yes",
+    "Nodes: " + String(summary.node_count || 0),
+    "Max depth: " + String(summary.max_depth || 0),
+    "",
+    "Preview:",
+  ];
+  const preview = Array.isArray(summary.preview) ? summary.preview : [];
+  if (!preview.length) {
+    lines.push("(no preview nodes available)");
+  } else {
+    preview.forEach(function (line) {
+      lines.push(String(line));
+    });
+  }
+  a11yTagStructure.textContent = lines.join("\n");
+}
+
+function renderAccessibilityModal() {
+  refreshAccessibilityFromFields();
+  a11yEnableInput.checked = !!state.accessibility.enabled;
+  a11yImageModeInput.checked = !!state.accessibility.imageMode;
+  a11yMetaLanguage.value = String(state.accessibility.metadata.language || "");
+  a11yMetaTitle.value = String(state.accessibility.metadata.title || "");
+  a11yMetaAuthor.value = String(state.accessibility.metadata.author || "");
+  a11yMetaSubject.value = String(state.accessibility.metadata.subject || "");
+  renderAccessibilityFieldList();
+  renderAccessibilityImages();
+  renderAccessibilityTagStructure();
+}
+
+function updateAccessibilityMetadataFromInputs() {
+  state.accessibility.metadata = {
+    language: String(a11yMetaLanguage.value || "").trim(),
+    title: String(a11yMetaTitle.value || "").trim(),
+    author: String(a11yMetaAuthor.value || "").trim(),
+    subject: String(a11yMetaSubject.value || "").trim(),
+  };
+}
+
+async function inspectAccessibilityData(forceRefresh) {
+  if (!state.pdfBytes) return;
+  if (state.accessibility.inspected && !forceRefresh) return;
+  const formData = new FormData();
+  formData.append("file", getPdfFileForRequests());
+  const response = await fetch(
+    apiUrl("/pdf-labeler/api/accessibility-inspect"),
+    {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    },
+  );
+  const payload = await parseApiResponse(response);
+  if (!payload.success || !payload.data) return;
+
+  const metadata = payload.data.metadata || {};
+  if (!state.accessibility.metadata.language)
+    state.accessibility.metadata.language = String(metadata.language || "");
+  if (!state.accessibility.metadata.title)
+    state.accessibility.metadata.title = String(metadata.title || "");
+  if (!state.accessibility.metadata.author)
+    state.accessibility.metadata.author = String(metadata.author || "");
+  if (!state.accessibility.metadata.subject)
+    state.accessibility.metadata.subject = String(metadata.subject || "");
+
+  const serverFields = Array.isArray(payload.data.fields)
+    ? payload.data.fields
+    : [];
+  serverFields.forEach(function (serverField) {
+    const matched = state.fields.find(function (field) {
+      return String(field.name || "") === String(serverField.name || "");
+    });
+    if (!matched) return;
+    if (
+      !String(matched.tooltip || "").trim() ||
+      serverField.has_custom_tooltip
+    ) {
+      matched.tooltip = String(
+        serverField.tooltip || defaultTooltipFromFieldName(matched.name),
+      );
+    }
+  });
+
+  const serverOrder = Array.isArray(payload.data.field_order)
+    ? payload.data.field_order.map(function (name) {
+        return String(name || "");
+      })
+    : [];
+  if (serverOrder.length) {
+    const byName = new Map();
+    state.fields.forEach(function (field) {
+      byName.set(String(field.name || ""), field.id);
+    });
+    const orderedIds = [];
+    serverOrder.forEach(function (name) {
+      const fieldId = byName.get(name);
+      if (fieldId && orderedIds.indexOf(fieldId) === -1) {
+        orderedIds.push(fieldId);
+      }
+    });
+    state.accessibility.fieldOrder = orderedIds;
+  }
+
+  state.accessibility.images = Array.isArray(payload.data.images)
+    ? payload.data.images.map(function (item) {
+        return {
+          assetId: String(item.assetId || ""),
+          pageIndex: Number(item.pageIndex || 0),
+          name: String(item.name || ""),
+          altText: String(item.altText || ""),
+          width: Number(item.width || 0),
+          height: Number(item.height || 0),
+        };
+      })
+    : [];
+  state.accessibility.tagStructure = payload.data.tag_structure || null;
+  state.accessibility.inspected = true;
+  refreshAccessibilityFromFields();
+}
+
+function buildAccessibilityPayload(exportNameMap) {
+  if (!state.accessibility.enabled) {
+    return {
+      enabled: false,
+      auto_fill_missing_tooltips: true,
     };
+  }
+  const fieldTooltips = {};
+  state.fields.forEach(function (field) {
+    const exportName = exportNameMap.get(field.id);
+    if (!exportName) return;
+    const tooltip =
+      String(field.tooltip || "").trim() ||
+      defaultTooltipFromFieldName(field.name);
+    fieldTooltips[exportName] = tooltip;
+  });
 
-    const DEFAULT_FIELD_NAME_LIBRARY = {
-        text: [
-            'users1_name_first',
-            'users1_name_last',
-            'users1_name_full',
-            'users1_address_address',
-            'users1_address_city',
-            'users1_address_state',
-            'users1_address_zip',
-            'users1_phone_number',
-            'users1_email',
-            'other_parties1_name_full',
-            'docket_number',
-            'case_name'
-        ],
-        multiline: [
-            'users1_mailing_address',
-            'special_instructions',
-            'facts_summary'
-        ],
-        signature: [
-            'users1_signature',
-            'other_parties1_signature',
-            'attorney_signature'
-        ],
-        checkbox: [
-            'user_agrees',
-            'is_plaintiff',
-            'is_defendant',
-            'has_children'
-        ],
-        dropdown: ['court_division', 'selected_claim_type'],
-        listbox: ['requested_relief', 'selected_issues'],
-        radio: ['service_method']
+  const orderedNames = state.accessibility.fieldOrder
+    .map(function (fieldId) {
+      return exportNameMap.get(fieldId);
+    })
+    .filter(Boolean);
+
+  const imageAltText = {};
+  state.accessibility.images.forEach(function (imageAsset) {
+    if (!imageAsset || !imageAsset.assetId) return;
+    imageAltText[String(imageAsset.assetId)] = String(
+      imageAsset.altText || "",
+    ).trim();
+  });
+
+  return {
+    enabled: true,
+    auto_fill_missing_tooltips: true,
+    field_tooltips: fieldTooltips,
+    field_order: orderedNames,
+    image_alt_text: imageAltText,
+    metadata: Object.assign({}, state.accessibility.metadata),
+  };
+}
+
+function invalidateBulkRenamePreview() {
+  state.bulkRenamePreviewCache = null;
+}
+
+function bumpFieldNamesVersion() {
+  state.fieldNamesVersion = (Number(state.fieldNamesVersion) || 0) + 1;
+  invalidateBulkRenamePreview();
+}
+
+function getDuplicateFieldNames() {
+  const counts = new Map();
+  state.fields.forEach(function (field) {
+    const name =
+      field.name === null || field.name === undefined || field.name === ""
+        ? "field"
+        : String(field.name);
+    counts.set(name, (counts.get(name) || 0) + 1);
+  });
+  const duplicates = [];
+  counts.forEach(function (count, name) {
+    if (count > 1) duplicates.push(name);
+  });
+  return duplicates;
+}
+
+function setFieldsPanelMode(nextMode) {
+  state.fieldsPanelMode = nextMode === "rename" ? "rename" : "filter";
+  fieldsModeInputs.forEach(function (input) {
+    input.checked = input.value === state.fieldsPanelMode;
+  });
+  const showRename = state.fieldsPanelMode === "rename";
+  fieldsFilterControls.classList.toggle("hidden", showRename);
+  bulkRenameControls.classList.toggle("hidden", !showRename);
+  fieldsPanel.classList.toggle("bulk-rename-expanded", showRename);
+  if (!showRename) {
+    state.fieldSearch = fieldSearchInput.value || "";
+    refreshFieldsListFromControls();
+    return;
+  }
+  refreshFieldsListFromControls();
+}
+
+function escapeRegexPattern(text) {
+  return String(text || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildWildcardRegex(patternText) {
+  const escaped = String(patternText || "")
+    .split("")
+    .map(function (char) {
+      if (char === "*") return ".*";
+      if (char === "?") return ".";
+      return escapeRegexPattern(char);
+    })
+    .join("");
+  return new RegExp(escaped, "g");
+}
+
+function compileBulkRenameTransform(renameType, findPattern, replacementText) {
+  const replacement = String(replacementText || "");
+  if (!findPattern) {
+    return { error: "", transform: null };
+  }
+  if (renameType === "regex") {
+    try {
+      const regex = new RegExp(findPattern, "g");
+      return {
+        error: "",
+        transform: function (name) {
+          return String(name || "").replace(regex, replacement);
+        },
+      };
+    } catch (error) {
+      return {
+        error:
+          "Invalid regex: " +
+          (error && error.message ? error.message : "unknown error"),
+        transform: null,
+      };
+    }
+  }
+  const hasWildcard = /[*?]/.test(findPattern);
+  if (hasWildcard) {
+    try {
+      const wildcardRegex = buildWildcardRegex(findPattern);
+      return {
+        error: "",
+        transform: function (name) {
+          return String(name || "").replace(wildcardRegex, replacement);
+        },
+      };
+    } catch (error) {
+      return { error: "Invalid wildcard pattern.", transform: null };
+    }
+  }
+  return {
+    error: "",
+    transform: function (name) {
+      const source = String(name || "");
+      if (!findPattern) return source;
+      if (source.indexOf(findPattern) === -1) return source;
+      return source.split(findPattern).join(replacement);
+    },
+  };
+}
+
+function getBulkRenamePreview() {
+  if (state.fieldsPanelMode !== "rename") {
+    return {
+      changedCount: 0,
+      renamedById: new Map(),
+      mapping: {},
+      error: "",
+      duplicates: [],
     };
+  }
+  const renameType = state.bulkRenameType === "regex" ? "regex" : "pattern";
+  const findPattern = String(state.bulkRenamePattern || "");
+  const replacementText = String(state.bulkRenameReplacement || "");
+  const cacheKey = [
+    state.fieldNamesVersion,
+    renameType,
+    findPattern,
+    replacementText,
+  ].join("::");
+  if (
+    state.bulkRenamePreviewCache &&
+    state.bulkRenamePreviewCache.key === cacheKey
+  ) {
+    return state.bulkRenamePreviewCache.value;
+  }
+  const compiled = compileBulkRenameTransform(
+    renameType,
+    findPattern,
+    replacementText,
+  );
+  if (!compiled.transform) {
+    const emptyResult = {
+      changedCount: 0,
+      renamedById: new Map(),
+      mapping: {},
+      error: compiled.error || "",
+      duplicates: [],
+    };
+    state.bulkRenamePreviewCache = { key: cacheKey, value: emptyResult };
+    return emptyResult;
+  }
 
-    const FIELD_NAME_LIBRARY = (PDF_CONFIG.fieldNameLibrary && Object.keys(PDF_CONFIG.fieldNameLibrary).length)
-        ? PDF_CONFIG.fieldNameLibrary
-        : ((PDF_CONFIG.field_name_library && Object.keys(PDF_CONFIG.field_name_library).length)
-            ? PDF_CONFIG.field_name_library
-            : DEFAULT_FIELD_NAME_LIBRARY);
+  const renamedById = new Map();
+  const mapping = {};
+  const resultingCounts = new Map();
+  let changedCount = 0;
 
-    const state = {
-        fileName: '',
-        pdfBytes: null,
-        requestPdfFile: null,
-        quickEditFieldId: null,
-        quickEditFocusPending: false,
-        pdfDoc: null,
-        pageCount: 0,
-        pageSizes: [],
-        pageTextBoxes: [],
-        fields: [],
-        selectedFieldId: null,
-        selectedTool: null,
-        previewMode: false,
-        renderScale: 1.35,
-        viewerZoom: 1,
-        defaultModel: 'gpt-5-mini',
-        recommendedModels: ['gpt-5-mini'],
-        availableModels: [],
-        model: 'gpt-5-mini',
-        hasUnsavedChanges: false,
-        fieldSearch: '',
-        fieldTypeFilter: '',
-        fieldSort: 'position',
-        fieldsPanelMode: 'filter',
-        bulkRenameType: 'pattern',
-        bulkRenamePattern: '',
-        bulkRenameReplacement: '',
-        fieldNamesVersion: 0,
-        bulkRenamePreviewCache: null,
-        auth: {
-            isAuthenticated: false,
-            email: '',
-            loginUrl: '/user/sign-in',
-            logoutUrl: '/user/sign-out',
-            aiEnabled: false,
-            menuItems: []
-        },
-        playgroundSource: {
-            project: '',
-            filename: '',
-        },
-        initialPlaygroundSource: {
-            project: INITIAL_PLAYGROUND_SOURCE.project || '',
-            filename: INITIAL_PLAYGROUND_SOURCE.filename || '',
-            attempted: false,
-        },
-        interviewSourceMode: 'playground',
-        playground: {
-            projects: [],
-            files: [],
-            selectedProject: INITIAL_PLAYGROUND_SOURCE.project || 'default',
-            selectedFile: '',
-            variables: [],
-            topLevelNames: []
-        },
-        installed: {
-            packages: [],
-            files: [],
-            selectedPackage: '',
-            selectedFile: '',
-            variables: [],
-            topLevelNames: []
-        },
-        usePlaygroundVariables: false,
-        accessibility: {
-            enabled: true,
-            fieldOrder: [],
-            metadata: {
-                language: '',
-                title: '',
-                author: '',
-                subject: ''
+  state.fields.forEach(function (field) {
+    const original = String(field.name || "");
+    const renamed = String(compiled.transform(original));
+    const finalName = renamed || original;
+    resultingCounts.set(finalName, (resultingCounts.get(finalName) || 0) + 1);
+    if (finalName !== original) {
+      changedCount += 1;
+      renamedById.set(field.id, {
+        oldName: original,
+        newName: finalName,
+      });
+      mapping[original] = finalName;
+    }
+  });
+
+  const duplicates = [];
+  resultingCounts.forEach(function (count, name) {
+    if (count > 1) duplicates.push(name);
+  });
+  const result = {
+    changedCount: changedCount,
+    renamedById: renamedById,
+    mapping: mapping,
+    error: "",
+    duplicates: duplicates,
+  };
+  state.bulkRenamePreviewCache = { key: cacheKey, value: result };
+  return result;
+}
+
+function updateBulkRenameUiState() {
+  const preview = getBulkRenamePreview();
+  const hasPattern = String(state.bulkRenamePattern || "").length > 0;
+  bulkRenameStatus.className = "bulk-rename-status small text-muted";
+  if (!hasPattern) {
+    bulkRenameStatus.textContent =
+      "Live preview will appear in the list below.";
+  } else if (preview.error) {
+    bulkRenameStatus.classList.add("error");
+    bulkRenameStatus.textContent = preview.error;
+  } else if (preview.duplicates.length) {
+    bulkRenameStatus.classList.add("warning");
+    bulkRenameStatus.textContent =
+      "Rename would create duplicate names: " +
+      preview.duplicates.slice(0, 3).join(", ") +
+      (preview.duplicates.length > 3 ? " ..." : "");
+  } else if (preview.changedCount === 0) {
+    bulkRenameStatus.textContent = "No matching fields for current pattern.";
+  } else {
+    bulkRenameStatus.textContent =
+      "Previewing " +
+      preview.changedCount +
+      " rename" +
+      (preview.changedCount === 1 ? "" : "s") +
+      ".";
+  }
+  bulkRenameApplyBtn.disabled =
+    !hasPattern ||
+    !!preview.error ||
+    preview.changedCount === 0 ||
+    preview.duplicates.length > 0;
+}
+
+function applyBulkRename() {
+  const preview = getBulkRenamePreview();
+  if (preview.error) {
+    showError(preview.error);
+    return;
+  }
+  if (!preview.changedCount) {
+    showError("No matching fields to rename.");
+    return;
+  }
+  if (preview.duplicates.length) {
+    showError("Bulk rename would create duplicate field names.");
+    return;
+  }
+  state.fields.forEach(function (field) {
+    const change = preview.renamedById.get(field.id);
+    if (change) {
+      field.name = change.newName;
+    }
+  });
+  bumpFieldNamesVersion();
+  setDirty(true);
+  renderFieldsList();
+  renderFieldsOnPages();
+  updateFieldCount();
+  showSuccess(
+    "Renamed " +
+      preview.changedCount +
+      " field" +
+      (preview.changedCount === 1 ? "" : "s") +
+      ".",
+  );
+}
+
+function refreshFieldsListFromControls() {
+  renderFieldsList();
+  if (
+    state.selectedFieldId &&
+    fieldsList.querySelector(
+      '.field-list-item[data-field-id="' + state.selectedFieldId + '"]',
+    )
+  ) {
+    scrollSelectedFieldIntoView(state.selectedFieldId);
+  }
+}
+
+function updateToolHint() {
+  return;
+}
+
+function hideQuickFieldEditor() {
+  state.quickEditFieldId = null;
+  state.quickEditFocusPending = false;
+  quickFieldEditor.classList.add("hidden");
+  quickFieldSuggestions.innerHTML = "";
+  quickFieldSuggestions.classList.add("hidden");
+}
+
+function getVisiblePdfViewportRect() {
+  const containerRect = pdfContainer.getBoundingClientRect();
+  const left = Math.max(containerRect.left + 8, 8);
+  const top = Math.max(containerRect.top + 8, 8);
+  const right = Math.min(containerRect.right - 8, window.innerWidth - 8);
+  const bottom = Math.min(containerRect.bottom - 8, window.innerHeight - 8);
+  return {
+    left: left,
+    top: top,
+    right: Math.max(right, left + 1),
+    bottom: Math.max(bottom, top + 1),
+  };
+}
+
+function getQuickFieldEditorWidth(_fieldEl, viewportRect) {
+  const nameLength = String(quickFieldNameInput.value || "").length;
+  const preferredWidth = Math.max(260, Math.min(720, 164 + nameLength * 9));
+  return clamp(preferredWidth, 260, viewportRect.right - viewportRect.left);
+}
+
+function positionQuickFieldEditor() {
+  if (quickFieldEditor.classList.contains("hidden")) return;
+  const field = getQuickEditField();
+  if (!field) {
+    hideQuickFieldEditor();
+    return;
+  }
+  const fieldEl = document.querySelector(
+    '.field-box[data-field-id="' + field.id + '"]',
+  );
+  const viewportRect = getVisiblePdfViewportRect();
+  const editorWidth = getQuickFieldEditorWidth(fieldEl, viewportRect);
+  quickFieldEditor.style.width = Math.round(editorWidth) + "px";
+  const editorRect = quickFieldEditor.getBoundingClientRect();
+  const margin = 12;
+  let top = viewportRect.top + margin;
+  let left = viewportRect.left + margin;
+
+  if (fieldEl) {
+    const fieldRect = fieldEl.getBoundingClientRect();
+    const fieldVisible =
+      fieldRect.bottom > viewportRect.top &&
+      fieldRect.top < viewportRect.bottom &&
+      fieldRect.right > viewportRect.left &&
+      fieldRect.left < viewportRect.right;
+    const preferredTop = fieldVisible
+      ? fieldRect.top - 2
+      : (fieldRect.top + fieldRect.bottom) / 2 - editorRect.height / 2;
+    const alignedLeft = clamp(
+      fieldRect.left,
+      viewportRect.left,
+      viewportRect.right - editorRect.width,
+    );
+
+    top = clamp(
+      preferredTop,
+      viewportRect.top,
+      viewportRect.bottom - editorRect.height,
+    );
+    left = alignedLeft;
+  }
+
+  quickFieldEditor.style.top = Math.round(top) + "px";
+  quickFieldEditor.style.left = Math.round(left) + "px";
+}
+
+function updateRenderedFieldName(fieldId) {
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  const fieldEl = document.querySelector(
+    '.field-box[data-field-id="' + field.id + '"]',
+  );
+  if (fieldEl) {
+    const chip = fieldEl.querySelector(".field-chip");
+    const chipName = chip && chip.querySelector(".field-chip-name");
+    if (chipName) {
+      chipName.textContent = field.name || "";
+    }
+    if (chip) {
+      applyFieldChipLayout(fieldEl, chip);
+    }
+  }
+  const listItem = fieldsList.querySelector(
+    '.field-list-item[data-field-id="' + field.id + '"]',
+  );
+  if (listItem) {
+    const title = listItem.querySelector(".field-list-name");
+    if (title && !title.classList.contains("field-list-name-preview")) {
+      title.textContent = field.name || "";
+    }
+    const sidebarInput = listItem.querySelector('[data-action="field-name"]');
+    if (sidebarInput && document.activeElement !== sidebarInput) {
+      sidebarInput.value = field.name || "";
+    }
+    const help = listItem.querySelector(".field-card-help");
+    if (help) {
+      const nameHelp = getFieldNameHelp(field);
+      help.className = "field-card-help " + nameHelp.level;
+      help.innerHTML = nameHelp.html;
+    }
+  }
+}
+
+function commitFieldNameChange(fieldId, nextValue, source) {
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  if (field.name === nextValue) return;
+  const previousName = String(field.name || "");
+  const previousDefaultTooltip = defaultTooltipFromFieldName(previousName);
+  field.name = nextValue;
+  const currentTooltip = String(field.tooltip || "").trim();
+  if (!currentTooltip || currentTooltip === previousDefaultTooltip) {
+    field.tooltip = defaultTooltipFromFieldName(nextValue);
+  }
+  bumpFieldNamesVersion();
+  reconcileAccessibilityFieldOrder();
+  setDirty(true);
+  if (state.fieldsPanelMode === "rename") {
+    renderFieldsList();
+  }
+  updateRenderedFieldName(fieldId);
+  if (source !== "quick") {
+    const quickField = getQuickEditField();
+    if (
+      quickField &&
+      quickField.id === fieldId &&
+      document.activeElement !== quickFieldNameInput
+    ) {
+      quickFieldNameInput.value = field.name || "";
+    }
+  }
+  syncQuickFieldEditor({ preserveInput: source === "quick" });
+  updateDuplicateFieldWarning();
+}
+
+function syncQuickFieldEditor(options) {
+  const settings = options || {};
+  const field = getQuickEditField();
+  if (!field || field.id !== state.selectedFieldId) {
+    hideQuickFieldEditor();
+    return;
+  }
+
+  const meta = getFieldTypeMeta(field.type);
+  quickFieldTypeBadge.innerHTML = meta.icon;
+  if (
+    !settings.preserveInput ||
+    document.activeElement !== quickFieldNameInput
+  ) {
+    quickFieldNameInput.value = field.name || "";
+  }
+  quickFieldNameInput.dataset.fieldId = field.id;
+  renderQuickFieldSuggestions(field);
+  quickFieldEditor.classList.remove("hidden");
+  positionQuickFieldEditor();
+
+  if (state.quickEditFocusPending) {
+    window.requestAnimationFrame(function () {
+      quickFieldNameInput.focus();
+      quickFieldNameInput.select();
+    });
+    state.quickEditFocusPending = false;
+  }
+}
+
+function renderQuickFieldSuggestions(field) {
+  const detectedSuggestions = Array.isArray(field && field.nameSuggestions)
+    ? field.nameSuggestions
+    : [];
+  // Merge in playground/installed variable names that match the current input
+  const varHints = getEffectivePdfVariables();
+  const currentVal = (quickFieldNameInput.value || "").trim().toLowerCase();
+  const detectedNames = new Set(
+    detectedSuggestions.map(function (s) {
+      return s.name;
+    }),
+  );
+  const extraSuggestions = [];
+  if (varHints.length > 0 && currentVal) {
+    varHints.forEach(function (v) {
+      if (!detectedNames.has(v) && v.toLowerCase().indexOf(currentVal) !== -1) {
+        extraSuggestions.push({ name: v, text: "From interview variables" });
+      }
+    });
+  }
+  const allSuggestions = detectedSuggestions.concat(
+    extraSuggestions.slice(0, 10),
+  );
+  quickFieldSuggestions.innerHTML = "";
+  if (!allSuggestions.length) {
+    quickFieldSuggestions.classList.add("hidden");
+    return;
+  }
+  allSuggestions.forEach(function (suggestion) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className =
+      "quick-field-suggestion btn btn-outline-secondary btn-sm";
+    button.dataset.suggestedName = suggestion.name;
+    button.title = suggestion.text
+      ? "From nearby text: " + suggestion.text
+      : suggestion.name;
+    button.textContent = suggestion.name;
+    if (
+      normalizePdfFieldName(suggestion.name) ===
+      normalizePdfFieldName(field.name)
+    ) {
+      button.classList.add("active");
+    }
+    quickFieldSuggestions.appendChild(button);
+  });
+  quickFieldSuggestions.classList.remove("hidden");
+}
+
+function updateOverlayCursorState() {
+  document.querySelectorAll(".page-overlay").forEach(function (overlay) {
+    overlay.classList.toggle("tool-active", !!state.selectedTool);
+    overlay.classList.toggle(
+      "point-insert",
+      !!state.selectedTool && POINT_INSERT_TYPES.has(state.selectedTool),
+    );
+  });
+}
+
+function setSelectedTool(tool) {
+  state.selectedTool = tool ? normalizeFieldType(tool) : null;
+  Object.keys(toolButtons).forEach(function (key) {
+    toolButtons[key].classList.toggle("active", key === state.selectedTool);
+  });
+  updateToolHint();
+  updateOverlayCursorState();
+}
+
+function applyBranding() {
+  if (pageTitle) {
+    pageTitle.textContent =
+      BRANDING.pdf_page_title || BRANDING.pdf_header_title || "PDF Labeler";
+    document.title = pageTitle.textContent;
+  }
+  if (pageFavicon && BRANDING.favicon_url) {
+    pageFavicon.href = BRANDING.favicon_url;
+  }
+  if (brandLogo && BRANDING.logo_url) {
+    brandLogo.src = BRANDING.logo_url;
+  }
+  if (brandLogo && BRANDING.logo_alt) {
+    brandLogo.alt = BRANDING.logo_alt;
+  }
+  if (brandPdfTitle) {
+    brandPdfTitle.textContent = BRANDING.pdf_header_title || "PDF Labeler";
+  }
+  if (brandPdfSubtitle) {
+    brandPdfSubtitle.textContent =
+      BRANDING.pdf_header_subtitle ||
+      "Add, inspect, rename, and export PDF form fields";
+  }
+}
+
+function renderAuthControls() {
+  if (!authControls) return;
+  if (state.auth.isAuthenticated) {
+    const emailText = state.auth.email || "Account";
+    const menuItems =
+      Array.isArray(state.auth.menuItems) && state.auth.menuItems.length
+        ? state.auth.menuItems
+        : [
+            {
+              label: "Sign Out",
+              url: state.auth.logoutUrl || "/user/sign-out",
             },
-            images: [],
-            imageMode: false,
-            tagStructure: null,
-            inspected: false
-        }
+          ];
+    authControls.innerHTML =
+      '<button id="auth-menu-btn" class="btn btn-outline-light btn-sm dropdown-toggle" type="button" aria-expanded="false">' +
+      escapeHtml(emailText) +
+      "</button>" +
+      '<div id="auth-menu" class="dropdown-menu dropdown-menu-end header-auth-menu">' +
+      menuItems
+        .map(function (item) {
+          return (
+            '<a class="dropdown-item" href="' +
+            escapeHtml(item.url || "#") +
+            '">' +
+            escapeHtml(item.label || "") +
+            "</a>"
+          );
+        })
+        .join("") +
+      "</div>";
+    const menuBtn = document.getElementById("auth-menu-btn");
+    const menu = document.getElementById("auth-menu");
+    menuBtn.addEventListener("click", function (event) {
+      event.stopPropagation();
+      menu.classList.toggle("show");
+    });
+  } else {
+    authControls.innerHTML =
+      '<a class="btn btn-outline-light btn-sm" href="' +
+      escapeHtml(state.auth.loginUrl || "/user/sign-in") +
+      '">Log in</a>';
+  }
+}
+
+function updateAiUiState() {
+  const aiEnabled = !!state.auth.aiEnabled;
+  autoDetectBtn.disabled = !state.pdfBytes || !aiEnabled;
+  if (relabelBtn) {
+    relabelBtn.disabled =
+      !state.pdfBytes || state.fields.length === 0 || !aiEnabled;
+  }
+  if (sidebarRelabelBtn) {
+    sidebarRelabelBtn.disabled =
+      !state.pdfBytes || state.fields.length === 0 || !aiEnabled;
+  }
+  if (!aiEnabled) {
+    aiAuthNotice.classList.remove("hidden");
+    aiAuthNotice.innerHTML =
+      'AI features require login. <a href="' +
+      escapeHtml(state.auth.loginUrl || "/user/sign-in") +
+      '">Log in</a> to use auto-detect and AI relabel.';
+  } else {
+    aiAuthNotice.classList.add("hidden");
+  }
+  savePlaygroundBtn.classList.toggle("hidden", !state.auth.isAuthenticated);
+  openPlaygroundBtn.classList.toggle("hidden", !state.auth.isAuthenticated);
+}
+
+async function fetchModelCatalog() {
+  try {
+    const response = await fetch(apiUrl("/labeler/api/models"), {
+      method: "GET",
+    });
+    const data = await response.json();
+    if (!data.success || !data.data) return;
+    state.defaultModel = data.data.default_model || state.defaultModel;
+    state.recommendedModels =
+      Array.isArray(data.data.recommended_models) &&
+      data.data.recommended_models.length
+        ? data.data.recommended_models
+        : [state.defaultModel];
+    state.availableModels = Array.isArray(data.data.available_models)
+      ? data.data.available_models
+      : [];
+    state.model = state.defaultModel;
+    aiModelInput.value = state.model;
+  } catch (_error) {
+    aiModelInput.value = state.model;
+  }
+}
+
+async function fetchAuthStatus() {
+  try {
+    const nextTarget = window.location.pathname + window.location.search;
+    const response = await fetch(
+      apiUrl("/labeler/api/auth-status") +
+        "?next=" +
+        encodeURIComponent(nextTarget),
+      { method: "GET" },
+    );
+    const data = await response.json();
+    if (data.success && data.data) {
+      state.auth.isAuthenticated = !!data.data.is_authenticated;
+      state.auth.email = data.data.email || "";
+      state.auth.loginUrl = data.data.login_url || "/user/sign-in";
+      state.auth.logoutUrl = data.data.logout_url || "/user/sign-out";
+      state.auth.aiEnabled = !!data.data.ai_enabled;
+      state.auth.menuItems = Array.isArray(data.data.menu_items)
+        ? data.data.menu_items
+        : [];
+    }
+  } catch (_error) {
+    state.auth = {
+      isAuthenticated: false,
+      email: "",
+      loginUrl: "/user/sign-in",
+      logoutUrl: "/user/sign-out",
+      aiEnabled: false,
+      menuItems: [],
     };
+  }
+  renderAuthControls();
+  updateAiUiState();
+  if (state.auth.isAuthenticated) {
+    await fetchPdfPlaygroundProjects();
+    await maybeOpenInitialPlaygroundTemplate();
+  }
+}
 
-    // --- Session-persisted defaults for font, fontSize, checkboxStyle ---
-    const SESSION_DEFAULTS_KEY = 'pdfLabeler_sessionDefaults';
-    const HARD_DEFAULTS = { font: 'Helvetica', fontSize: 10, checkboxStyle: 'cross', checkboxExportValue: 'Yes' };
+async function maybeOpenInitialPlaygroundTemplate() {
+  if (!state.auth.isAuthenticated) return;
+  if (state.initialPlaygroundSource.attempted) return;
+  var project = state.initialPlaygroundSource.project;
+  var filename = state.initialPlaygroundSource.filename;
+  if (!project || !filename) {
+    state.initialPlaygroundSource.attempted = true;
+    return;
+  }
+  state.initialPlaygroundSource.attempted = true;
+  if (state.playground.projects.indexOf(project) === -1) return;
+  state.playground.selectedProject = project;
+  renderPdfInterviewPicker();
+  await openPdfTemplateFromPlayground(project, filename, {
+    showSuccess: false,
+  });
+}
 
-    function _loadSessionDefaults() {
-        try {
-            const raw = sessionStorage.getItem(SESSION_DEFAULTS_KEY);
-            if (raw) {
-                const parsed = JSON.parse(raw);
-                return Object.assign({}, HARD_DEFAULTS, parsed);
-            }
-        } catch (_e) { /* ignore */ }
-        return Object.assign({}, HARD_DEFAULTS);
+// ================================================================
+// Playground integration (variable hints, open, save)
+// ================================================================
+
+async function fetchPdfPlaygroundProjects() {
+  if (!state.auth.isAuthenticated) {
+    state.playground.projects = [];
+    state.playground.files = [];
+    return;
+  }
+  try {
+    var response = await fetch(apiUrl("/labeler/api/playground-projects"), {
+      method: "GET",
+      credentials: "same-origin",
+    });
+    var data = await response.json();
+    state.playground.projects =
+      data && data.success && data.data && Array.isArray(data.data.projects)
+        ? data.data.projects
+        : [];
+    if (
+      state.playground.projects.indexOf(state.playground.selectedProject) === -1
+    )
+      state.playground.selectedProject =
+        state.playground.projects[0] || "default";
+    await fetchPdfPlaygroundFiles();
+  } catch (_e) {
+    state.playground.projects = [];
+  }
+  renderPdfInterviewPicker();
+}
+
+async function fetchPdfPlaygroundFiles() {
+  if (!state.playground.selectedProject) {
+    state.playground.files = [];
+    renderPdfInterviewPicker();
+    return;
+  }
+  try {
+    var response = await fetch(
+      apiUrl(
+        "/labeler/api/playground-files?project=" +
+          encodeURIComponent(state.playground.selectedProject),
+      ),
+      { method: "GET", credentials: "same-origin" },
+    );
+    var data = await response.json();
+    var files =
+      data && data.success && data.data && Array.isArray(data.data.files)
+        ? data.data.files
+        : [];
+    state.playground.files = files;
+    var exists = files.some(function (f) {
+      return f.filename === state.playground.selectedFile;
+    });
+    state.playground.selectedFile = exists
+      ? state.playground.selectedFile
+      : files[0]
+        ? files[0].filename
+        : "";
+    await fetchPdfPlaygroundVariables();
+  } catch (_e) {
+    state.playground.files = [];
+    state.playground.variables = [];
+    state.playground.topLevelNames = [];
+  }
+  renderPdfInterviewPicker();
+}
+
+async function fetchPdfPlaygroundVariables() {
+  if (!state.playground.selectedProject || !state.playground.selectedFile) {
+    state.playground.variables = [];
+    state.playground.topLevelNames = [];
+    renderPdfInterviewPicker();
+    return;
+  }
+  try {
+    var response = await fetch(
+      apiUrl(
+        "/labeler/api/playground-variables?project=" +
+          encodeURIComponent(state.playground.selectedProject) +
+          "&filename=" +
+          encodeURIComponent(state.playground.selectedFile),
+      ),
+      { method: "GET", credentials: "same-origin" },
+    );
+    var data = await response.json();
+    state.playground.variables =
+      data && data.success && data.data && Array.isArray(data.data.all_names)
+        ? data.data.all_names
+        : [];
+    state.playground.topLevelNames =
+      data &&
+      data.success &&
+      data.data &&
+      Array.isArray(data.data.top_level_names)
+        ? data.data.top_level_names
+        : [];
+  } catch (_e) {
+    state.playground.variables = [];
+    state.playground.topLevelNames = [];
+  }
+  renderPdfInterviewPicker();
+}
+
+async function fetchPdfInstalledPackages() {
+  if (!state.auth.isAuthenticated) {
+    state.installed.packages = [];
+    return;
+  }
+  try {
+    var response = await fetch(apiUrl("/labeler/api/installed-packages"), {
+      method: "GET",
+      credentials: "same-origin",
+    });
+    var data = await response.json();
+    state.installed.packages =
+      data && data.success && data.data && Array.isArray(data.data.packages)
+        ? data.data.packages
+        : [];
+    if (
+      state.installed.packages.indexOf(state.installed.selectedPackage) === -1
+    )
+      state.installed.selectedPackage = state.installed.packages[0] || "";
+    await fetchPdfInstalledFiles();
+  } catch (_e) {
+    state.installed.packages = [];
+  }
+  renderPdfInterviewPicker();
+}
+
+async function fetchPdfInstalledFiles() {
+  if (!state.installed.selectedPackage) {
+    state.installed.files = [];
+    renderPdfInterviewPicker();
+    return;
+  }
+  try {
+    var response = await fetch(
+      apiUrl(
+        "/labeler/api/installed-files?package=" +
+          encodeURIComponent(state.installed.selectedPackage),
+      ),
+      { method: "GET", credentials: "same-origin" },
+    );
+    var data = await response.json();
+    var files =
+      data && data.success && data.data && Array.isArray(data.data.files)
+        ? data.data.files
+        : [];
+    state.installed.files = files;
+    var exists = files.some(function (f) {
+      return f.filename === state.installed.selectedFile;
+    });
+    state.installed.selectedFile = exists
+      ? state.installed.selectedFile
+      : files[0]
+        ? files[0].filename
+        : "";
+    await fetchPdfInstalledVariables();
+  } catch (_e) {
+    state.installed.files = [];
+    state.installed.variables = [];
+    state.installed.topLevelNames = [];
+  }
+  renderPdfInterviewPicker();
+}
+
+async function fetchPdfInstalledVariables() {
+  if (!state.installed.selectedPackage || !state.installed.selectedFile) {
+    state.installed.variables = [];
+    state.installed.topLevelNames = [];
+    renderPdfInterviewPicker();
+    return;
+  }
+  try {
+    var path =
+      state.installed.selectedPackage + ":" + state.installed.selectedFile;
+    var response = await fetch(
+      apiUrl(
+        "/labeler/api/installed-variables?interview_path=" +
+          encodeURIComponent(path),
+      ),
+      { method: "GET", credentials: "same-origin" },
+    );
+    var data = await response.json();
+    state.installed.variables =
+      data && data.success && data.data && Array.isArray(data.data.all_names)
+        ? data.data.all_names
+        : [];
+    state.installed.topLevelNames =
+      data &&
+      data.success &&
+      data.data &&
+      Array.isArray(data.data.top_level_names)
+        ? data.data.top_level_names
+        : [];
+  } catch (_e) {
+    state.installed.variables = [];
+    state.installed.topLevelNames = [];
+  }
+  renderPdfInterviewPicker();
+}
+
+function renderPdfInterviewPicker() {
+  pdfInterviewPicker.classList.toggle("hidden", !state.usePlaygroundVariables);
+  var isPlayground = state.interviewSourceMode === "playground";
+  pdfPlaygroundFields.classList.toggle("hidden", !isPlayground);
+  pdfInstalledFields.classList.toggle("hidden", isPlayground);
+  pdfInterviewSourceModeInputs.forEach(function (inp) {
+    inp.checked = inp.value === state.interviewSourceMode;
+  });
+
+  // Populate playground selects
+  pdfPlaygroundProjectSelect.innerHTML = "";
+  state.playground.projects.forEach(function (proj) {
+    var opt = document.createElement("option");
+    opt.value = proj;
+    opt.textContent = proj;
+    opt.selected = proj === state.playground.selectedProject;
+    pdfPlaygroundProjectSelect.appendChild(opt);
+  });
+  pdfPlaygroundYamlFileSelect.innerHTML = "";
+  state.playground.files.forEach(function (f) {
+    var opt = document.createElement("option");
+    opt.value = f.filename;
+    opt.textContent = f.filename;
+    opt.selected = f.filename === state.playground.selectedFile;
+    pdfPlaygroundYamlFileSelect.appendChild(opt);
+  });
+
+  // Populate installed selects
+  pdfInstalledPackageSelect.innerHTML = "";
+  state.installed.packages.forEach(function (pkg) {
+    var opt = document.createElement("option");
+    opt.value = pkg;
+    opt.textContent = pkg;
+    opt.selected = pkg === state.installed.selectedPackage;
+    pdfInstalledPackageSelect.appendChild(opt);
+  });
+  pdfInstalledYamlFileSelect.innerHTML = "";
+  state.installed.files.forEach(function (f) {
+    var opt = document.createElement("option");
+    opt.value = f.filename;
+    opt.textContent = f.filename;
+    opt.selected = f.filename === state.installed.selectedFile;
+    pdfInstalledYamlFileSelect.appendChild(opt);
+  });
+
+  // Variable summary
+  var vars = getEffectivePdfVariables();
+  if (vars.length > 0) {
+    pdfInterviewVariableSummary.textContent =
+      vars.length +
+      " variable name" +
+      (vars.length === 1 ? "" : "s") +
+      " loaded.";
+    pdfInterviewVariableSummary.classList.remove("hidden");
+  } else {
+    pdfInterviewVariableSummary.classList.add("hidden");
+  }
+}
+
+function getEffectivePdfVariables() {
+  if (!state.usePlaygroundVariables) return [];
+  if (state.interviewSourceMode === "installed")
+    return state.installed.variables || [];
+  return state.playground.variables || [];
+}
+
+// Open from Playground modal
+async function openPlaygroundModal() {
+  if (!state.auth.isAuthenticated) {
+    showError("Login required to access Playground.");
+    return;
+  }
+  // Show modal immediately with loading states
+  var openPgProject = document.getElementById("open-pg-project");
+  var openPgTemplate = document.getElementById("open-pg-template");
+  openPgProject.innerHTML = '<option value="">Loading projects...</option>';
+  openPgTemplate.innerHTML =
+    '<option value="">Waiting for projects...</option>';
+  openPlaygroundModalEl.classList.remove("hidden");
+  // Load data in background
+  (async function () {
+    try {
+      await fetchPdfPlaygroundProjects();
+      openPgProject.innerHTML = "";
+      state.playground.projects.forEach(function (proj) {
+        var opt = document.createElement("option");
+        opt.value = proj;
+        opt.textContent = proj;
+        opt.selected = proj === state.playground.selectedProject;
+        openPgProject.appendChild(opt);
+      });
+      await fetchOpenPlaygroundTemplates();
+    } catch (e) {
+      console.error("Error loading playground data:", e);
+      openPgProject.innerHTML =
+        '<option value="">(error loading projects)</option>';
+      openPgTemplate.innerHTML =
+        '<option value="">(error loading templates)</option>';
     }
-    function _saveSessionDefaults(defaults) {
-        try {
-            sessionStorage.setItem(SESSION_DEFAULTS_KEY, JSON.stringify(defaults));
-        } catch (_e) { /* ignore */ }
+  })();
+}
+
+async function fetchOpenPlaygroundTemplates() {
+  var openPgProject = document.getElementById("open-pg-project");
+  var openPgTemplate = document.getElementById("open-pg-template");
+  var project = openPgProject.value || "default";
+  openPgTemplate.innerHTML = '<option value="">Loading...</option>';
+  try {
+    var response = await fetch(
+      apiUrl(
+        "/labeler/api/playground-templates?project=" +
+          encodeURIComponent(project) +
+          "&type=pdf",
+      ),
+      { method: "GET", credentials: "same-origin" },
+    );
+    var data = await response.json();
+    var templates =
+      data && data.success && data.data && Array.isArray(data.data.templates)
+        ? data.data.templates
+        : [];
+    openPgTemplate.innerHTML = "";
+    if (templates.length === 0) {
+      var opt = document.createElement("option");
+      opt.value = "";
+      opt.textContent = "(no PDF templates found)";
+      openPgTemplate.appendChild(opt);
+      return;
     }
-    function getSessionDefault(key) {
-        return _loadSessionDefaults()[key] || HARD_DEFAULTS[key];
+    templates.forEach(function (t) {
+      var opt = document.createElement("option");
+      opt.value = t.filename;
+      opt.textContent =
+        t.filename + (t.size ? " (" + Math.round(t.size / 1024) + " KB)" : "");
+      openPgTemplate.appendChild(opt);
+    });
+  } catch (_e) {
+    openPgTemplate.innerHTML =
+      '<option value="">(error loading templates)</option>';
+  }
+}
+
+async function confirmOpenFromPlayground() {
+  var openPgProject = document.getElementById("open-pg-project");
+  var openPgTemplate = document.getElementById("open-pg-template");
+  var project = openPgProject.value || "default";
+  var filename = openPgTemplate.value;
+  if (!filename) {
+    showError("Select a template file.");
+    return;
+  }
+  openPlaygroundModalEl.classList.add("hidden");
+  await openPdfTemplateFromPlayground(project, filename);
+}
+
+async function openPdfTemplateFromPlayground(project, filename, options) {
+  options = options || {};
+  showLoading("Loading " + filename + " from Playground...");
+  try {
+    var response = await fetch(
+      apiUrl(
+        "/labeler/api/playground-templates/load?project=" +
+          encodeURIComponent(project) +
+          "&filename=" +
+          encodeURIComponent(filename),
+      ),
+      { method: "GET", credentials: "same-origin" },
+    );
+    var data = await response.json();
+    if (!data.success || !data.data || !data.data.file_content_base64) {
+      throw new Error(
+        (data.error && data.error.message) || "Failed to load template.",
+      );
     }
-    function setSessionDefault(key, value) {
-        const defaults = _loadSessionDefaults();
-        defaults[key] = value;
-        _saveSessionDefaults(defaults);
+    var bytes = base64ToUint8Array(data.data.file_content_base64);
+    var file = new File([bytes], filename, { type: "application/pdf" });
+    state.playgroundSource = { project: project, filename: filename };
+    savePlaygroundBtn.classList.remove("hidden");
+    await loadPdf(file);
+    if (options.showSuccess !== false) {
+      showSuccess("Opened " + filename + " from Playground.");
+    }
+  } catch (error) {
+    showPdfWorkspace();
+    showError(
+      "Failed to load from Playground: " + (error.message || "Unknown error."),
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+// Save to Playground modal
+async function openSavePlaygroundModal() {
+  if (!state.auth.isAuthenticated) {
+    showError("Login required to save to Playground.");
+    return;
+  }
+  if (!state.pdfBytes) {
+    showError("No PDF loaded.");
+    return;
+  }
+  // Show modal immediately
+  var savePgProject = document.getElementById("save-pg-project");
+  var savePgFilename = document.getElementById("save-pg-filename");
+  var savePgStatus = document.getElementById("save-pg-status");
+  savePgProject.innerHTML = '<option value="">Loading projects...</option>';
+  savePgFilename.value =
+    state.playgroundSource.filename || state.fileName || "template.pdf";
+  if (!savePgFilename.value.toLowerCase().endsWith(".pdf"))
+    savePgFilename.value += ".pdf";
+  var duplicateNames = getDuplicateFieldNames();
+  var saveDedupeInput = document.getElementById(
+    "save-pg-deduplicate-field-names",
+  );
+  var saveDuplicateWarning = document.getElementById(
+    "save-pg-duplicate-warning",
+  );
+  if (saveDedupeInput) {
+    saveDedupeInput.checked =
+      !exportDeduplicateFieldNamesInput ||
+      exportDeduplicateFieldNamesInput.checked;
+  }
+  if (saveDuplicateWarning) {
+    saveDuplicateWarning.classList.toggle(
+      "hidden",
+      duplicateNames.length === 0,
+    );
+    if (duplicateNames.length) {
+      saveDuplicateWarning.textContent =
+        "Duplicate PDF field names detected: " +
+        duplicateNames.slice(0, 5).join(", ") +
+        (duplicateNames.length > 5 ? " ..." : "") +
+        ". Some PDF viewers handle duplicate names unpredictably.";
+    }
+  }
+  savePgStatus.classList.add("hidden");
+  savePlaygroundModalEl.classList.remove("hidden");
+  // Load projects in background
+  (async function () {
+    try {
+      await fetchPdfPlaygroundProjects();
+      savePgProject.innerHTML = "";
+      state.playground.projects.forEach(function (proj) {
+        var opt = document.createElement("option");
+        opt.value = proj;
+        opt.textContent = proj;
+        opt.selected =
+          proj ===
+          (state.playgroundSource.project || state.playground.selectedProject);
+        savePgProject.appendChild(opt);
+      });
+    } catch (e) {
+      console.error("Error loading projects:", e);
+      savePgProject.innerHTML =
+        '<option value="">(error loading projects)</option>';
+    }
+  })();
+}
+
+async function confirmSaveToPlayground() {
+  var savePgProject = document.getElementById("save-pg-project");
+  var savePgFilename = document.getElementById("save-pg-filename");
+  var savePgStatus = document.getElementById("save-pg-status");
+  var project = savePgProject.value || "default";
+  var filename = savePgFilename.value.trim();
+  if (!filename || !filename.toLowerCase().endsWith(".pdf")) {
+    savePgStatus.textContent = "Filename must end with .pdf";
+    savePgStatus.classList.remove("hidden");
+    return;
+  }
+  savePlaygroundModalEl.classList.add("hidden");
+  showLoading("Saving to Playground...");
+  try {
+    // First export to get the latest PDF with field changes applied
+    var pdfContent;
+    var saveRenamedFields = [];
+    var saveDeduplicateFieldNames = document.getElementById(
+      "save-pg-deduplicate-field-names",
+    ).checked;
+    if (
+      state.fields.length > 0 &&
+      (state.hasUnsavedChanges || saveDeduplicateFieldNames)
+    ) {
+      var formData = new FormData();
+      formData.append("file", getPdfFileForRequests());
+      var saveNameMap = buildExportNameMap({
+        deduplicate: saveDeduplicateFieldNames,
+      });
+      saveRenamedFields = getRenamedFields(saveNameMap);
+      formData.append(
+        "fields",
+        JSON.stringify(convertFieldsToAbsoluteCoordinates(saveNameMap)),
+      );
+      formData.append(
+        "accessibility",
+        JSON.stringify(buildAccessibilityPayload(saveNameMap)),
+      );
+      formData.append(
+        "deduplicate_field_names",
+        saveDeduplicateFieldNames ? "true" : "false",
+      );
+      var exportResponse = await fetch(
+        apiUrl("/pdf-labeler/api/apply-fields"),
+        {
+          method: "POST",
+          headers: { Accept: "application/json" },
+          body: formData,
+        },
+      );
+      var exportData = await parseApiResponse(exportResponse);
+      if (
+        !exportData.success ||
+        !exportData.data ||
+        !exportData.data.pdf_base64
+      ) {
+        throw new Error("Failed to apply fields before saving.");
+      }
+      pdfContent = exportData.data.pdf_base64;
+    } else {
+      // Use current PDF bytes as-is
+      var raw = "";
+      var bytes = new Uint8Array(state.pdfBytes);
+      for (var i = 0; i < bytes.length; i++)
+        raw += String.fromCharCode(bytes[i]);
+      pdfContent = window.btoa(raw);
     }
 
-    function looksLikeSingleLineAutoSizeField(fieldName) {
-        return /(name|address|street|city|state|zip|postal|phone|phone_number|email|cell)/i.test(String(fieldName || ''));
+    var response = await fetch(
+      apiUrl("/labeler/api/playground-templates/save"),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          project: project,
+          filename: filename,
+          file_content_base64: pdfContent,
+        }),
+        credentials: "same-origin",
+      },
+    );
+    var data = await response.json();
+    if (!data.success)
+      throw new Error((data.error && data.error.message) || "Save failed.");
+    state.playgroundSource = { project: project, filename: filename };
+    savePlaygroundBtn.classList.remove("hidden");
+    setDirty(false);
+    showPdfWorkspace();
+    showSuccess(
+      (data.data && data.data.created ? "Created" : "Updated") +
+        " " +
+        filename +
+        " in Playground.",
+    );
+    showFieldRenameSummary(
+      saveRenamedFields,
+      "The PDF was saved after these exact duplicate field names were made unique.",
+    );
+  } catch (error) {
+    showPdfWorkspace();
+    showError(
+      "Save to Playground failed: " + (error.message || "Unknown error."),
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+function renderModelSuggestions(filterText) {
+  const filter = (filterText || "").trim().toLowerCase();
+  const source = filter
+    ? state.availableModels.length
+      ? state.availableModels
+      : state.recommendedModels
+    : state.recommendedModels;
+  const models = source
+    .filter(function (name) {
+      return !filter || name.toLowerCase().includes(filter);
+    })
+    .slice(0, 20);
+  aiModelSuggestions.innerHTML = "";
+  if (models.length === 0) {
+    aiModelSuggestions.classList.add("hidden");
+    return;
+  }
+  models.forEach(function (name) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "model-suggestion-btn font-monospace";
+    button.textContent = name;
+    button.addEventListener("click", function () {
+      aiModelInput.value = name;
+      state.model = name;
+      aiModelSuggestions.classList.add("hidden");
+    });
+    aiModelSuggestions.appendChild(button);
+  });
+  aiModelSuggestions.classList.remove("hidden");
+}
+
+function arrayBufferToUint8Array(buffer) {
+  return new Uint8Array(buffer);
+}
+
+function base64ToUint8Array(base64String) {
+  const binaryString = window.atob(base64String);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let index = 0; index < binaryString.length; index += 1) {
+    bytes[index] = binaryString.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function clonePdfBytes(pdfBytes) {
+  if (!pdfBytes) return null;
+  if (pdfBytes instanceof Uint8Array) {
+    return new Uint8Array(pdfBytes);
+  }
+  if (ArrayBuffer.isView(pdfBytes)) {
+    return new Uint8Array(
+      pdfBytes.buffer.slice(
+        pdfBytes.byteOffset,
+        pdfBytes.byteOffset + pdfBytes.byteLength,
+      ),
+    );
+  }
+  if (pdfBytes instanceof ArrayBuffer) {
+    return new Uint8Array(pdfBytes.slice(0));
+  }
+  return new Uint8Array(pdfBytes);
+}
+
+function looksLikePdfBytes(pdfBytes) {
+  if (!pdfBytes || pdfBytes.length < 5) return false;
+  return (
+    pdfBytes[0] === 0x25 &&
+    pdfBytes[1] === 0x50 &&
+    pdfBytes[2] === 0x44 &&
+    pdfBytes[3] === 0x46 &&
+    pdfBytes[4] === 0x2d
+  );
+}
+
+function applyReturnedPdfPayload(data, fallbackName) {
+  if (!data || !data.pdf_base64) {
+    return false;
+  }
+  const nextPdfBytes = base64ToUint8Array(data.pdf_base64);
+  if (!looksLikePdfBytes(nextPdfBytes)) {
+    throw new Error("AI relabel returned output that was not a valid PDF.");
+  }
+  syncPdfState(
+    nextPdfBytes,
+    data.output_filename ||
+      data.filename ||
+      fallbackName ||
+      state.fileName ||
+      "edited-form.pdf",
+  );
+  return true;
+}
+
+function getRelabelChangedCount(data) {
+  const previous = Array.isArray(data && data.fields_old)
+    ? data.fields_old
+    : [];
+  const next = Array.isArray(data && data.fields) ? data.fields : [];
+  if (!previous.length || previous.length !== next.length) return null;
+  let changedCount = 0;
+  previous.forEach(function (name, index) {
+    if (String(name || "") !== String(next[index] || "")) {
+      changedCount += 1;
     }
+  });
+  return changedCount;
+}
 
-    let draftState = null;
-    let dragState = null;
-    let resizeState = null;
-    let currentVisiblePageIndex = 0;
-    let fieldsListSyncRaf = null;
-    let fieldsListProgrammaticScroll = false;
-    let fieldsListManualScrollUntil = 0;
-    let pageManagerState = null;
-    let pageManagerDragPageId = null;
-    let a11yDragFieldId = null;
+function reconcileRelabeledFields(fields, data) {
+  const expectedNames = Array.isArray(data && data.fields)
+    ? data.fields.map(function (name) {
+        return String(name || "");
+      })
+    : [];
+  const previousNames = Array.isArray(data && data.fields_old)
+    ? data.fields_old.map(function (name) {
+        return String(name || "");
+      })
+    : [];
 
-    const fileInput = document.getElementById('file-input');
-    const pdfContainer = document.getElementById('pdf-container');
-    const pdfEmpty = document.getElementById('pdf-empty');
-    const pdfLoading = document.getElementById('pdf-loading');
-    const loadingMessage = document.getElementById('loading-message');
-    const managePagesBtn = document.getElementById('manage-pages-btn');
-    const pdfZoomOutBtn = document.getElementById('pdf-zoom-out');
-    const pdfZoomInBtn = document.getElementById('pdf-zoom-in');
-    const pdfZoomResetBtn = document.getElementById('pdf-zoom-reset');
-    const pdfZoomLabel = document.getElementById('pdf-zoom-label');
-    const floatingToolPicker = document.getElementById('floating-tool-picker');
-    const pdfPages = document.getElementById('pdf-pages');
-    const fieldsEmpty = document.getElementById('fields-empty');
-    const fieldsList = document.getElementById('fields-list');
-    const fieldCount = document.getElementById('field-count');
-    const fieldSearchInput = document.getElementById('field-search');
-    const fieldTypeFilterInput = document.getElementById('field-type-filter');
-    const fieldSortInput = document.getElementById('field-sort');
-    const fieldsPanel = document.getElementById('fields-panel');
-    const fieldsFilterControls = document.getElementById('fields-filter-controls');
-    const bulkRenameControls = document.getElementById('bulk-rename-controls');
-    const fieldsModeInputs = Array.from(document.querySelectorAll('input[name="fields-panel-mode"]'));
-    const bulkRenameTypeInput = document.getElementById('bulk-rename-type');
-    const bulkRenamePatternInput = document.getElementById('bulk-rename-pattern');
-    const bulkRenameReplacementInput = document.getElementById('bulk-rename-replacement');
-    const bulkRenameStatus = document.getElementById('bulk-rename-status');
-    const bulkRenameApplyBtn = document.getElementById('bulk-rename-apply');
-    const autoDetectBtn = document.getElementById('auto-detect-btn');
-    const relabelBtn = document.getElementById('relabel-btn');
-    const sidebarRelabelBtn = document.getElementById('sidebar-relabel-btn');
-    const exportDeduplicateFieldNamesInput = document.getElementById('export-deduplicate-field-names');
-    const duplicateFieldWarning = document.getElementById('duplicate-field-warning');
-    const exportBtn = document.getElementById('export-btn');
-    const testFillingBtn = document.getElementById('test-filling-btn');
-    const normalizePassBtn = document.getElementById('normalize-pass-btn');
-    const errorToast = document.getElementById('error-toast');
-    const errorToastMessage = document.getElementById('error-toast-message');
-    const successToast = document.getElementById('success-toast');
-    const successToastMessage = document.getElementById('success-toast-message');
-    const aiAuthNotice = document.getElementById('ai-auth-notice');
-    const authControls = document.getElementById('auth-controls');
-    const settingsBtn = document.getElementById('settings-btn');
-    const settingsModal = document.getElementById('settings-modal');
-    const closeSettingsBtn = document.getElementById('close-settings');
-    const saveSettingsBtn = document.getElementById('save-settings');
-    const resetSettingsBtn = document.getElementById('reset-settings');
-    const normalizationModal = document.getElementById('normalization-modal');
-    const closeNormalizationBtn = document.getElementById('close-normalization');
-    const applyNormalizationBtn = document.getElementById('apply-normalization');
-    const repairBtn = document.getElementById('repair-btn');
-    const repairModal = document.getElementById('repair-modal');
-    const closeRepairBtn = document.getElementById('close-repair');
-    const repairStatus = document.getElementById('repair-status');
-    const repairStatusText = document.getElementById('repair-status-text');
-    const utilitiesBtn = document.getElementById('utilities-btn');
-    const accessibilityBtn = document.getElementById('accessibility-btn');
-    const previewBtn = document.getElementById('preview-btn');
-    const accessibilityModal = document.getElementById('accessibility-modal');
-    const closeAccessibilityBtn = document.getElementById('close-accessibility');
-    const a11yEnableInput = document.getElementById('a11y-enable');
-    const a11yAutofillTooltipsBtn = document.getElementById('a11y-autofill-tooltips');
-    const a11yFieldList = document.getElementById('a11y-field-list');
-    const a11yMetaLanguage = document.getElementById('a11y-meta-language');
-    const a11yMetaTitle = document.getElementById('a11y-meta-title');
-    const a11yMetaAuthor = document.getElementById('a11y-meta-author');
-    const a11yMetaSubject = document.getElementById('a11y-meta-subject');
-    const a11yImageModeInput = document.getElementById('a11y-image-mode');
-    const a11yImageList = document.getElementById('a11y-image-list');
-    const a11yTagStructure = document.getElementById('a11y-tag-structure');
-    const utilitiesModal = document.getElementById('utilities-modal');
-    const utilitiesCloseBtn = document.getElementById('utilities-close');
-    const fieldRenameSummaryModal = document.getElementById('field-rename-summary-modal');
-    const fieldRenameSummaryContext = document.getElementById('field-rename-summary-context');
-    const fieldRenameSummaryList = document.getElementById('field-rename-summary-list');
-    const pageManagerModal = document.getElementById('page-manager-modal');
-    const closePageManagerBtn = document.getElementById('close-page-manager');
-    const pageManagerStatus = document.getElementById('page-manager-status');
-    const pageManagerPages = document.getElementById('page-manager-pages');
-    const pageManagerDropzone = document.getElementById('page-manager-dropzone');
-    const pageManagerSummary = document.getElementById('page-manager-summary');
-    const pageManagerInsertFileInput = document.getElementById('page-manager-insert-file');
-    const pageManagerInsertFileName = document.getElementById('page-manager-insert-file-name');
-    const pageManagerInsertPosition = document.getElementById('page-manager-insert-position');
-    const pageManagerInsertSelectionSummary = document.getElementById('page-manager-insert-selection-summary');
-    const pageManagerInsertPages = document.getElementById('page-manager-insert-pages');
-    const pageManagerInsertRunBtn = document.getElementById('page-manager-insert-run');
-    const pageManagerResetBtn = document.getElementById('page-manager-reset');
-    const pageManagerDownloadSplitsBtn = document.getElementById('page-manager-download-splits');
-    const pageManagerApplyBtn = document.getElementById('page-manager-apply');
-    const passwordModal = document.getElementById('password-modal');
-    const passwordInput = document.getElementById('password-input');
-    const passwordError = document.getElementById('password-error');
-    const passwordSubmitBtn = document.getElementById('password-submit');
-    const passwordCancelBtn = document.getElementById('password-cancel');
-    const repairPromptModal = document.getElementById('repair-prompt-modal');
-    const repairPromptMessage = document.getElementById('repair-prompt-message');
-    const repairPromptFixBtn = document.getElementById('repair-prompt-fix');
-    const repairPromptCancelBtn = document.getElementById('repair-prompt-cancel');
-    const aiModelInput = document.getElementById('ai-model');
-    const aiModelSuggestions = document.getElementById('ai-model-suggestions');
-    const pageTitle = document.getElementById('page-title');
-    const pageFavicon = document.getElementById('page-favicon');
-    const brandLogo = document.getElementById('brand-logo');
-    const brandPdfTitle = document.getElementById('brand-pdf-title');
-    const brandPdfSubtitle = document.getElementById('brand-pdf-subtitle');
-    const documentName = document.getElementById('document-name');
-    const dirtyIndicator = document.getElementById('dirty-indicator');
-    const openPlaygroundBtn = document.getElementById('open-playground-btn');
-    const savePlaygroundBtn = document.getElementById('save-playground-btn');
-    const openPlaygroundModalEl = document.getElementById('open-playground-modal');
-    const savePlaygroundModalEl = document.getElementById('save-playground-modal');
-    const usePlaygroundVariablesInput = document.getElementById('use-playground-variables');
-    const pdfInterviewPicker = document.getElementById('pdf-interview-picker');
-    const pdfPlaygroundFields = document.getElementById('pdf-playground-fields');
-    const pdfInstalledFields = document.getElementById('pdf-installed-fields');
-    const pdfPlaygroundProjectSelect = document.getElementById('pdf-playground-project');
-    const pdfPlaygroundYamlFileSelect = document.getElementById('pdf-playground-yaml-file');
-    const pdfInstalledPackageSelect = document.getElementById('pdf-installed-package');
-    const pdfInstalledYamlFileSelect = document.getElementById('pdf-installed-yaml-file');
-    const pdfInterviewVariableSummary = document.getElementById('pdf-interview-variable-summary');
-    const pdfInterviewSourceModeInputs = Array.from(document.querySelectorAll('input[name="pdf-interview-source-mode"]'));
-    const quickFieldEditor = document.getElementById('quick-field-editor');
-    const quickFieldTypeBadge = document.getElementById('quick-field-type-badge');
-    const quickFieldNameInput = document.getElementById('quick-field-name');
-    const quickFieldDeleteBtn = document.getElementById('quick-field-delete');
-    const quickFieldCloseBtn = document.getElementById('quick-field-close');
-    const quickFieldSuggestions = document.getElementById('quick-field-suggestions');
+  if (!expectedNames.length) {
+    return Array.isArray(fields) ? fields : [];
+  }
 
-    const toolButtons = {
-        text: document.getElementById('tool-text'),
-        multiline: document.getElementById('tool-multiline'),
-        checkbox: document.getElementById('tool-checkbox'),
-        signature: document.getElementById('tool-signature'),
-        dropdown: document.getElementById('tool-dropdown'),
-        listbox: document.getElementById('tool-listbox'),
+  const baseFields =
+    Array.isArray(fields) && fields.length
+      ? fields.map(function (field) {
+          return Object.assign({}, field);
+        })
+      : state.fields.map(function (field) {
+          return Object.assign({}, field);
+        });
+
+  if (baseFields.length !== expectedNames.length) {
+    return baseFields;
+  }
+
+  if (previousNames.length === expectedNames.length) {
+    const renameMap = new Map();
+    previousNames.forEach(function (name, index) {
+      renameMap.set(name, expectedNames[index]);
+    });
+    return baseFields.map(function (field, index) {
+      const nextName =
+        renameMap.get(String(field.name || "")) || expectedNames[index];
+      return Object.assign({}, field, { name: nextName || field.name });
+    });
+  }
+
+  return baseFields.map(function (field, index) {
+    return Object.assign({}, field, {
+      name: expectedNames[index] || field.name,
+    });
+  });
+}
+
+function logRelabelDebug(data, detectedFields, relabeledFields) {
+  const previousNames = Array.isArray(data && data.fields_old)
+    ? data.fields_old.slice()
+    : [];
+  const nextNames = Array.isArray(data && data.fields)
+    ? data.fields.slice()
+    : [];
+  const renamedCount = getRelabelChangedCount(data);
+  const detectedNames = Array.isArray(detectedFields)
+    ? detectedFields.map(function (field) {
+        return field.name;
+      })
+    : [];
+  const finalNames = Array.isArray(relabeledFields)
+    ? relabeledFields.map(function (field) {
+        return field.name;
+      })
+    : [];
+  console.groupCollapsed("[pdf-labeler] AI relabel result");
+  console.info("renamedCount:", renamedCount);
+  console.info("worker fields_old:", previousNames);
+  console.info("worker fields:", nextNames);
+  console.info("detected field names after relabel:", detectedNames);
+  console.info("final field names rendered in UI:", finalNames);
+  console.info("raw relabel payload:", data);
+  console.groupEnd();
+}
+
+function updateRequestPdfFile(pdfBytes, fileName, originalFile) {
+  const nextName = fileName || state.fileName || "edited-form.pdf";
+  if (originalFile instanceof File && originalFile.size > 0) {
+    if (originalFile.name === nextName) {
+      state.requestPdfFile = originalFile;
+    } else {
+      state.requestPdfFile = new File([originalFile], nextName, {
+        type: "application/pdf",
+      });
+    }
+    return;
+  }
+  if (pdfBytes && pdfBytes.length) {
+    state.requestPdfFile = new File([pdfBytes], nextName, {
+      type: "application/pdf",
+    });
+    return;
+  }
+  state.requestPdfFile = null;
+}
+
+function syncPdfState(pdfBytes, fileName, originalFile) {
+  state.pdfBytes = clonePdfBytes(pdfBytes);
+  if (fileName) {
+    state.fileName = fileName;
+  }
+  state.accessibility.inspected = false;
+  state.accessibility.images = [];
+  state.accessibility.tagStructure = null;
+  updateRequestPdfFile(state.pdfBytes, state.fileName, originalFile);
+}
+
+async function refreshPdfDocumentFromState(renderOptions) {
+  state.pdfDoc = await pdfjsLib.getDocument({
+    data: clonePdfBytes(state.pdfBytes),
+  }).promise;
+  state.pageCount = state.pdfDoc.numPages;
+  state.pageSizes = [];
+  state.pageTextBoxes = [];
+
+  for (let index = 1; index <= state.pageCount; index += 1) {
+    const page = await state.pdfDoc.getPage(index);
+    const viewport = page.getViewport({ scale: 1 });
+    state.pageSizes.push({ width: viewport.width, height: viewport.height });
+    state.pageTextBoxes.push(await extractTextBoxesFromPage(page));
+  }
+
+  await renderPages(renderOptions);
+}
+
+function stripPdfExtension(fileName) {
+  return String(fileName || "document").replace(/\.pdf$/i, "");
+}
+
+function sanitizeFilenameSegment(value, fallbackValue) {
+  const cleaned = String(value || "")
+    .replace(/[^a-z0-9._-]+/gi, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || fallbackValue || "document";
+}
+
+function downloadBlob(blob, fileName) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+function getPdfFileForRequests() {
+  if (state.requestPdfFile && state.requestPdfFile.size > 0) {
+    return state.requestPdfFile;
+  }
+  updateRequestPdfFile(state.pdfBytes, state.fileName);
+  if (state.requestPdfFile && state.requestPdfFile.size > 0) {
+    return state.requestPdfFile;
+  }
+  return new File([], state.fileName || "edited-form.pdf", {
+    type: "application/pdf",
+  });
+}
+
+async function parseApiResponse(response) {
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch (_error) {
+    const returnedHtml = text.trim().startsWith("<");
+    const statusText = response.status ? "HTTP " + response.status : "request";
+    const finalUrl = response.url ? " from " + response.url : "";
+    if (
+      returnedHtml &&
+      response.redirected &&
+      response.url &&
+      response.url.indexOf("/user/sign-in") !== -1
+    ) {
+      throw new Error("Login required for this AI action.");
+    }
+    throw new Error(
+      returnedHtml
+        ? "The server returned HTML instead of JSON (" +
+            statusText +
+            finalUrl +
+            ")."
+        : "The server returned invalid JSON (" + statusText + finalUrl + ").",
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      data && data.error && data.error.message
+        ? data.error.message
+        : "Request failed (" + response.status + ").",
+    );
+  }
+  return data;
+}
+
+function sleep(milliseconds) {
+  return new Promise(function (resolve) {
+    window.setTimeout(resolve, milliseconds);
+  });
+}
+
+async function pollLabelerJob(jobUrl, progressMessage) {
+  const startedAt = Date.now();
+  const timeoutMs = 8 * 60 * 1000;
+  while (Date.now() - startedAt < timeoutMs) {
+    await sleep(1500);
+    const response = await fetch(jobUrl, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+    const payload = await parseApiResponse(response);
+    if (payload.status === "queued" || payload.status === "running") {
+      showLoading(progressMessage);
+      continue;
+    }
+    if (payload.status === "failed") {
+      throw new Error(
+        (payload.error && payload.error.message) || "Background job failed.",
+      );
+    }
+    if (payload.status === "succeeded") {
+      return payload.data || {};
+    }
+    throw new Error("Unexpected background job status.");
+  }
+  throw new Error("The background job timed out before it completed.");
+}
+
+async function requestAsyncLabelerAction(
+  endpointPath,
+  formData,
+  progressMessage,
+) {
+  formData.append("mode", "async");
+  const response = await fetch(apiUrl(endpointPath), {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    body: formData,
+  });
+  const payload = await parseApiResponse(response);
+  if (payload.status === "queued" && payload.job_url) {
+    showLoading(progressMessage);
+    return pollLabelerJob(payload.job_url, progressMessage);
+  }
+  return payload && payload.data ? payload.data : {};
+}
+
+function normalizeExistingRect(rect, pageSize) {
+  const normalizedWidth = clamp(rect.width / pageSize.width, 0.01, 1);
+  const normalizedHeight = clamp(rect.height / pageSize.height, 0.01, 1);
+  const normalizedX = clamp(rect.x / pageSize.width, 0, 1 - normalizedWidth);
+  const normalizedY = clamp(
+    1 - (rect.y + rect.height) / pageSize.height,
+    0,
+    1 - normalizedHeight,
+  );
+  return {
+    x: normalizedX,
+    y: normalizedY,
+    width: normalizedWidth,
+    height: normalizedHeight,
+  };
+}
+
+async function parseExistingFieldsLocally(pdfBytes, pageSizes) {
+  if (!PDFLibGlobal.PDFDocument) {
+    return [];
+  }
+  const fields = [];
+  try {
+    const pdfDoc = await PDFLibGlobal.PDFDocument.load(clonePdfBytes(pdfBytes));
+    const form = pdfDoc.getForm();
+    const pdfPages = pdfDoc.getPages();
+
+    form.getFields().forEach(function (field) {
+      let type = null;
+      let options = undefined;
+
+      if (
+        PDFLibGlobal.PDFTextField &&
+        field instanceof PDFLibGlobal.PDFTextField
+      ) {
+        type = field.isMultiline() ? "multiline" : "text";
+      } else if (
+        PDFLibGlobal.PDFCheckBox &&
+        field instanceof PDFLibGlobal.PDFCheckBox
+      ) {
+        type = "checkbox";
+      } else if (
+        PDFLibGlobal.PDFSignature &&
+        field instanceof PDFLibGlobal.PDFSignature
+      ) {
+        type = "signature";
+      } else if (
+        PDFLibGlobal.PDFRadioGroup &&
+        field instanceof PDFLibGlobal.PDFRadioGroup
+      ) {
+        type = "radio";
+        options =
+          typeof field.getOptions === "function"
+            ? field.getOptions()
+            : DEFAULT_OPTION_LIST.slice();
+      } else if (
+        PDFLibGlobal.PDFDropdown &&
+        field instanceof PDFLibGlobal.PDFDropdown
+      ) {
+        type = "dropdown";
+        options =
+          typeof field.getOptions === "function"
+            ? field.getOptions()
+            : DEFAULT_OPTION_LIST.slice();
+      } else if (
+        PDFLibGlobal.PDFOptionList &&
+        field instanceof PDFLibGlobal.PDFOptionList
+      ) {
+        type = "listbox";
+        options =
+          typeof field.getOptions === "function"
+            ? field.getOptions()
+            : DEFAULT_OPTION_LIST.slice();
+      }
+
+      if (!type) return;
+
+      const widgets = field.acroField.getWidgets();
+      widgets.forEach(function (widget) {
+        const rect = widget.getRectangle();
+        if (!rect) return;
+
+        const pageRef = widget.P();
+        let pageIndex = 0;
+        if (pageRef) {
+          const foundIndex = pdfPages.findIndex(function (page) {
+            return (page.ref || null) === pageRef;
+          });
+          if (foundIndex >= 0) {
+            pageIndex = foundIndex;
+          }
+        }
+        const pageSize = pageSizes[pageIndex] || pdfPages[pageIndex].getSize();
+        const normalizedRect = normalizeExistingRect(rect, pageSize);
+        fields.push({
+          id: generateId(),
+          name: field.getName() || getDefaultFieldName(type),
+          type: type,
+          pageIndex: pageIndex,
+          x: normalizedRect.x,
+          y: normalizedRect.y,
+          width: normalizedRect.width,
+          height: normalizedRect.height,
+          font: getSessionDefault("font"),
+          fontSize: getSessionDefault("fontSize"),
+          autoSize: true,
+          options: Array.isArray(options) ? options.slice() : undefined,
+        });
+      });
+    });
+    return fields;
+  } catch (error) {
+    console.warn("Unable to parse existing PDF fields locally", error);
+    return [];
+  }
+}
+
+async function detectExistingFieldsWithServer() {
+  if (!state.pdfBytes) return [];
+  const formData = new FormData();
+  formData.append("file", getPdfFileForRequests());
+  const response = await fetch(apiUrl("/pdf-labeler/api/detect-fields"), {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    body: formData,
+  });
+  const data = await parseApiResponse(response);
+  const importedFields = Array.isArray(data.data && data.data.fields)
+    ? data.data.fields
+    : [];
+  return importedFields.map(function (field) {
+    const pageSize = state.pageSizes[field.pageIndex];
+    const fieldType = normalizeFieldType(field.type);
+    const width = pageSize ? clamp(field.width / pageSize.width, 0.01, 1) : 0.1;
+    const height = pageSize
+      ? clamp(field.height / pageSize.height, 0.01, 1)
+      : 0.03;
+    const x = pageSize ? clamp(field.x / pageSize.width, 0, 1 - width) : 0;
+    const y = pageSize
+      ? clamp(1 - (field.y + field.height) / pageSize.height, 0, 1 - height)
+      : 0;
+    return {
+      id: generateId(),
+      name: field.name || getDefaultFieldName(fieldType),
+      type: fieldType,
+      pageIndex: field.pageIndex,
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+      font: field.font || getSessionDefault("font"),
+      fontSize: field.fontSize || getSessionDefault("fontSize"),
+      autoSize: field.autoSize !== false,
+      checkboxStyle:
+        field.checkboxStyle ||
+        (fieldType === "checkbox"
+          ? getSessionDefault("checkboxStyle") || "cross"
+          : undefined),
+      checkboxExportValue: field.checkboxExportValue || undefined,
+      checkboxBorder: !!field.checkboxBorder,
+      checkboxBorderWidth: field.checkboxBorderWidth || "thin",
+      options: Array.isArray(field.options) ? field.options.slice() : undefined,
     };
+  });
+}
 
-    function generateId() {
-        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
-            return 'field-' + window.crypto.randomUUID();
-        }
-        return 'field-' + Math.random().toString(36).slice(2, 11);
+async function runRepairAction(action) {
+  if (!state.pdfBytes) return;
+  var allBtns = repairModal.querySelectorAll(".repair-run-btn");
+  allBtns.forEach(function (b) {
+    b.disabled = true;
+  });
+  repairStatus.className = "alert alert-info small mb-3";
+  repairStatusText.textContent = "Running " + action + "...";
+  repairStatus.classList.remove("hidden");
+
+  try {
+    var formData = new FormData();
+    formData.append("file", getPdfFileForRequests());
+    formData.append("action", action);
+
+    if (action === "ghostscript_reprint") {
+      var preserve = document.getElementById("repair-gs-preserve").checked;
+      formData.append("preserve_fields", preserve ? "true" : "false");
+      var pdfOpt =
+        document.getElementById("repair-gs-optimization").value || "prepress";
+      formData.append("pdf_optimization", pdfOpt);
+    } else if (action === "unlock") {
+      var pw = document.getElementById("repair-unlock-pw").value;
+      if (pw) formData.append("password", pw);
+    } else if (action === "ocr") {
+      var lang =
+        document.getElementById("repair-ocr-lang").value.trim() || "eng";
+      formData.append("language", lang);
+      var skip = document.getElementById("repair-ocr-skip").checked;
+      formData.append("skip_text", skip ? "true" : "false");
     }
 
-    function apiUrl(path) {
-        return API_BASE_PATH + path;
+    var response = await fetch(apiUrl("/pdf-labeler/api/repair"), {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+    var result = await parseApiResponse(response);
+    if (!result.success) {
+      var errMsg = (result.error && result.error.message) || "Repair failed.";
+      throw new Error(errMsg);
     }
 
-    function escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text == null ? '' : String(text);
-        return div.innerHTML;
+    var data = result.data || {};
+    var pdfBase64 = data.pdf_base64;
+    if (!pdfBase64) throw new Error("No repaired PDF was returned.");
+
+    // Decode base64 to Uint8Array
+    var binaryStr = atob(pdfBase64);
+    var bytes = new Uint8Array(binaryStr.length);
+    for (var i = 0; i < binaryStr.length; i++) {
+      bytes[i] = binaryStr.charCodeAt(i);
     }
 
-    /** Map PDF standard font names to CSS font-family + weight. */
-    function pdfFontToCss(pdfFont) {
-        var f = String(pdfFont || 'Helvetica');
-        if (f === 'Helvetica-Bold') return { family: 'Helvetica, Arial, sans-serif', weight: 'bold' };
-        if (f === 'Courier') return { family: '"Courier New", Courier, monospace', weight: 'normal' };
-        if (f === 'Courier-Bold') return { family: '"Courier New", Courier, monospace', weight: 'bold' };
-        if (f === 'Times-Roman') return { family: '"Times New Roman", Times, serif', weight: 'normal' };
-        if (f === 'Times-Bold') return { family: '"Times New Roman", Times, serif', weight: 'bold' };
-        return { family: 'Helvetica, Arial, sans-serif', weight: 'normal' };
-    }
+    // Reload the repaired PDF into the editor
+    var repairedFile = new File(
+      [bytes],
+      data.filename || state.fileName || "repaired.pdf",
+      { type: "application/pdf" },
+    );
+    repairModal.classList.add("hidden");
+    await loadPdf(repairedFile);
 
-    var CHECKBOX_PREVIEW_GLYPHS = {
-        cross: '\u2717',    // ✗
-        check: '\u2713',    // ✓
-        circle: '\u25CF',   // ●
-        star: '\u2605',     // ★
-        diamond: '\u25C6',  // ◆
-        square: '\u25A0'    // ■
+    var repairResult = data.repair_result || {};
+    var summaryParts = [action + " completed"];
+    if (repairResult.fields_restored) {
+      summaryParts.push(repairResult.fields_restored + " fields restored");
+    }
+    if (repairResult.appearances_restored) {
+      summaryParts.push(
+        repairResult.appearances_restored + " appearances restored",
+      );
+    }
+    if (repairResult.warnings && repairResult.warnings.length) {
+      summaryParts.push(repairResult.warnings.join("; "));
+    }
+    showSuccess(summaryParts.join(". ") + ".");
+  } catch (err) {
+    repairStatus.className = "alert alert-danger small mb-3";
+    repairStatusText.textContent = err.message || "Repair failed.";
+    allBtns.forEach(function (b) {
+      b.disabled = false;
+    });
+  }
+}
+
+function getFieldNameHelp(field) {
+  const rawName = String(field.name || "").trim();
+  const normalized = normalizePdfFieldName(rawName);
+  const duplicateExists = state.fields.some(function (candidate) {
+    return (
+      candidate.id !== field.id &&
+      String(candidate.name || "") === String(field.name || "")
+    );
+  });
+
+  if (!rawName) {
+    return {
+      level: "warning",
+      html: "Field labels are required.",
     };
+  }
+  if (duplicateExists) {
+    return {
+      level: "warning",
+      html: "Another field already uses this PDF label. Some PDF viewers handle duplicate names unpredictably.",
+    };
+  }
+  if (rawName !== normalized && /[[\].()]/.test(rawName)) {
+    return {
+      level: "info",
+      html:
+        "This looks like DOCX/Jinja syntax. PDFs should use labels like <code>" +
+        escapeHtml(normalized) +
+        "</code>.",
+    };
+  }
+  return {
+    level: "info",
+    html: "AssemblyLine PDF labels use underscores and inline list numbers, for example <code>users1_name_full</code>.",
+  };
+}
 
-    var _signatureDataUrl = null;
-    (function preloadSignature() {
-        var img = new Image();
-        img.onload = function () {
-            var canvas = document.createElement('canvas');
-            canvas.width = img.naturalWidth;
-            canvas.height = img.naturalHeight;
-            canvas.getContext('2d').drawImage(img, 0, 0);
-            _signatureDataUrl = canvas.toDataURL('image/png');
-        };
-        img.src = '/packagestatic/docassemble.ALDashboard/placeholder_signature.png';
-    })();
+function renderFontOptions(selectedFont) {
+  return FONT_OPTIONS.map(function (font) {
+    return (
+      '<option value="' +
+      escapeHtml(font) +
+      '"' +
+      (font === selectedFont ? " selected" : "") +
+      ">" +
+      escapeHtml(font) +
+      "</option>"
+    );
+  }).join("");
+}
 
-    function setDirty(value) {
-        state.hasUnsavedChanges = !!value;
-        dirtyIndicator.classList.toggle('hidden', !state.hasUnsavedChanges);
+function ptToNormalizedLength(points, pageIndex, axis) {
+  const pageSize = state.pageSizes[pageIndex] || { width: 612, height: 792 };
+  const dimension = axis === "x" ? pageSize.width : pageSize.height;
+  return clamp(Number(points) / dimension, 0.001, 1);
+}
+
+function getRadioOptionSuffixes(options) {
+  const normalized = options.map(function (option) {
+    return String(option || "")
+      .trim()
+      .toLowerCase();
+  });
+  if (normalized.length === 2) {
+    const yesIndex = normalized.findIndex(function (option) {
+      return option === "yes" || option === "true";
+    });
+    const noIndex = normalized.findIndex(function (option) {
+      return option === "no" || option === "false";
+    });
+    if (yesIndex >= 0 && noIndex >= 0) {
+      return normalized.map(function (_option, index) {
+        return index === yesIndex ? "yes" : "no";
+      });
     }
+  }
+  return normalized.map(function (_option, index) {
+    return index === 0 ? "opt" : "opt" + String(index + 1);
+  });
+}
 
-    function updateDocumentName() {
-        documentName.textContent = state.fileName ? state.fileName : '';
+function dedupeNormalizedFieldNames(fields) {
+  const used = new Set();
+  return fields.map(function (field) {
+    const updated = Object.assign({}, field);
+    const baseName = normalizePdfFieldName(updated.name);
+    let candidate = baseName;
+    let suffix = 1;
+    while (used.has(candidate)) {
+      candidate = baseName + "__" + suffix;
+      suffix += 1;
     }
+    used.add(candidate);
+    updated.name = candidate;
+    return updated;
+  });
+}
 
-    function clamp(value, min, max) {
-        return Math.min(Math.max(value, min), max);
+function alignFieldsByRow(fields, thresholdPoints) {
+  const groupedByPage = {};
+  fields.forEach(function (field) {
+    if (!(
+      field.type === "text" ||
+      field.type === "multiline" ||
+      field.type === "checkbox"
+    ))
+      return;
+    if (!groupedByPage[field.pageIndex]) {
+      groupedByPage[field.pageIndex] = [];
     }
-
-    function getViewerRenderScale() {
-        return state.renderScale * state.viewerZoom;
-    }
-
-    function updateZoomControls() {
-        const hasPdf = !!state.pdfBytes;
-        const zoomPercent = Math.round(state.viewerZoom * 100);
-        pdfZoomLabel.textContent = zoomPercent + '%';
-        pdfZoomOutBtn.disabled = !hasPdf || state.viewerZoom <= 0.6;
-        pdfZoomInBtn.disabled = !hasPdf || state.viewerZoom >= 2.4;
-        pdfZoomResetBtn.disabled = !hasPdf || Math.abs(state.viewerZoom - 1) < 0.001;
-    }
-
-    function captureViewerAnchor() {
-        const shell = document.querySelector('.pdf-page-shell[data-page-index="' + currentVisiblePageIndex + '"]');
-        if (!shell) {
-            return { pageIndex: currentVisiblePageIndex || 0, offsetRatio: 0 };
-        }
-        const pageHeight = Math.max(shell.offsetHeight, 1);
-        return {
-            pageIndex: Number(shell.dataset.pageIndex || 0),
-            offsetRatio: clamp((pdfContainer.scrollTop - shell.offsetTop) / pageHeight, 0, 1)
-        };
-    }
-
-    function restoreViewerAnchor(anchor) {
-        if (!anchor) return;
-        const shell = document.querySelector('.pdf-page-shell[data-page-index="' + anchor.pageIndex + '"]');
-        if (!shell) return;
-        pdfContainer.scrollTop = shell.offsetTop + (shell.offsetHeight * clamp(anchor.offsetRatio || 0, 0, 1));
-        currentVisiblePageIndex = anchor.pageIndex;
-    }
-
-    async function updateViewerZoom(nextZoom) {
-        const clampedZoom = clamp(Number(nextZoom) || 1, 0.6, 2.4);
-        if (!state.pdfDoc || Math.abs(clampedZoom - state.viewerZoom) < 0.001) {
-            state.viewerZoom = clampedZoom;
-            updateZoomControls();
-            return;
-        }
-        const anchor = captureViewerAnchor();
-        state.viewerZoom = clampedZoom;
-        updateZoomControls();
-        await renderPages({ anchor: anchor });
-    }
-
-    function normalizeFieldType(rawType) {
-        const type = String(rawType || 'text').toLowerCase();
-        return FIELD_TYPES.includes(type) ? type : 'text';
-    }
-
-    function normalizeOptionalFieldType(rawType) {
-        const type = String(rawType || '').trim().toLowerCase();
-        return FIELD_TYPES.includes(type) ? type : '';
-    }
-
-    function normalizePdfFieldName(rawName) {
-        let name = String(rawName || '').trim();
-        if (!name) return 'field';
-        name = name.replace(/\(\)/g, '');
-        name = name.replace(/['`’]/g, '');
-        name = name.replace(/\[(\d+)\]/g, function (_match, index) {
-            return String(Number(index) + 1);
-        });
-        name = name.replace(/\./g, '_');
-        name = name.replace(/[^a-zA-Z0-9_]+/g, '_');
-        name = name.replace(/_+/g, '_');
-        name = name.replace(/^_+|_+$/g, '');
-        if (!name) name = 'field';
-        if (/^[0-9]/.test(name)) {
-            name = 'field_' + name;
-        }
-        return name;
-    }
-
-    function extractTextBoxesFromPage(pageProxy) {
-        return pageProxy.getTextContent().then(function (textContent) {
-            const viewport = pageProxy.getViewport({ scale: 1 });
-            const textItems = [];
-            textContent.items.forEach(function (item) {
-                if (!item || !('str' in item) || !item.str || !item.str.trim() || !('transform' in item)) {
-                    return;
-                }
-                const transform = item.transform;
-                const x = Number(transform[4] || 0);
-                const y = viewport.height - Number(transform[5] || 0);
-                const fontSize = Math.max(Math.abs(Number(transform[3] || 0)), 6);
-                const width = Math.max(Number(item.width || 0), item.str.trim().length * fontSize * 0.46);
-                textItems.push({
-                    text: item.str.trim(),
-                    x: x,
-                    y: y,
-                    width: width,
-                    height: fontSize,
-                    fontSize: fontSize
-                });
-            });
-            return groupTextItemsIntoBoxes(textItems).map(function (box) {
-                return {
-                    text: box.text,
-                    x: clamp(box.x / viewport.width, 0, 1),
-                    y: clamp(box.y / viewport.height, 0, 1),
-                    width: clamp(box.width / viewport.width, 0, 1),
-                    height: clamp(box.height / viewport.height, 0, 1),
-                    fontSize: box.fontSize
-                };
-            });
-        }).catch(function (error) {
-            console.warn('Failed to extract PDF text for heuristic naming:', error);
-            return [];
-        });
-    }
-
-    function groupTextItemsIntoBoxes(textItems) {
-        if (!Array.isArray(textItems) || textItems.length === 0) return [];
-        const items = textItems.slice().sort(function (left, right) {
-            const yDiff = Math.abs(left.y - right.y);
-            if (yDiff < 3) {
-                return left.x - right.x;
-            }
-            return left.y - right.y;
-        });
-        const boxes = [];
-        let currentBox = null;
-        items.forEach(function (item) {
-            if (!currentBox) {
-                currentBox = {
-                    text: item.text,
-                    x: item.x,
-                    y: item.y,
-                    width: item.width,
-                    height: item.height,
-                    fontSize: item.fontSize
-                };
-                return;
-            }
-            const sameLineThreshold = Math.max(currentBox.fontSize * 0.45, 4);
-            const gap = item.x - (currentBox.x + currentBox.width);
-            const maxGap = Math.max(currentBox.fontSize * 0.9, 12);
-            if (Math.abs(item.y - currentBox.y) <= sameLineThreshold && gap <= maxGap) {
-                currentBox.text += (gap > 2 ? ' ' : '') + item.text;
-                currentBox.width = Math.max(currentBox.width, (item.x + item.width) - currentBox.x);
-                currentBox.height = Math.max(currentBox.height, item.height);
-                currentBox.fontSize = Math.max(currentBox.fontSize, item.fontSize);
-                return;
-            }
-            boxes.push(currentBox);
-            currentBox = {
-                text: item.text,
-                x: item.x,
-                y: item.y,
-                width: item.width,
-                height: item.height,
-                fontSize: item.fontSize
-            };
-        });
-        if (currentBox) {
-            boxes.push(currentBox);
-        }
-        return boxes.filter(function (box) {
-            return box.text && box.text.trim() && !/^[_\s.\-:]{1,4}$/.test(box.text.trim());
-        });
-    }
-
-    function getRectBounds(rect) {
-        return {
-            left: rect.x,
-            right: rect.x + rect.width,
-            top: rect.y,
-            bottom: rect.y + rect.height,
-            centerX: rect.x + (rect.width / 2),
-            centerY: rect.y + (rect.height / 2)
-        };
-    }
-
-    function getTextBoxBounds(box) {
-        return {
-            left: box.x,
-            right: box.x + box.width,
-            top: box.y,
-            bottom: box.y + box.height,
-            centerX: box.x + (box.width / 2),
-            centerY: box.y + (box.height / 2)
-        };
-    }
-
-    function cleanSuggestedLabelText(rawText) {
-        let text = String(rawText || '').trim();
-        if (!text) return '';
-        text = text.replace(/\s+/g, ' ');
-        text = text.replace(/^[\s:;.,\-–—_]+|[\s:;.,\-–—_]+$/g, '');
-        if (!text) return '';
-        const parts = text.split(/\s+/);
-        if (parts.length > 10) {
-            text = parts.slice(0, 10).join(' ');
-        }
-        return text;
-    }
-
-    function getNearbyFieldNameBases(pageIndex, rect, excludeFieldId) {
-        const rectBounds = getRectBounds(rect);
-        const nearby = new Set();
-        state.fields.forEach(function (field) {
-            if (field.pageIndex !== pageIndex || field.id === excludeFieldId) return;
-            const fieldBounds = getRectBounds(field);
-            const verticalDistance = Math.abs(fieldBounds.centerY - rectBounds.centerY);
-            const horizontalGap = Math.min(
-                Math.abs(rectBounds.left - fieldBounds.right),
-                Math.abs(fieldBounds.left - rectBounds.right)
-            );
-            if (verticalDistance <= Math.max(rect.height * 1.6, field.height * 1.6, 0.05) && horizontalGap <= 0.1) {
-                nearby.add(normalizePdfFieldName(field.name));
-            }
-        });
-        return nearby;
-    }
-
-    // Contract: return up to 3 normalized field-name suggestions for a candidate
-    // rect on a page, ordered by likely usefulness and already filtered against
-    // immediate neighboring field names.
-    function buildFieldNameSuggestions(pageIndex, rect, type, excludeFieldId) {
-        const textBoxes = Array.isArray(state.pageTextBoxes[pageIndex]) ? state.pageTextBoxes[pageIndex] : [];
-        if (!textBoxes.length) return [];
-        const rectBounds = getRectBounds(rect);
-        const rowTolerance = Math.max(rect.height * 1.6, 0.045);
-        const sideGapLimit = Math.max(rect.width * 3.5, 0.22);
-        const belowGapLimit = Math.max(rect.height * 2.4, 0.12);
-        const nearbyNames = getNearbyFieldNameBases(pageIndex, rect, excludeFieldId);
-        const matches = [];
-
-        textBoxes.forEach(function (box) {
-            const text = cleanSuggestedLabelText(box.text);
-            if (!text) return;
-            const boxBounds = getTextBoxBounds(box);
-            const verticalDistance = Math.abs(boxBounds.centerY - rectBounds.centerY);
-            const overlapWidth = Math.min(rectBounds.right, boxBounds.right) - Math.max(rectBounds.left, boxBounds.left);
-            const overlapRatio = overlapWidth > 0 ? overlapWidth / Math.min(rect.width, box.width) : 0;
-
-            if (boxBounds.right <= rectBounds.left + 0.01 && verticalDistance <= rowTolerance) {
-                const gap = rectBounds.left - boxBounds.right;
-                if (gap <= sideGapLimit) {
-                    matches.push({
-                        text: text,
-                        source: 'left',
-                        score: 320 - (gap * 1000) - (verticalDistance * 700)
-                    });
-                }
-            }
-
-            if (boxBounds.left >= rectBounds.right - 0.01 && verticalDistance <= rowTolerance) {
-                const gap = boxBounds.left - rectBounds.right;
-                if (gap <= sideGapLimit) {
-                    matches.push({
-                        text: text,
-                        source: 'right',
-                        score: 220 - (gap * 1000) - (verticalDistance * 700)
-                    });
-                }
-            }
-
-            if (boxBounds.top >= rectBounds.bottom - 0.01) {
-                const gap = boxBounds.top - rectBounds.bottom;
-                if (gap <= belowGapLimit && overlapRatio >= 0.18) {
-                    matches.push({
-                        text: text,
-                        source: 'below',
-                        score: 180 - (gap * 1200) + (overlapRatio * 100)
-                    });
-                }
-            }
-        });
-
-        const leftMatches = matches
-            .filter(function (candidate) { return candidate.source === 'left'; })
-            .sort(function (left, right) { return right.score - left.score; });
-        const rightMatches = matches
-            .filter(function (candidate) { return candidate.source === 'right'; })
-            .sort(function (left, right) { return right.score - left.score; });
-        const belowMatches = matches
-            .filter(function (candidate) { return candidate.source === 'below'; })
-            .sort(function (left, right) { return right.score - left.score; });
-
-        const ordered = [];
-        if (leftMatches[0]) {
-            ordered.push(leftMatches[0]);
-            if (belowMatches[0]) ordered.push(belowMatches[0]);
-            if (rightMatches[0]) ordered.push(rightMatches[0]);
-        } else {
-            if (rightMatches[0]) ordered.push(rightMatches[0]);
-            if (belowMatches[0]) ordered.push(belowMatches[0]);
-        }
-
-        const seenNames = new Set();
-        const suggestions = [];
-        ordered.forEach(function (candidate) {
-            if (!candidate || suggestions.length >= 3) return;
-            const normalized = normalizePdfFieldName(candidate.text);
-            if (!normalized || seenNames.has(normalized) || nearbyNames.has(normalized)) {
-                return;
-            }
-            seenNames.add(normalized);
-            suggestions.push({
-                name: ensureUniqueFieldName(normalized, excludeFieldId || null),
-                source: candidate.source,
-                text: candidate.text
-            });
-        });
-
-        return suggestions.slice(0, 3);
-    }
-
-    function ensureUniqueFieldName(baseName, excludeFieldId) {
-        const used = new Set(
-            state.fields
-                .filter(function (field) { return field.id !== excludeFieldId; })
-                .map(function (field) { return normalizePdfFieldName(field.name); })
-        );
-        const normalizedBase = normalizePdfFieldName(baseName);
-        let candidate = normalizedBase;
-        let suffix = 1;
-        while (used.has(candidate)) {
-            candidate = normalizedBase + '__' + suffix;
-            suffix += 1;
-        }
-        return candidate;
-    }
-
-    function getDefaultFieldName(type) {
-        const normalizedType = normalizeFieldType(type);
-        const library = Array.isArray(FIELD_NAME_LIBRARY[normalizedType])
-            ? FIELD_NAME_LIBRARY[normalizedType]
-            : (normalizedType === 'multiline' ? FIELD_NAME_LIBRARY.text : []);
-        for (let index = 0; index < library.length; index += 1) {
-            const candidate = normalizePdfFieldName(library[index]);
-            if (!state.fields.some(function (field) { return normalizePdfFieldName(field.name) === candidate; })) {
-                return candidate;
-            }
-        }
-        const fallbackBase = normalizedType === 'checkbox'
-            ? 'checkbox'
-            : normalizedType === 'signature'
-                ? 'signature'
-                : normalizedType === 'dropdown'
-                    ? 'dropdown'
-                    : normalizedType === 'listbox'
-                        ? 'listbox'
-                        : normalizedType === 'radio'
-                            ? 'radio_group'
-                            : normalizedType === 'multiline'
-                                ? 'text_area'
-                                : 'text';
-        return ensureUniqueFieldName(fallbackBase, null);
-    }
-
-    function getFieldTypeMeta(type) {
-        return FIELD_TYPE_META[normalizeFieldType(type)] || FIELD_TYPE_META.text;
-    }
-
-    function getCurrentField() {
-        return state.fields.find(function (field) {
-            return field.id === state.selectedFieldId;
-        }) || null;
-    }
-
-    function getQuickEditField() {
-        if (!state.quickEditFieldId) return null;
-        return state.fields.find(function (field) {
-            return field.id === state.quickEditFieldId;
-        }) || null;
-    }
-
-    function getOverlayForPage(pageIndex) {
-        return document.querySelector('.page-overlay[data-page-index="' + pageIndex + '"]');
-    }
-
-    function showLoading(message) {
-        loadingMessage.textContent = message;
-        pdfEmpty.classList.add('hidden');
-        pdfLoading.classList.remove('hidden');
-        pdfPages.classList.add('hidden');
-    }
-
-    function hideLoading() {
-        pdfLoading.classList.add('hidden');
-    }
-
-    function showPdfWorkspace() {
-        if (state.pdfBytes) {
-            pdfPages.classList.remove('hidden');
-            pdfEmpty.classList.add('hidden');
-        }
-        updateZoomControls();
-    }
-
-    function getCurrentVisiblePageIndex() {
-        if (!state.pageCount) return 0;
-        const containerRect = pdfContainer.getBoundingClientRect();
-        const containerCenterY = containerRect.top + (containerRect.height / 2);
-        let bestPageIndex = currentVisiblePageIndex || 0;
-        let bestDistance = Number.POSITIVE_INFINITY;
-        document.querySelectorAll('.pdf-page-shell').forEach(function (shell) {
-            const rect = shell.getBoundingClientRect();
-            if (rect.bottom < containerRect.top || rect.top > containerRect.bottom) {
-                return;
-            }
-            const centerY = rect.top + (rect.height / 2);
-            const distance = Math.abs(centerY - containerCenterY);
-            if (distance < bestDistance) {
-                bestDistance = distance;
-                bestPageIndex = Number(shell.dataset.pageIndex || 0);
-            }
-        });
-        return bestPageIndex;
-    }
-
-    function scrollFieldsListToElement(element, options) {
-        if (!element || fieldsList.classList.contains('hidden')) return;
-        const settings = options || {};
-        const behavior = settings.behavior || 'smooth';
-        const mode = settings.mode || 'nearest';
-        const listRect = fieldsList.getBoundingClientRect();
-        const itemRect = element.getBoundingClientRect();
-        const topWithinList = itemRect.top - listRect.top + fieldsList.scrollTop;
-        const bottomWithinList = itemRect.bottom - listRect.top + fieldsList.scrollTop;
-        let targetTop = fieldsList.scrollTop;
-
-        if (mode === 'start') {
-            targetTop = topWithinList;
-        } else if (mode === 'center') {
-            targetTop = topWithinList - ((fieldsList.clientHeight - itemRect.height) / 2);
-        } else {
-            const visibleTop = fieldsList.scrollTop;
-            const visibleBottom = visibleTop + fieldsList.clientHeight;
-            if (topWithinList < visibleTop) {
-                targetTop = topWithinList;
-            } else if (bottomWithinList > visibleBottom) {
-                targetTop = bottomWithinList - fieldsList.clientHeight;
-            }
-        }
-
-        fieldsListProgrammaticScroll = true;
-        fieldsList.scrollTo({
-            top: Math.max(0, targetTop),
-            behavior: behavior,
-        });
-        window.setTimeout(function () {
-            fieldsListProgrammaticScroll = false;
-        }, behavior === 'auto' ? 0 : 220);
-    }
-
-    function syncFieldsListToVisiblePage(force) {
-        if (state.fieldSort !== 'position') return;
-        if (state.pageCount <= 1 || fieldsList.classList.contains('hidden')) return;
-        if (!force && Date.now() < fieldsListManualScrollUntil) return;
-        const pageIndex = getCurrentVisiblePageIndex();
-        currentVisiblePageIndex = pageIndex;
-        const group = fieldsList.querySelector('.field-list-page[data-page-index="' + pageIndex + '"]');
-        if (!group) return;
-        scrollFieldsListToElement(group, {
-            mode: 'start',
-            behavior: force ? 'auto' : 'smooth'
-        });
-    }
-
-    function scheduleFieldsListSync(force) {
-        if (fieldsListSyncRaf) {
-            window.cancelAnimationFrame(fieldsListSyncRaf);
-        }
-        fieldsListSyncRaf = window.requestAnimationFrame(function () {
-            fieldsListSyncRaf = null;
-            syncFieldsListToVisiblePage(force);
-        });
-    }
-
-    function scrollSelectedFieldIntoView(fieldId) {
-        if (!fieldId || fieldsList.classList.contains('hidden')) return;
-        const item = fieldsList.querySelector('.field-list-item[data-field-id="' + fieldId + '"]');
-        if (!item) return;
-        scrollFieldsListToElement(item, { mode: 'nearest', behavior: 'smooth' });
-    }
-
-    function hideToasts() {
-        errorToast.classList.add('hidden');
-        successToast.classList.add('hidden');
-    }
-
-    function showError(message, timeoutMs) {
-        hideToasts();
-        errorToastMessage.textContent = message;
-        errorToast.classList.remove('hidden');
-        window.setTimeout(function () {
-            errorToast.classList.add('hidden');
-        }, typeof timeoutMs === 'number' ? timeoutMs : 6000);
-    }
-
-    function showSuccess(message, timeoutMs) {
-        hideToasts();
-        successToastMessage.textContent = message;
-        successToast.classList.remove('hidden');
-        window.setTimeout(function () {
-            successToast.classList.add('hidden');
-        }, typeof timeoutMs === 'number' ? timeoutMs : 3200);
-    }
-
-    function updateDuplicateFieldWarning() {
-        const duplicateNames = getDuplicateFieldNames();
-        if (duplicateFieldWarning) {
-            duplicateFieldWarning.classList.toggle('hidden', duplicateNames.length === 0);
-            duplicateFieldWarning.title = duplicateNames.length
-                ? 'Repeated names: ' + duplicateNames.slice(0, 5).join(', ') + (duplicateNames.length > 5 ? ' ...' : '')
-                : '';
-        }
-    }
-
-    function updateFieldCount() {
-        const totalCount = state.fields.length;
-        const filteredCount = totalCount === 0 ? 0 : getDisplayedFields().length;
-        const filtersActive = state.fieldsPanelMode !== 'rename' && Boolean(String(state.fieldSearch || '').trim() || normalizeOptionalFieldType(state.fieldTypeFilter || ''));
-        if (totalCount === 0) {
-            fieldCount.textContent = 'No fields';
-        } else if (filtersActive) {
-            fieldCount.textContent = filteredCount + ' of ' + totalCount + ' fields';
-        } else {
-            fieldCount.textContent = totalCount + ' field' + (totalCount === 1 ? '' : 's');
-        }
-        fieldsEmpty.classList.toggle('hidden', totalCount !== 0);
-        fieldsList.classList.toggle('hidden', totalCount === 0);
-        floatingToolPicker.classList.toggle('hidden', !state.pdfBytes);
-        autoDetectBtn.disabled = !state.pdfBytes;
-        exportBtn.disabled = !state.pdfBytes || totalCount === 0;
-        if (testFillingBtn) testFillingBtn.disabled = !state.pdfBytes || totalCount === 0;
-        savePlaygroundBtn.disabled = !state.pdfBytes || totalCount === 0;
-        normalizePassBtn.disabled = !state.pdfBytes || totalCount === 0;
-        repairBtn.disabled = !state.pdfBytes;
-        if (relabelBtn) {
-            relabelBtn.disabled = !state.pdfBytes || totalCount === 0 || !state.auth.aiEnabled;
-        }
-        if (sidebarRelabelBtn) {
-            sidebarRelabelBtn.disabled = !state.pdfBytes || totalCount === 0 || !state.auth.aiEnabled;
-        }
-        previewBtn.disabled = !state.pdfBytes || totalCount === 0;
-        accessibilityBtn.disabled = !state.pdfBytes;
-        managePagesBtn.disabled = !state.pdfBytes;
-        if (!state.pdfBytes || totalCount === 0) {
-            state.previewMode = false;
-            previewBtn.classList.remove('active');
-            document.getElementById('preview-icon-open').classList.remove('hidden');
-            document.getElementById('preview-icon-closed').classList.add('hidden');
-        }
-        updateDuplicateFieldWarning();
-        updateZoomControls();
-    }
-
-    function getDisplayedFields() {
-        const inRenameMode = state.fieldsPanelMode === 'rename';
-        const search = inRenameMode ? '' : String(state.fieldSearch || '').trim().toLowerCase();
-        const typeFilter = inRenameMode ? '' : normalizeOptionalFieldType(state.fieldTypeFilter || '');
-        const hasTypeFilter = !inRenameMode && FIELD_TYPES.includes(typeFilter);
-        const filtered = state.fields.filter(function (field) {
-            if (hasTypeFilter && field.type !== typeFilter) {
-                return false;
-            }
-            if (search && String(field.name || '').toLowerCase().indexOf(search) === -1) {
-                return false;
-            }
-            return true;
-        });
-
-        const sorted = filtered.slice();
-        if (state.fieldSort === 'name_asc') {
-            sorted.sort(function (left, right) {
-                return String(left.name || '').localeCompare(String(right.name || ''), undefined, { sensitivity: 'base' });
-            });
-            return sorted;
-        }
-        if (state.fieldSort === 'name_desc') {
-            sorted.sort(function (left, right) {
-                return String(right.name || '').localeCompare(String(left.name || ''), undefined, { sensitivity: 'base' });
-            });
-            return sorted;
-        }
-        if (state.fieldSort === 'type_name') {
-            sorted.sort(function (left, right) {
-                const leftMeta = getFieldTypeMeta(left.type);
-                const rightMeta = getFieldTypeMeta(right.type);
-                const typeCompare = leftMeta.label.localeCompare(rightMeta.label, undefined, { sensitivity: 'base' });
-                if (typeCompare !== 0) return typeCompare;
-                return String(left.name || '').localeCompare(String(right.name || ''), undefined, { sensitivity: 'base' });
-            });
-            return sorted;
-        }
-        sorted.sort(function (left, right) {
-            if (left.pageIndex !== right.pageIndex) return left.pageIndex - right.pageIndex;
-            if (Math.abs(left.y - right.y) > 0.002) return left.y - right.y;
-            return left.x - right.x;
-        });
-        return sorted;
-    }
-
-    function defaultTooltipFromFieldName(name) {
-        const normalized = String(name || '').replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
-        return normalized || 'Field';
-    }
-
-    function sortedFieldIdsByDefaultOrder() {
-        return state.fields
-            .slice()
-            .sort(function (left, right) {
-                if (left.pageIndex !== right.pageIndex) return left.pageIndex - right.pageIndex;
-                if (Math.abs(left.y - right.y) > 0.002) return left.y - right.y;
-                if (Math.abs(left.x - right.x) > 0.002) return left.x - right.x;
-                return String(left.name || '').localeCompare(String(right.name || ''), undefined, { sensitivity: 'base' });
-            })
-            .map(function (field) { return field.id; });
-    }
-
-    function reconcileAccessibilityFieldOrder() {
-        const knownIds = new Set(state.fields.map(function (field) { return field.id; }));
-        const next = [];
-        (state.accessibility.fieldOrder || []).forEach(function (fieldId) {
-            if (knownIds.has(fieldId)) {
-                next.push(fieldId);
-                knownIds.delete(fieldId);
-            }
-        });
-        sortedFieldIdsByDefaultOrder().forEach(function (fieldId) {
-            if (knownIds.has(fieldId)) {
-                next.push(fieldId);
-                knownIds.delete(fieldId);
-            }
-        });
-        state.accessibility.fieldOrder = next;
-    }
-
-    function ensureFieldAccessibilityDefaults(field) {
-        if (!field) return;
-        if (!String(field.tooltip || '').trim()) {
-            field.tooltip = defaultTooltipFromFieldName(field.name);
-        }
-    }
-
-    function refreshAccessibilityFromFields() {
-        state.fields.forEach(ensureFieldAccessibilityDefaults);
-        reconcileAccessibilityFieldOrder();
-    }
-
-    function renderAccessibilityFieldList() {
-        if (!a11yFieldList) return;
-        a11yFieldList.innerHTML = '';
-        if (!state.fields.length) {
-            a11yFieldList.innerHTML = '<div class="small text-muted">No fields detected yet.</div>';
-            return;
-        }
-        const fragment = document.createDocumentFragment();
-        state.accessibility.fieldOrder.forEach(function (fieldId, index) {
-            const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-            if (!field) return;
-            const row = document.createElement('div');
-            row.className = 'a11y-field-row border rounded p-2';
-            row.dataset.fieldId = field.id;
-            row.innerHTML =
-                '<div class="d-flex align-items-center justify-content-between gap-2 mb-2">' +
-                    '<div class="d-flex align-items-center gap-1">' +
-                        '<span class="a11y-drag-handle" draggable="true" aria-hidden="true" title="Drag to reorder">⠿</span>' +
-                        '<div class="small fw-semibold">' + escapeHtml(field.name) + '</div>' +
-                    '</div>' +
-                    '<div class="btn-group btn-group-sm">' +
-                        '<button type="button" class="btn btn-outline-secondary" data-a11y-action="move-up" data-field-id="' + escapeHtml(field.id) + '"' + (index === 0 ? ' disabled' : '') + '>Up</button>' +
-                        '<button type="button" class="btn btn-outline-secondary" data-a11y-action="move-down" data-field-id="' + escapeHtml(field.id) + '"' + (index === state.accessibility.fieldOrder.length - 1 ? ' disabled' : '') + '>Down</button>' +
-                    '</div>' +
-                '</div>' +
-                '<label class="form-label small text-muted mb-1">Tooltip</label>' +
-                '<input type="text" class="form-control form-control-sm" data-a11y-action="tooltip" data-field-id="' + escapeHtml(field.id) + '" value="' + escapeHtml(String(field.tooltip || '')) + '">';
-            fragment.appendChild(row);
-        });
-        a11yFieldList.appendChild(fragment);
-    }
-
-    function renderAccessibilityImages() {
-        if (!a11yImageList) return;
-        a11yImageList.innerHTML = '';
-        const showImages = !!state.accessibility.imageMode;
-        a11yImageList.classList.toggle('hidden', !showImages);
-        if (!showImages) return;
-        if (!state.accessibility.images.length) {
-            a11yImageList.innerHTML = '<div class="small text-muted">No embedded image assets were detected.</div>';
-            return;
-        }
-        const fragment = document.createDocumentFragment();
-        state.accessibility.images.forEach(function (imageAsset) {
-            const row = document.createElement('div');
-            row.className = 'border rounded p-2';
-            row.innerHTML =
-                '<div class="small fw-semibold mb-1">Page ' + (Number(imageAsset.pageIndex || 0) + 1) + ' - ' + escapeHtml(String(imageAsset.name || imageAsset.assetId || 'Image')) + '</div>' +
-                '<div class="small text-muted mb-1">Asset ID: ' + escapeHtml(String(imageAsset.assetId || '')) + '</div>' +
-                '<input type="text" class="form-control form-control-sm" data-a11y-action="image-alt" data-asset-id="' + escapeHtml(String(imageAsset.assetId || '')) + '" value="' + escapeHtml(String(imageAsset.altText || '')) + '" placeholder="Alternative text">';
-            fragment.appendChild(row);
-        });
-        a11yImageList.appendChild(fragment);
-    }
-
-    function renderAccessibilityTagStructure() {
-        if (!a11yTagStructure) return;
-        const summary = state.accessibility.tagStructure;
-        if (!summary || !summary.present) {
-            a11yTagStructure.textContent = 'No document tag tree detected.';
-            return;
-        }
-        const lines = [
-            'Tag tree present: yes',
-            'Nodes: ' + String(summary.node_count || 0),
-            'Max depth: ' + String(summary.max_depth || 0),
-            '',
-            'Preview:'
-        ];
-        const preview = Array.isArray(summary.preview) ? summary.preview : [];
-        if (!preview.length) {
-            lines.push('(no preview nodes available)');
-        } else {
-            preview.forEach(function (line) { lines.push(String(line)); });
-        }
-        a11yTagStructure.textContent = lines.join('\n');
-    }
-
-    function renderAccessibilityModal() {
-        refreshAccessibilityFromFields();
-        a11yEnableInput.checked = !!state.accessibility.enabled;
-        a11yImageModeInput.checked = !!state.accessibility.imageMode;
-        a11yMetaLanguage.value = String(state.accessibility.metadata.language || '');
-        a11yMetaTitle.value = String(state.accessibility.metadata.title || '');
-        a11yMetaAuthor.value = String(state.accessibility.metadata.author || '');
-        a11yMetaSubject.value = String(state.accessibility.metadata.subject || '');
-        renderAccessibilityFieldList();
-        renderAccessibilityImages();
-        renderAccessibilityTagStructure();
-    }
-
-    function updateAccessibilityMetadataFromInputs() {
-        state.accessibility.metadata = {
-            language: String(a11yMetaLanguage.value || '').trim(),
-            title: String(a11yMetaTitle.value || '').trim(),
-            author: String(a11yMetaAuthor.value || '').trim(),
-            subject: String(a11yMetaSubject.value || '').trim()
-        };
-    }
-
-    async function inspectAccessibilityData(forceRefresh) {
-        if (!state.pdfBytes) return;
-        if (state.accessibility.inspected && !forceRefresh) return;
-        const formData = new FormData();
-        formData.append('file', getPdfFileForRequests());
-        const response = await fetch(apiUrl('/pdf-labeler/api/accessibility-inspect'), {
-            method: 'POST',
-            headers: { 'Accept': 'application/json' },
-            body: formData
-        });
-        const payload = await parseApiResponse(response);
-        if (!payload.success || !payload.data) return;
-
-        const metadata = payload.data.metadata || {};
-        if (!state.accessibility.metadata.language) state.accessibility.metadata.language = String(metadata.language || '');
-        if (!state.accessibility.metadata.title) state.accessibility.metadata.title = String(metadata.title || '');
-        if (!state.accessibility.metadata.author) state.accessibility.metadata.author = String(metadata.author || '');
-        if (!state.accessibility.metadata.subject) state.accessibility.metadata.subject = String(metadata.subject || '');
-
-        const serverFields = Array.isArray(payload.data.fields) ? payload.data.fields : [];
-        serverFields.forEach(function (serverField) {
-            const matched = state.fields.find(function (field) {
-                return String(field.name || '') === String(serverField.name || '');
-            });
-            if (!matched) return;
-            if (!String(matched.tooltip || '').trim() || serverField.has_custom_tooltip) {
-                matched.tooltip = String(serverField.tooltip || defaultTooltipFromFieldName(matched.name));
-            }
-        });
-
-        const serverOrder = Array.isArray(payload.data.field_order)
-            ? payload.data.field_order.map(function (name) { return String(name || ''); })
-            : [];
-        if (serverOrder.length) {
-            const byName = new Map();
-            state.fields.forEach(function (field) {
-                byName.set(String(field.name || ''), field.id);
-            });
-            const orderedIds = [];
-            serverOrder.forEach(function (name) {
-                const fieldId = byName.get(name);
-                if (fieldId && orderedIds.indexOf(fieldId) === -1) {
-                    orderedIds.push(fieldId);
-                }
-            });
-            state.accessibility.fieldOrder = orderedIds;
-        }
-
-        state.accessibility.images = Array.isArray(payload.data.images)
-            ? payload.data.images.map(function (item) {
-                return {
-                    assetId: String(item.assetId || ''),
-                    pageIndex: Number(item.pageIndex || 0),
-                    name: String(item.name || ''),
-                    altText: String(item.altText || ''),
-                    width: Number(item.width || 0),
-                    height: Number(item.height || 0)
-                };
-            })
-            : [];
-        state.accessibility.tagStructure = payload.data.tag_structure || null;
-        state.accessibility.inspected = true;
-        refreshAccessibilityFromFields();
-    }
-
-    function buildAccessibilityPayload(exportNameMap) {
-        if (!state.accessibility.enabled) {
-            return {
-                enabled: false,
-                auto_fill_missing_tooltips: true,
-            };
-        }
-        const fieldTooltips = {};
-        state.fields.forEach(function (field) {
-            const exportName = exportNameMap.get(field.id);
-            if (!exportName) return;
-            const tooltip = String(field.tooltip || '').trim() || defaultTooltipFromFieldName(field.name);
-            fieldTooltips[exportName] = tooltip;
-        });
-
-        const orderedNames = state.accessibility.fieldOrder
-            .map(function (fieldId) { return exportNameMap.get(fieldId); })
-            .filter(Boolean);
-
-        const imageAltText = {};
-        state.accessibility.images.forEach(function (imageAsset) {
-            if (!imageAsset || !imageAsset.assetId) return;
-            imageAltText[String(imageAsset.assetId)] = String(imageAsset.altText || '').trim();
-        });
-
-        return {
-            enabled: true,
-            auto_fill_missing_tooltips: true,
-            field_tooltips: fieldTooltips,
-            field_order: orderedNames,
-            image_alt_text: imageAltText,
-            metadata: Object.assign({}, state.accessibility.metadata)
-        };
-    }
-
-    function invalidateBulkRenamePreview() {
-        state.bulkRenamePreviewCache = null;
-    }
-
-    function bumpFieldNamesVersion() {
-        state.fieldNamesVersion = (Number(state.fieldNamesVersion) || 0) + 1;
-        invalidateBulkRenamePreview();
-    }
-
-    function getDuplicateFieldNames() {
-        const counts = new Map();
-        state.fields.forEach(function (field) {
-            const name = field.name === null || field.name === undefined || field.name === ''
-                ? 'field'
-                : String(field.name);
-            counts.set(name, (counts.get(name) || 0) + 1);
-        });
-        const duplicates = [];
-        counts.forEach(function (count, name) {
-            if (count > 1) duplicates.push(name);
-        });
-        return duplicates;
-    }
-
-    function setFieldsPanelMode(nextMode) {
-        state.fieldsPanelMode = (nextMode === 'rename') ? 'rename' : 'filter';
-        fieldsModeInputs.forEach(function (input) {
-            input.checked = input.value === state.fieldsPanelMode;
-        });
-        const showRename = state.fieldsPanelMode === 'rename';
-        fieldsFilterControls.classList.toggle('hidden', showRename);
-        bulkRenameControls.classList.toggle('hidden', !showRename);
-        fieldsPanel.classList.toggle('bulk-rename-expanded', showRename);
-        if (!showRename) {
-            state.fieldSearch = fieldSearchInput.value || '';
-            refreshFieldsListFromControls();
-            return;
-        }
-        refreshFieldsListFromControls();
-    }
-
-    function escapeRegexPattern(text) {
-        return String(text || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    }
-
-    function buildWildcardRegex(patternText) {
-        const escaped = String(patternText || '')
-            .split('')
-            .map(function (char) {
-                if (char === '*') return '.*';
-                if (char === '?') return '.';
-                return escapeRegexPattern(char);
-            })
-            .join('');
-        return new RegExp(escaped, 'g');
-    }
-
-    function compileBulkRenameTransform(renameType, findPattern, replacementText) {
-        const replacement = String(replacementText || '');
-        if (!findPattern) {
-            return { error: '', transform: null };
-        }
-        if (renameType === 'regex') {
-            try {
-                const regex = new RegExp(findPattern, 'g');
-                return {
-                    error: '',
-                    transform: function (name) {
-                        return String(name || '').replace(regex, replacement);
-                    }
-                };
-            } catch (error) {
-                return { error: 'Invalid regex: ' + (error && error.message ? error.message : 'unknown error'), transform: null };
-            }
-        }
-        const hasWildcard = /[*?]/.test(findPattern);
-        if (hasWildcard) {
-            try {
-                const wildcardRegex = buildWildcardRegex(findPattern);
-                return {
-                    error: '',
-                    transform: function (name) {
-                        return String(name || '').replace(wildcardRegex, replacement);
-                    }
-                };
-            } catch (error) {
-                return { error: 'Invalid wildcard pattern.', transform: null };
-            }
-        }
-        return {
-            error: '',
-            transform: function (name) {
-                const source = String(name || '');
-                if (!findPattern) return source;
-                if (source.indexOf(findPattern) === -1) return source;
-                return source.split(findPattern).join(replacement);
-            }
-        };
-    }
-
-    function getBulkRenamePreview() {
-        if (state.fieldsPanelMode !== 'rename') {
-            return { changedCount: 0, renamedById: new Map(), mapping: {}, error: '', duplicates: [] };
-        }
-        const renameType = state.bulkRenameType === 'regex' ? 'regex' : 'pattern';
-        const findPattern = String(state.bulkRenamePattern || '');
-        const replacementText = String(state.bulkRenameReplacement || '');
-        const cacheKey = [
-            state.fieldNamesVersion,
-            renameType,
-            findPattern,
-            replacementText
-        ].join('::');
-        if (state.bulkRenamePreviewCache && state.bulkRenamePreviewCache.key === cacheKey) {
-            return state.bulkRenamePreviewCache.value;
-        }
-        const compiled = compileBulkRenameTransform(renameType, findPattern, replacementText);
-        if (!compiled.transform) {
-            const emptyResult = {
-                changedCount: 0,
-                renamedById: new Map(),
-                mapping: {},
-                error: compiled.error || '',
-                duplicates: []
-            };
-            state.bulkRenamePreviewCache = { key: cacheKey, value: emptyResult };
-            return emptyResult;
-        }
-
-        const renamedById = new Map();
-        const mapping = {};
-        const resultingCounts = new Map();
-        let changedCount = 0;
-
-        state.fields.forEach(function (field) {
-            const original = String(field.name || '');
-            const renamed = String(compiled.transform(original));
-            const finalName = renamed || original;
-            resultingCounts.set(finalName, (resultingCounts.get(finalName) || 0) + 1);
-            if (finalName !== original) {
-                changedCount += 1;
-                renamedById.set(field.id, {
-                    oldName: original,
-                    newName: finalName
-                });
-                mapping[original] = finalName;
-            }
-        });
-
-        const duplicates = [];
-        resultingCounts.forEach(function (count, name) {
-            if (count > 1) duplicates.push(name);
-        });
-        const result = {
-            changedCount: changedCount,
-            renamedById: renamedById,
-            mapping: mapping,
-            error: '',
-            duplicates: duplicates
-        };
-        state.bulkRenamePreviewCache = { key: cacheKey, value: result };
-        return result;
-    }
-
-    function updateBulkRenameUiState() {
-        const preview = getBulkRenamePreview();
-        const hasPattern = String(state.bulkRenamePattern || '').length > 0;
-        bulkRenameStatus.className = 'bulk-rename-status small text-muted';
-        if (!hasPattern) {
-            bulkRenameStatus.textContent = 'Live preview will appear in the list below.';
-        } else if (preview.error) {
-            bulkRenameStatus.classList.add('error');
-            bulkRenameStatus.textContent = preview.error;
-        } else if (preview.duplicates.length) {
-            bulkRenameStatus.classList.add('warning');
-            bulkRenameStatus.textContent = 'Rename would create duplicate names: ' + preview.duplicates.slice(0, 3).join(', ') + (preview.duplicates.length > 3 ? ' ...' : '');
-        } else if (preview.changedCount === 0) {
-            bulkRenameStatus.textContent = 'No matching fields for current pattern.';
-        } else {
-            bulkRenameStatus.textContent = 'Previewing ' + preview.changedCount + ' rename' + (preview.changedCount === 1 ? '' : 's') + '.';
-        }
-        bulkRenameApplyBtn.disabled = !hasPattern || !!preview.error || preview.changedCount === 0 || preview.duplicates.length > 0;
-    }
-
-    function applyBulkRename() {
-        const preview = getBulkRenamePreview();
-        if (preview.error) {
-            showError(preview.error);
-            return;
-        }
-        if (!preview.changedCount) {
-            showError('No matching fields to rename.');
-            return;
-        }
-        if (preview.duplicates.length) {
-            showError('Bulk rename would create duplicate field names.');
-            return;
-        }
-        state.fields.forEach(function (field) {
-            const change = preview.renamedById.get(field.id);
-            if (change) {
-                field.name = change.newName;
-            }
-        });
-        bumpFieldNamesVersion();
-        setDirty(true);
-        renderFieldsList();
-        renderFieldsOnPages();
-        updateFieldCount();
-        showSuccess('Renamed ' + preview.changedCount + ' field' + (preview.changedCount === 1 ? '' : 's') + '.');
-    }
-
-    function refreshFieldsListFromControls() {
-        renderFieldsList();
-        if (state.selectedFieldId && fieldsList.querySelector('.field-list-item[data-field-id="' + state.selectedFieldId + '"]')) {
-            scrollSelectedFieldIntoView(state.selectedFieldId);
-            return;
-        }
-    }
-
-    function updateToolHint() {
+    groupedByPage[field.pageIndex].push(field);
+  });
+
+  Object.keys(groupedByPage).forEach(function (pageKey) {
+    const pageIndex = Number(pageKey);
+    const threshold = ptToNormalizedLength(thresholdPoints, pageIndex, "y");
+    const pageFields = groupedByPage[pageKey]
+      .slice()
+      .sort(function (left, right) {
+        return left.y + left.height / 2 - (right.y + right.height / 2);
+      });
+    let cluster = [];
+    pageFields.forEach(function (field) {
+      const centerY = field.y + field.height / 2;
+      if (!cluster.length) {
+        cluster = [field];
         return;
+      }
+      const clusterCenter =
+        cluster.reduce(function (sum, item) {
+          return sum + item.y + item.height / 2;
+        }, 0) / cluster.length;
+      if (Math.abs(centerY - clusterCenter) <= threshold) {
+        cluster.push(field);
+        return;
+      }
+      if (cluster.length > 1) {
+        const targetCenter =
+          cluster.reduce(function (sum, item) {
+            return sum + item.y + item.height / 2;
+          }, 0) / cluster.length;
+        cluster.forEach(function (item) {
+          item.y = clamp(targetCenter - item.height / 2, 0, 1 - item.height);
+        });
+      }
+      cluster = [field];
+    });
+    if (cluster.length > 1) {
+      const targetCenter =
+        cluster.reduce(function (sum, item) {
+          return sum + item.y + item.height / 2;
+        }, 0) / cluster.length;
+      cluster.forEach(function (item) {
+        item.y = clamp(targetCenter - item.height / 2, 0, 1 - item.height);
+      });
+    }
+  });
+}
+
+function alignFieldsByColumn(fields, thresholdPoints) {
+  const groupedByPage = {};
+  fields.forEach(function (field) {
+    if (!(
+      field.type === "text" ||
+      field.type === "multiline" ||
+      field.type === "checkbox"
+    ))
+      return;
+    if (!groupedByPage[field.pageIndex]) {
+      groupedByPage[field.pageIndex] = [];
+    }
+    groupedByPage[field.pageIndex].push(field);
+  });
+
+  Object.keys(groupedByPage).forEach(function (pageKey) {
+    const pageIndex = Number(pageKey);
+    const threshold = ptToNormalizedLength(thresholdPoints, pageIndex, "x");
+    const pageFields = groupedByPage[pageKey]
+      .slice()
+      .sort(function (left, right) {
+        return left.x - right.x;
+      });
+    let cluster = [];
+    pageFields.forEach(function (field) {
+      if (!cluster.length) {
+        cluster = [field];
+        return;
+      }
+      const clusterLeft =
+        cluster.reduce(function (sum, item) {
+          return sum + item.x;
+        }, 0) / cluster.length;
+      if (Math.abs(field.x - clusterLeft) <= threshold) {
+        cluster.push(field);
+        return;
+      }
+      if (cluster.length > 1) {
+        var targetLeft =
+          cluster.reduce(function (sum, item) {
+            return sum + item.x;
+          }, 0) / cluster.length;
+        cluster.forEach(function (item) {
+          item.x = clamp(targetLeft, 0, 1 - item.width);
+        });
+      }
+      cluster = [field];
+    });
+    if (cluster.length > 1) {
+      var targetLeft =
+        cluster.reduce(function (sum, item) {
+          return sum + item.x;
+        }, 0) / cluster.length;
+      cluster.forEach(function (item) {
+        item.x = clamp(targetLeft, 0, 1 - item.width);
+      });
+    }
+  });
+}
+
+function readNormalizationSettings() {
+  return {
+    normalizeCheckboxStyle: document.getElementById(
+      "norm-checkbox-style-enable",
+    ).checked,
+    checkboxStyle: document.getElementById("norm-checkbox-style").value || "",
+    checkboxExportValue:
+      String(
+        document.getElementById("norm-checkbox-export-value").value || "",
+      ).trim() || "Yes",
+    uniformCheckboxSize: document.getElementById("norm-checkbox-uniform")
+      .checked,
+    checkboxSizePt: Number(
+      document.getElementById("norm-checkbox-size").value || 12,
+    ),
+    normalizeFont: document.getElementById("norm-font-normalize").checked,
+    normalizeFontSize: document.getElementById("norm-fontsize-normalize")
+      .checked,
+    fontName:
+      document.getElementById("norm-font-name").value ||
+      getSessionDefault("font"),
+    fontSizePt: Number(
+      document.getElementById("norm-font-size").value ||
+        getSessionDefault("fontSize"),
+    ),
+    dropdownsToText: document.getElementById("norm-dropdowns-to-text").checked,
+    radiosToCheckboxes: document.getElementById("norm-radios-to-checkboxes")
+      .checked,
+    alignRows: document.getElementById("norm-align-rows").checked,
+    alignThresholdPt: Number(
+      document.getElementById("norm-align-threshold").value || 6,
+    ),
+    alignColumns: document.getElementById("norm-align-columns").checked,
+    alignColumnThresholdPt: Number(
+      document.getElementById("norm-align-col-threshold").value || 6,
+    ),
+    autoSizeNameAddress: document.getElementById("norm-autosize-name-address")
+      .checked,
+    fixedTextHeightPt: Number(
+      document.getElementById("norm-text-height").value || 14,
+    ),
+    disableAutoScroll: document.getElementById("norm-disable-scroll").checked,
+    multilineTallFields: document.getElementById("norm-multiline-tall").checked,
+    multilineThresholdLines: Number(
+      document.getElementById("norm-multiline-lines").value || 2.2,
+    ),
+    multilineWhiteBackground: document.getElementById("norm-multiline-white")
+      .checked,
+    removeEmbeddedFonts: document.getElementById("norm-remove-embedded-fonts")
+      .checked,
+    lowercaseNames: document.getElementById("norm-lowercase-names").checked,
+  };
+}
+
+function buildNormalizedFields(settings) {
+  const transformed = [];
+  state.fields.forEach(function (field) {
+    const nextField = Object.assign({}, field);
+    nextField.font = nextField.font || getSessionDefault("font");
+    nextField.fontSize =
+      Number(nextField.fontSize) || getSessionDefault("fontSize");
+
+    if (settings.dropdownsToText && nextField.type === "dropdown") {
+      nextField.type = "text";
+      delete nextField.options;
     }
 
-    function hideQuickFieldEditor() {
-        state.quickEditFieldId = null;
-        state.quickEditFocusPending = false;
-        quickFieldEditor.classList.add('hidden');
-        quickFieldSuggestions.innerHTML = '';
-        quickFieldSuggestions.classList.add('hidden');
+    if (settings.radiosToCheckboxes && nextField.type === "radio") {
+      const options =
+        Array.isArray(nextField.options) && nextField.options.length
+          ? nextField.options.slice()
+          : ["Yes", "No"];
+      const suffixes = getRadioOptionSuffixes(options);
+      const boxWidth = ptToNormalizedLength(
+        settings.checkboxSizePt,
+        nextField.pageIndex,
+        "x",
+      );
+      const boxHeight = ptToNormalizedLength(
+        settings.checkboxSizePt,
+        nextField.pageIndex,
+        "y",
+      );
+      const gap = ptToNormalizedLength(
+        Math.max(4, settings.checkboxSizePt * 0.35),
+        nextField.pageIndex,
+        "x",
+      );
+      const totalWidth = options.length * boxWidth + (options.length - 1) * gap;
+      const startX = clamp(
+        nextField.x + Math.max(0, (nextField.width - totalWidth) / 2),
+        0,
+        1 - boxWidth,
+      );
+      const targetY = clamp(
+        nextField.y + nextField.height / 2 - boxHeight / 2,
+        0,
+        1 - boxHeight,
+      );
+      const baseName = normalizePdfFieldName(nextField.name);
+      options.forEach(function (_option, index) {
+        transformed.push({
+          id: generateId(),
+          name: baseName + "_" + suffixes[index],
+          type: "checkbox",
+          pageIndex: nextField.pageIndex,
+          x: clamp(startX + index * (boxWidth + gap), 0, 1 - boxWidth),
+          y: targetY,
+          width: boxWidth,
+          height: boxHeight,
+          font: settings.normalizeFont ? settings.fontName : nextField.font,
+          fontSize: settings.normalizeFontSize
+            ? settings.fontSizePt
+            : nextField.fontSize,
+          autoSize: false,
+          checkboxStyle:
+            (settings.normalizeCheckboxStyle && settings.checkboxStyle) ||
+            nextField.checkboxStyle ||
+            "cross",
+          checkboxExportValue:
+            (settings.normalizeCheckboxStyle && settings.checkboxExportValue) ||
+            nextField.checkboxExportValue ||
+            "Yes",
+          allowScroll: false,
+        });
+      });
+      return;
     }
 
-    function getVisiblePdfViewportRect() {
-        const containerRect = pdfContainer.getBoundingClientRect();
-        const left = Math.max(containerRect.left + 8, 8);
-        const top = Math.max(containerRect.top + 8, 8);
-        const right = Math.min(containerRect.right - 8, window.innerWidth - 8);
-        const bottom = Math.min(containerRect.bottom - 8, window.innerHeight - 8);
+    if (
+      settings.normalizeFont &&
+      (nextField.type === "text" ||
+        nextField.type === "multiline" ||
+        nextField.type === "signature")
+    ) {
+      nextField.font = settings.fontName;
+    }
+    if (
+      settings.normalizeFontSize &&
+      (nextField.type === "text" ||
+        nextField.type === "multiline" ||
+        nextField.type === "signature")
+    ) {
+      nextField.fontSize = settings.fontSizePt;
+    }
+
+    if (
+      settings.normalizeCheckboxStyle &&
+      nextField.type === "checkbox" &&
+      settings.checkboxStyle
+    ) {
+      nextField.checkboxStyle = settings.checkboxStyle;
+    }
+
+    if (
+      settings.normalizeCheckboxStyle &&
+      nextField.type === "checkbox" &&
+      settings.checkboxExportValue
+    ) {
+      nextField.checkboxExportValue = settings.checkboxExportValue;
+    }
+
+    if (settings.uniformCheckboxSize && nextField.type === "checkbox") {
+      nextField.width = ptToNormalizedLength(
+        settings.checkboxSizePt,
+        nextField.pageIndex,
+        "x",
+      );
+      nextField.height = ptToNormalizedLength(
+        settings.checkboxSizePt,
+        nextField.pageIndex,
+        "y",
+      );
+    }
+
+    if (
+      settings.disableAutoScroll &&
+      (nextField.type === "text" || nextField.type === "multiline")
+    ) {
+      nextField.allowScroll = false;
+    }
+
+    if (nextField.type === "text" || nextField.type === "multiline") {
+      nextField.autoSize = false;
+    }
+
+    if (
+      !settings.normalizeFontSize &&
+      settings.autoSizeNameAddress &&
+      nextField.type === "text" &&
+      looksLikeSingleLineAutoSizeField(nextField.name)
+    ) {
+      nextField.autoSize = true;
+    }
+    if (
+      settings.autoSizeNameAddress &&
+      nextField.type === "text" &&
+      looksLikeSingleLineAutoSizeField(nextField.name)
+    ) {
+      nextField.height = ptToNormalizedLength(
+        settings.fixedTextHeightPt,
+        nextField.pageIndex,
+        "y",
+      );
+    }
+
+    if (settings.multilineTallFields && nextField.type === "text") {
+      const lineHeightPt = settings.fontSizePt * 1.2;
+      const fieldHeightPt =
+        nextField.height *
+        (state.pageSizes[nextField.pageIndex]
+          ? state.pageSizes[nextField.pageIndex].height
+          : 792);
+      if (fieldHeightPt / lineHeightPt >= settings.multilineThresholdLines) {
+        nextField.type = "multiline";
+      }
+    }
+
+    if (settings.multilineWhiteBackground && nextField.type === "multiline") {
+      nextField.backgroundColor = "#ffffff";
+    }
+
+    transformed.push(nextField);
+  });
+
+  if (settings.alignRows) {
+    alignFieldsByRow(transformed, settings.alignThresholdPt);
+  }
+  if (settings.alignColumns) {
+    alignFieldsByColumn(transformed, settings.alignColumnThresholdPt);
+  }
+  if (settings.lowercaseNames) {
+    transformed.forEach(function (field) {
+      field.name = field.name.toLowerCase();
+    });
+  }
+  return dedupeNormalizedFieldNames(transformed);
+}
+
+function renderFieldEditor(field) {
+  const meta = getFieldTypeMeta(field.type);
+  const nameHelp = getFieldNameHelp(field);
+  const optionsValue =
+    Array.isArray(field.options) && field.options.length
+      ? field.options.join(", ")
+      : DEFAULT_OPTION_LIST.join(", ");
+  const isTextLike = field.type === "text" || field.type === "multiline";
+  const autoSize = field.autoSize !== false;
+  return (
+    "" +
+    '<div class="field-card-editor">' +
+    '<div class="d-flex align-items-center justify-content-between gap-2 mb-3">' +
+    '<div class="field-type-badge">' +
+    meta.icon +
+    "<span>" +
+    escapeHtml(meta.label) +
+    "</span></div>" +
+    '<div class="field-card-subtext">Editing selected field</div>' +
+    "</div>" +
+    '<div class="mb-3">' +
+    '<label class="form-label small text-muted fw-semibold mb-1" for="field-name-' +
+    escapeHtml(field.id) +
+    '">PDF field label</label>' +
+    '<div class="d-flex gap-2">' +
+    '<input type="text" id="field-name-' +
+    escapeHtml(field.id) +
+    '" class="form-control form-control-sm font-monospace" data-action="field-name" data-field-id="' +
+    escapeHtml(field.id) +
+    '" value="' +
+    escapeHtml(field.name) +
+    '">' +
+    '<button type="button" class="btn btn-outline-secondary btn-sm" data-action="normalize-name" data-field-id="' +
+    escapeHtml(field.id) +
+    '">Normalize</button>' +
+    "</div>" +
+    '<div class="field-card-help ' +
+    escapeHtml(nameHelp.level) +
+    '">' +
+    nameHelp.html +
+    "</div>" +
+    "</div>" +
+    '<div class="mb-3">' +
+    '<label class="form-label small text-muted fw-semibold mb-1" for="field-type-' +
+    escapeHtml(field.id) +
+    '">Field type</label>' +
+    '<select id="field-type-' +
+    escapeHtml(field.id) +
+    '" class="form-select form-select-sm" data-action="field-type" data-field-id="' +
+    escapeHtml(field.id) +
+    '">' +
+    '<option value="text"' +
+    (field.type === "text" ? " selected" : "") +
+    ">Single-line Text</option>" +
+    '<option value="multiline"' +
+    (field.type === "multiline" ? " selected" : "") +
+    ">Multi-line Text</option>" +
+    '<option value="checkbox"' +
+    (field.type === "checkbox" ? " selected" : "") +
+    ">Checkbox</option>" +
+    '<option value="signature"' +
+    (field.type === "signature" ? " selected" : "") +
+    ">Signature</option>" +
+    '<option value="radio"' +
+    (field.type === "radio" ? " selected" : "") +
+    ">Radio Group</option>" +
+    '<option value="dropdown"' +
+    (field.type === "dropdown" ? " selected" : "") +
+    ">Dropdown</option>" +
+    '<option value="listbox"' +
+    (field.type === "listbox" ? " selected" : "") +
+    ">List Box</option>" +
+    "</select>" +
+    "</div>" +
+    (isTextLike
+      ? '<div class="mb-3">' +
+        '<label class="form-label small text-muted fw-semibold mb-1">Font and size</label>' +
+        '<div class="font-row">' +
+        "<div>" +
+        '<select class="form-select form-select-sm" aria-label="Font for ' +
+        escapeHtml(field.name) +
+        '" data-action="field-font" data-field-id="' +
+        escapeHtml(field.id) +
+        '">' +
+        renderFontOptions(field.font || getSessionDefault("font")) +
+        "</select>" +
+        "</div>" +
+        '<label class="auto-size-wrap form-check small mb-0 mt-1">' +
+        '<input class="form-check-input" type="checkbox" data-action="field-auto-size" data-field-id="' +
+        escapeHtml(field.id) +
+        '"' +
+        (autoSize ? " checked" : "") +
+        ">" +
+        '<span class="form-check-label">Auto size</span>' +
+        "</label>" +
+        "<div>" +
+        '<input type="number" min="4" max="72" step="1" aria-label="Font size for ' +
+        escapeHtml(field.name) +
+        '" class="form-control form-control-sm" data-action="field-font-size" data-field-id="' +
+        escapeHtml(field.id) +
+        '" value="' +
+        escapeHtml(String(field.fontSize || getSessionDefault("fontSize"))) +
+        '"' +
+        (autoSize ? " disabled" : "") +
+        ">" +
+        "</div>" +
+        "</div>" +
+        "</div>"
+      : "") +
+    (field.type === "checkbox"
+      ? '<div class="mb-3">' +
+        '<label class="form-label small text-muted fw-semibold mb-1">Checkbox settings</label>' +
+        '<div class="normalization-inline-2">' +
+        "<div>" +
+        '<label class="form-label small text-muted mb-1" for="field-checkbox-style-' +
+        escapeHtml(field.id) +
+        '">Style</label>' +
+        '<select id="field-checkbox-style-' +
+        escapeHtml(field.id) +
+        '" class="form-select form-select-sm" data-action="field-checkbox-style" data-field-id="' +
+        escapeHtml(field.id) +
+        '">' +
+        '<option value="cross"' +
+        ((field.checkboxStyle || "cross") === "cross" ? " selected" : "") +
+        ">Cross</option>" +
+        '<option value="check"' +
+        ((field.checkboxStyle || "cross") === "check" ? " selected" : "") +
+        ">Check</option>" +
+        '<option value="circle"' +
+        (field.checkboxStyle === "circle" ? " selected" : "") +
+        ">Circle</option>" +
+        '<option value="star"' +
+        (field.checkboxStyle === "star" ? " selected" : "") +
+        ">Star</option>" +
+        '<option value="diamond"' +
+        (field.checkboxStyle === "diamond" ? " selected" : "") +
+        ">Diamond</option>" +
+        '<option value="square"' +
+        (field.checkboxStyle === "square" ? " selected" : "") +
+        ">Square</option>" +
+        "</select>" +
+        "</div>" +
+        "<div>" +
+        '<label class="form-label small text-muted mb-1" for="field-checkbox-export-value-' +
+        escapeHtml(field.id) +
+        '">Export value</label>' +
+        '<input id="field-checkbox-export-value-' +
+        escapeHtml(field.id) +
+        '" type="text" class="form-control form-control-sm font-monospace" data-action="field-checkbox-export-value" data-field-id="' +
+        escapeHtml(field.id) +
+        '" value="' +
+        escapeHtml(String(field.checkboxExportValue || "Yes")) +
+        '">' +
+        "</div>" +
+        '<label class="form-check small mb-0 align-self-end">' +
+        '<input class="form-check-input" type="checkbox" data-action="field-checkbox-border" data-field-id="' +
+        escapeHtml(field.id) +
+        '"' +
+        (field.checkboxBorder ? " checked" : "") +
+        ">" +
+        '<span class="form-check-label">Border</span>' +
+        "</label>" +
+        "<div>" +
+        '<label class="form-label small text-muted mb-1" for="field-checkbox-border-width-' +
+        escapeHtml(field.id) +
+        '">Border width</label>' +
+        '<select id="field-checkbox-border-width-' +
+        escapeHtml(field.id) +
+        '" class="form-select form-select-sm" data-action="field-checkbox-border-width" data-field-id="' +
+        escapeHtml(field.id) +
+        '"' +
+        (field.checkboxBorder ? "" : " disabled") +
+        ">" +
+        '<option value="thin"' +
+        ((field.checkboxBorderWidth || "thin") === "thin" ? " selected" : "") +
+        ">Thin</option>" +
+        '<option value="medium"' +
+        (field.checkboxBorderWidth === "medium" ? " selected" : "") +
+        ">Medium</option>" +
+        '<option value="thick"' +
+        (field.checkboxBorderWidth === "thick" ? " selected" : "") +
+        ">Thick</option>" +
+        "</select>" +
+        "</div>" +
+        "</div>" +
+        "</div>"
+      : "") +
+    (OPTION_TYPES.has(field.type)
+      ? '<div class="mb-3">' +
+        '<label class="form-label small text-muted fw-semibold mb-1" for="field-options-' +
+        escapeHtml(field.id) +
+        '">Options</label>' +
+        '<textarea id="field-options-' +
+        escapeHtml(field.id) +
+        '" rows="3" class="form-control form-control-sm" data-action="field-options" data-field-id="' +
+        escapeHtml(field.id) +
+        '">' +
+        escapeHtml(optionsValue) +
+        "</textarea>" +
+        '<div class="form-text small">Separate each option with a comma.</div>' +
+        "</div>"
+      : "") +
+    '<div class="field-card-actions">' +
+    '<button type="button" class="btn btn-outline-secondary btn-sm" data-action="duplicate-field" data-field-id="' +
+    escapeHtml(field.id) +
+    '">Duplicate</button>' +
+    '<button type="button" class="btn btn-outline-danger btn-sm" data-action="delete-field" data-field-id="' +
+    escapeHtml(field.id) +
+    '">Delete</button>' +
+    '<select class="form-select form-select-sm d-inline-block w-auto ms-1" data-action="move-field-page" data-field-id="' +
+    escapeHtml(field.id) +
+    '" aria-label="Move to page">' +
+    '<option value="">Move to page...</option>' +
+    Array.apply(null, Array(state.pageCount))
+      .map(function (_, i) {
+        return (
+          '<option value="' +
+          i +
+          '"' +
+          (field.pageIndex === i ? " disabled" : "") +
+          ">Page " +
+          (i + 1) +
+          "</option>"
+        );
+      })
+      .join("") +
+    "</select>" +
+    "</div>" +
+    "</div>"
+  );
+}
+
+function renderFieldsList() {
+  updateBulkRenameUiState();
+  updateFieldCount();
+  if (state.fields.length === 0) {
+    fieldsList.innerHTML = "";
+    return;
+  }
+  const showPageGroups = state.pageCount > 1 && state.fieldSort === "position";
+  const orderedFields = getDisplayedFields();
+  const renamePreview =
+    state.fieldsPanelMode === "rename" ? getBulkRenamePreview() : null;
+  fieldsList.innerHTML = "";
+  if (orderedFields.length === 0) {
+    fieldsList.innerHTML =
+      '<div class="text-muted small px-1 py-2">No fields match the current filter.</div>';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  let currentGroup = null;
+  let currentPage = null;
+
+  orderedFields.forEach(function (field) {
+    const meta = getFieldTypeMeta(field.type);
+    if (!currentGroup || (showPageGroups && currentPage !== field.pageIndex)) {
+      currentPage = field.pageIndex;
+      currentGroup = document.createElement("section");
+      currentGroup.className = "field-list-page";
+      if (showPageGroups) {
+        currentGroup.dataset.pageIndex = String(field.pageIndex);
+      }
+      if (showPageGroups) {
+        const divider = document.createElement("div");
+        divider.className = "field-page-divider";
+        divider.textContent = "Page " + (field.pageIndex + 1);
+        currentGroup.appendChild(divider);
+      }
+      fragment.appendChild(currentGroup);
+    }
+    const item = document.createElement("div");
+    item.className =
+      "field-list-item" +
+      (field.id === state.selectedFieldId ? " selected" : "");
+    item.dataset.fieldId = field.id;
+    const renameChange = renamePreview
+      ? renamePreview.renamedById.get(field.id)
+      : null;
+    const displayNameHtml = renameChange
+      ? '<div class="field-list-name field-list-name-preview" title="' +
+        escapeHtml(renameChange.oldName + " -> " + renameChange.newName) +
+        '">' +
+        '<span class="rename-old">' +
+        escapeHtml(renameChange.oldName) +
+        "</span>" +
+        '<span class="rename-arrow">-></span>' +
+        '<span class="rename-new">' +
+        escapeHtml(renameChange.newName) +
+        "</span>" +
+        "</div>"
+      : '<div class="field-list-name" title="' +
+        escapeHtml(field.name) +
+        '">' +
+        escapeHtml(field.name) +
+        "</div>";
+    item.innerHTML =
+      '<div class="field-list-row">' +
+      '<div class="field-list-icon" aria-hidden="true">' +
+      meta.icon +
+      "</div>" +
+      displayNameHtml +
+      "</div>" +
+      (field.id === state.selectedFieldId ? renderFieldEditor(field) : "");
+    item.addEventListener("click", function (event) {
+      if (
+        /** @type {any} */ (event.target).closest(
+          "input, select, textarea, button",
+        )
+      ) {
+        return;
+      }
+      selectField(field.id, { focusNameInput: false, scrollIntoView: true });
+    });
+    item
+      .querySelectorAll("input, select, textarea")
+      .forEach(function (control) {
+        control.addEventListener("click", function (event) {
+          event.stopPropagation();
+        });
+      });
+    currentGroup.appendChild(item);
+  });
+  fieldsList.appendChild(fragment);
+}
+
+function renderDraftRect() {
+  document.querySelectorAll(".draft-rect").forEach(function (node) {
+    node.remove();
+  });
+  if (!draftState) return;
+  const overlay = getOverlayForPage(draftState.pageIndex);
+  if (!overlay) return;
+  const draftRect = document.createElement("div");
+  draftRect.className = "draft-rect";
+  draftRect.style.left =
+    Math.min(draftState.startX, draftState.currentX) * 100 + "%";
+  draftRect.style.top =
+    Math.min(draftState.startY, draftState.currentY) * 100 + "%";
+  draftRect.style.width =
+    Math.abs(draftState.currentX - draftState.startX) * 100 + "%";
+  draftRect.style.height =
+    Math.abs(draftState.currentY - draftState.startY) * 100 + "%";
+  overlay.appendChild(draftRect);
+}
+
+function getFieldBoxClasses(field) {
+  return "field-box" + (field.id === state.selectedFieldId ? " selected" : "");
+}
+
+function applyFieldChipLayout(fieldEl, labelEl) {
+  const width = fieldEl.offsetWidth;
+  const height = fieldEl.offsetHeight;
+  labelEl.classList.remove("hide-name", "icon-only", "wrap-name", "compact");
+
+  if (width < 20 || height < 11) {
+    labelEl.classList.add("hide-name", "icon-only");
+    return;
+  }
+
+  if (width < 34) {
+    labelEl.classList.add("hide-name", "icon-only");
+    return;
+  }
+
+  if (height < 16) {
+    if (width >= 60) {
+      labelEl.classList.add("compact");
+      return;
+    }
+    labelEl.classList.add("hide-name", "icon-only");
+    return;
+  }
+
+  if (width >= 96 && height >= 24) {
+    labelEl.classList.add("wrap-name");
+  }
+}
+
+function renderFieldsOnPages() {
+  document.querySelectorAll(".field-box").forEach(function (node) {
+    node.remove();
+  });
+  state.fields.forEach(function (field) {
+    const overlay = getOverlayForPage(field.pageIndex);
+    if (!overlay) return;
+
+    const meta = getFieldTypeMeta(field.type);
+    const fieldEl = document.createElement("div");
+    fieldEl.className = getFieldBoxClasses(field);
+    fieldEl.dataset.fieldId = field.id;
+    fieldEl.dataset.fieldType = field.type;
+    fieldEl.style.left = field.x * 100 + "%";
+    fieldEl.style.top = field.y * 100 + "%";
+    fieldEl.style.width = field.width * 100 + "%";
+    fieldEl.style.height = field.height * 100 + "%";
+    if (field.backgroundColor) {
+      fieldEl.style.background = field.backgroundColor;
+    }
+
+    const label = document.createElement("div");
+    label.className = "field-chip";
+    label.innerHTML =
+      meta.icon +
+      '<span class="field-chip-name">' +
+      escapeHtml(field.name) +
+      "</span>";
+    fieldEl.appendChild(label);
+
+    // --- Preview mode content ---
+    if (state.previewMode) {
+      fieldEl.classList.add("previewing");
+      var previewDiv = document.createElement("div");
+      previewDiv.className = "field-preview-content";
+
+      if (field.type === "checkbox" || field.type === "radio") {
+        previewDiv.classList.add("preview-checkbox");
+        var glyph =
+          CHECKBOX_PREVIEW_GLYPHS[
+            field.checkboxStyle || getSessionDefault("checkboxStyle")
+          ] || "\u2713";
+        previewDiv.textContent = glyph;
+        // Scale the glyph to fit the box
+        var overlayEl = getOverlayForPage(field.pageIndex);
+        var boxPx = overlayEl
+          ? Math.min(
+              field.width * overlayEl.offsetWidth,
+              field.height * overlayEl.offsetHeight,
+            )
+          : 20;
+        previewDiv.style.fontSize = Math.max(8, boxPx * 0.8) + "px";
+        previewDiv.style.lineHeight = "1";
+        previewDiv.style.color = "#000";
+        if (field.checkboxBorder) {
+          var borderWidths = { thin: 1, medium: 2, thick: 3 };
+          previewDiv.style.border =
+            (borderWidths[field.checkboxBorderWidth || "thin"] || 1) +
+            "px solid #000";
+        }
+      } else if (field.type === "signature") {
+        previewDiv.classList.add("preview-signature");
+        if (_signatureDataUrl) {
+          var sigImg = document.createElement("img");
+          sigImg.src = _signatureDataUrl;
+          sigImg.alt = "Signature preview";
+          previewDiv.appendChild(sigImg);
+        }
+      } else {
+        // text, multiline, dropdown, listbox — render the field name
+        var css = pdfFontToCss(field.font || getSessionDefault("font"));
+        var ptSize = field.fontSize || getSessionDefault("fontSize") || 10;
+        // 1 PDF pt = renderScale CSS px on the scaled canvas overlay
+        var pxSize = ptSize * getViewerRenderScale();
+        previewDiv.style.fontFamily = css.family;
+        previewDiv.style.fontWeight = css.weight;
+        previewDiv.style.lineHeight = "1.15";
+        previewDiv.style.color = "#000";
+        previewDiv.style.whiteSpace =
+          field.type === "multiline" ? "pre-wrap" : "nowrap";
+        previewDiv.textContent = field.name || "";
+
+        // Apply auto-sizing: adjust font to fit field dimensions
+        if (field.autoSize && field.name && field.type === "text") {
+          var pageSize = state.pageSizes[field.pageIndex] || {
+            width: 612,
+            height: 792,
+          };
+          var fieldWidthPx =
+            field.width * (pageSize.width * getViewerRenderScale());
+          var fieldHeightPx =
+            field.height * (pageSize.height * getViewerRenderScale());
+
+          // Max font size based on field height (single-line text, ~15% padding)
+          var maxPxSize = (fieldHeightPx * 0.85) / 1.15; // Account for line-height
+
+          // PDF auto-size derives its starting size from the widget height.
+          pxSize = maxPxSize;
+
+          // Now check if text width fits; scale down if needed
+          var fontStr =
+            css.weight + " " + Math.round(pxSize) + "px " + css.family;
+          var canvas = document.createElement("canvas");
+          var ctx = canvas.getContext("2d");
+          if (ctx) {
+            ctx.font = fontStr;
+            var textWidth = ctx.measureText(previewDiv.textContent).width;
+            var padding = 4; // Left/right padding in PDF viewer
+
+            // Scale down if text exceeds field width
+            if (textWidth + padding > fieldWidthPx && textWidth > 0) {
+              pxSize = (pxSize * (fieldWidthPx - padding)) / textWidth;
+            }
+          }
+        }
+
+        previewDiv.style.fontSize = pxSize + "px";
+      }
+      fieldEl.appendChild(previewDiv);
+    }
+
+    if (field.id === state.selectedFieldId) {
+      ["nw", "n", "ne", "e", "se", "s", "sw", "w"].forEach(
+        function (handleName) {
+          const handle = document.createElement("div");
+          handle.className = "resize-handle " + handleName;
+          handle.dataset.handle = handleName;
+          fieldEl.appendChild(handle);
+        },
+      );
+    }
+
+    fieldEl.addEventListener("pointerdown", function (event) {
+      event.stopPropagation();
+      setSelectedTool(null);
+
+      const target = /** @type {any} */ (event.target);
+      if (target && target.dataset && target.dataset.handle) {
+        selectField(field.id, { focusNameInput: false, scrollIntoView: false });
+        startResize(field.id, target.dataset.handle, event, overlay);
+        return;
+      }
+      startDrag(field.id, event, overlay);
+    });
+
+    fieldEl.addEventListener("click", function (event) {
+      const target = /** @type {any} */ (event.target);
+      if (target && target.dataset && target.dataset.handle) {
+        return;
+      }
+      event.stopPropagation();
+      // First click selects (handles only); second click on
+      // already-selected field opens the quick editor.
+      if (state.selectedFieldId === field.id) {
+        selectField(field.id, { focusNameInput: true, scrollIntoView: false });
+      } else {
+        selectField(field.id, { focusNameInput: false, scrollIntoView: false });
+      }
+    });
+
+    fieldEl.addEventListener("dblclick", function (event) {
+      event.stopPropagation();
+      selectField(field.id, { focusNameInput: true, scrollIntoView: false });
+    });
+
+    overlay.appendChild(fieldEl);
+    applyFieldChipLayout(fieldEl, label);
+  });
+  renderDraftRect();
+  syncQuickFieldEditor({ preserveInput: true });
+}
+
+function selectField(fieldId, options) {
+  const settings = options || {};
+  state.selectedFieldId = fieldId;
+  if (!fieldId) {
+    hideQuickFieldEditor();
+  } else if (settings.focusNameInput) {
+    state.quickEditFieldId = fieldId;
+    state.quickEditFocusPending = true;
+  } else if (state.quickEditFieldId && state.quickEditFieldId !== fieldId) {
+    hideQuickFieldEditor();
+  }
+  renderFieldsList();
+  renderFieldsOnPages();
+  if (fieldId && settings.scrollIntoView) {
+    const fieldEl = document.querySelector(
+      '.field-box[data-field-id="' + fieldId + '"]',
+    );
+    if (fieldEl) {
+      fieldEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }
+  if (fieldId) {
+    scrollSelectedFieldIntoView(fieldId);
+  }
+  syncQuickFieldEditor({ preserveInput: true });
+}
+
+function replaceFields(fields, options) {
+  const settings = options || {};
+  state.fields = fields.map(function (field) {
+    const width = clamp(Number(field.width), 0.01, 1);
+    const height = clamp(Number(field.height), 0.01, 1);
+    return {
+      id: field.id || generateId(),
+      name: field.name,
+      type: normalizeFieldType(field.type),
+      pageIndex: Number(field.pageIndex) || 0,
+      x: clamp(Number(field.x), 0, 1 - width),
+      y: clamp(Number(field.y), 0, 1 - height),
+      width: width,
+      height: height,
+      font: field.font || getSessionDefault("font"),
+      fontSize: Number(field.fontSize) || getSessionDefault("fontSize"),
+      autoSize: field.autoSize !== false,
+      checkboxStyle: field.checkboxStyle || undefined,
+      checkboxExportValue: field.checkboxExportValue || undefined,
+      checkboxBorder: !!field.checkboxBorder,
+      checkboxBorderWidth: field.checkboxBorderWidth || "thin",
+      allowScroll: field.allowScroll !== false,
+      backgroundColor: field.backgroundColor || undefined,
+      options: Array.isArray(field.options) ? field.options.slice() : undefined,
+      tooltip: String(field.tooltip || "").trim(),
+    };
+  });
+  refreshAccessibilityFromFields();
+  bumpFieldNamesVersion();
+  state.selectedFieldId =
+    settings.preserveSelection &&
+    state.fields.some(function (field) {
+      return field.id === state.selectedFieldId;
+    })
+      ? state.selectedFieldId
+      : state.fields[0]
+        ? state.fields[0].id
+        : null;
+  if (
+    !state.fields.some(function (field) {
+      return field.id === state.quickEditFieldId;
+    })
+  ) {
+    hideQuickFieldEditor();
+  }
+  renderFieldsList();
+  renderFieldsOnPages();
+  updateFieldCount();
+}
+
+function markDirtyAndRender(skipListRefresh) {
+  setDirty(true);
+  renderFieldsOnPages();
+  if (!skipListRefresh) {
+    renderFieldsList();
+  }
+  updateFieldCount();
+  syncQuickFieldEditor({ preserveInput: true });
+}
+
+function createFieldFromTool(pageIndex, x, y, width, height) {
+  if (!state.selectedTool) return;
+  const type = normalizeFieldType(state.selectedTool);
+  const rect = {
+    x: clamp(x, 0, 1 - clamp(width, 0.01, 1)),
+    y: clamp(y, 0, 1 - clamp(height, 0.01, 1)),
+    width: clamp(width, 0.01, 1),
+    height: clamp(height, 0.01, 1),
+  };
+  const nameSuggestions = buildFieldNameSuggestions(
+    pageIndex,
+    rect,
+    type,
+    null,
+  );
+  const field = {
+    id: generateId(),
+    name: nameSuggestions[0]
+      ? nameSuggestions[0].name
+      : getDefaultFieldName(type),
+    type: type,
+    pageIndex: pageIndex,
+    x: 0,
+    y: 0,
+    width: rect.width,
+    height: rect.height,
+    font: getSessionDefault("font"),
+    fontSize: getSessionDefault("fontSize"),
+    autoSize:
+      type === "text" &&
+      looksLikeSingleLineAutoSizeField(
+        nameSuggestions[0]
+          ? nameSuggestions[0].name
+          : getDefaultFieldName(type),
+      ),
+    checkboxStyle:
+      type === "checkbox"
+        ? getSessionDefault("checkboxStyle") || "cross"
+        : undefined,
+    checkboxExportValue:
+      type === "checkbox"
+        ? getSessionDefault("checkboxExportValue")
+        : undefined,
+    checkboxBorder: false,
+    checkboxBorderWidth: "thin",
+    options: OPTION_TYPES.has(type) ? DEFAULT_OPTION_LIST.slice() : undefined,
+    nameSuggestions: nameSuggestions,
+    tooltip: "",
+  };
+  field.x = rect.x;
+  field.y = rect.y;
+  ensureFieldAccessibilityDefaults(field);
+  state.fields.push(field);
+  reconcileAccessibilityFieldOrder();
+  bumpFieldNamesVersion();
+  selectField(field.id, { focusNameInput: true, scrollIntoView: false });
+  setDirty(true);
+  updateFieldCount();
+  renderFieldsList();
+  renderFieldsOnPages();
+}
+
+function createPointField(pageIndex, pointX, pointY) {
+  const meta = getFieldTypeMeta(state.selectedTool);
+  const width = meta.defaultWidth || 0.032;
+  const height = meta.defaultHeight || 0.032;
+  const x = clamp(pointX - width / 2, 0, 1 - width);
+  const y = clamp(pointY - height / 2, 0, 1 - height);
+  createFieldFromTool(pageIndex, x, y, width, height);
+}
+
+function startDrag(fieldId, event, overlay) {
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  const rect = overlay.getBoundingClientRect();
+  const pointerX = (event.clientX - rect.left) / rect.width;
+  const pointerY = (event.clientY - rect.top) / rect.height;
+  dragState = {
+    fieldId: fieldId,
+    pageIndex: field.pageIndex,
+    startClientX: event.clientX,
+    startClientY: event.clientY,
+    startPointerX: pointerX,
+    startPointerY: pointerY,
+    originX: field.x,
+    originY: field.y,
+    moved: false,
+  };
+}
+
+function startResize(fieldId, handle, event, overlay) {
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  const rect = overlay.getBoundingClientRect();
+  resizeState = {
+    fieldId: fieldId,
+    handle: handle,
+    startX: (event.clientX - rect.left) / rect.width,
+    startY: (event.clientY - rect.top) / rect.height,
+    originX: field.x,
+    originY: field.y,
+    originWidth: field.width,
+    originHeight: field.height,
+  };
+}
+
+function handleDragMove(event) {
+  if (!dragState) return;
+  const dragDistance = Math.hypot(
+    event.clientX - dragState.startClientX,
+    event.clientY - dragState.startClientY,
+  );
+  if (!dragState.moved) {
+    if (dragDistance < 4) {
+      return;
+    }
+    dragState.moved = true;
+    if (state.selectedFieldId !== dragState.fieldId) {
+      selectField(dragState.fieldId, {
+        focusNameInput: false,
+        scrollIntoView: false,
+      });
+    }
+  }
+  const overlay = getOverlayForPage(dragState.pageIndex);
+  if (!overlay) return;
+  const rect = overlay.getBoundingClientRect();
+  const pointerX = (event.clientX - rect.left) / rect.width;
+  const pointerY = (event.clientY - rect.top) / rect.height;
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === dragState.fieldId;
+  });
+  if (!field) return;
+  field.x = clamp(
+    dragState.originX + (pointerX - dragState.startPointerX),
+    0,
+    1 - field.width,
+  );
+  field.y = clamp(
+    dragState.originY + (pointerY - dragState.startPointerY),
+    0,
+    1 - field.height,
+  );
+  markDirtyAndRender(true);
+}
+
+function handleResizeMove(event) {
+  if (!resizeState) return;
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === resizeState.fieldId;
+  });
+  if (!field) return;
+  const overlay = getOverlayForPage(field.pageIndex);
+  if (!overlay) return;
+  const rect = overlay.getBoundingClientRect();
+  const pointerX = (event.clientX - rect.left) / rect.width;
+  const pointerY = (event.clientY - rect.top) / rect.height;
+  const deltaX = pointerX - resizeState.startX;
+  const deltaY = pointerY - resizeState.startY;
+  let newX = resizeState.originX;
+  let newY = resizeState.originY;
+  let newWidth = resizeState.originWidth;
+  let newHeight = resizeState.originHeight;
+  const minSize = 0.01;
+
+  if (resizeState.handle.includes("e")) {
+    newWidth = resizeState.originWidth + deltaX;
+  }
+  if (resizeState.handle.includes("s")) {
+    newHeight = resizeState.originHeight + deltaY;
+  }
+  if (resizeState.handle.includes("w")) {
+    newWidth = resizeState.originWidth - deltaX;
+    newX = resizeState.originX + deltaX;
+  }
+  if (resizeState.handle.includes("n")) {
+    newHeight = resizeState.originHeight - deltaY;
+    newY = resizeState.originY + deltaY;
+  }
+
+  newWidth = Math.max(minSize, newWidth);
+  newHeight = Math.max(minSize, newHeight);
+  newX = clamp(newX, 0, 1 - newWidth);
+  newY = clamp(newY, 0, 1 - newHeight);
+
+  if (resizeState.handle.includes("w")) {
+    newWidth = Math.min(
+      newWidth,
+      resizeState.originX + resizeState.originWidth - newX,
+    );
+  }
+  if (resizeState.handle.includes("n")) {
+    newHeight = Math.min(
+      newHeight,
+      resizeState.originY + resizeState.originHeight - newY,
+    );
+  }
+
+  field.x = newX;
+  field.y = newY;
+  field.width = clamp(newWidth, minSize, 1 - field.x);
+  field.height = clamp(newHeight, minSize, 1 - field.y);
+  markDirtyAndRender(true);
+}
+
+function clearInteractionState() {
+  draftState = null;
+  dragState = null;
+  resizeState = null;
+  renderDraftRect();
+}
+
+function setupPageInteractions(overlay, pageIndex) {
+  overlay.addEventListener("pointerdown", function (event) {
+    if (event.button !== 0) return;
+    const rect = overlay.getBoundingClientRect();
+    const pointX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    const pointY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+
+    if (!state.selectedTool) {
+      if (event.target === overlay) {
+        selectField(null, { focusNameInput: false, scrollIntoView: false });
+      }
+      return;
+    }
+
+    if (event.target !== overlay) return;
+
+    if (POINT_INSERT_TYPES.has(state.selectedTool)) {
+      createPointField(pageIndex, pointX, pointY);
+      return;
+    }
+
+    draftState = {
+      pageIndex: pageIndex,
+      startX: pointX,
+      startY: pointY,
+      currentX: pointX,
+      currentY: pointY,
+    };
+    selectField(null, { focusNameInput: false, scrollIntoView: false });
+    renderDraftRect();
+  });
+}
+
+function createPageShell(pageIndex) {
+  const shell = document.createElement("div");
+  shell.className = "pdf-page-shell";
+  shell.dataset.pageIndex = String(pageIndex);
+
+  const label = document.createElement("div");
+  label.className = "pdf-page-label";
+  label.textContent = "Page " + (pageIndex + 1);
+  shell.appendChild(label);
+
+  const page = document.createElement("div");
+  page.className = "pdf-page";
+  page.dataset.pageIndex = String(pageIndex);
+  shell.appendChild(page);
+  return { shell: shell, page: page };
+}
+
+async function renderPages(options) {
+  const settings = options || {};
+  pdfPages.innerHTML = "";
+
+  for (let pageIndex = 0; pageIndex < state.pageCount; pageIndex += 1) {
+    const pageProxy = await state.pdfDoc.getPage(pageIndex + 1);
+    const viewport = pageProxy.getViewport({ scale: getViewerRenderScale() });
+    const pageShell = createPageShell(pageIndex);
+    pageShell.page.style.width = viewport.width + "px";
+    pageShell.page.style.height = viewport.height + "px";
+
+    const canvas = document.createElement("canvas");
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+    pageShell.page.appendChild(canvas);
+
+    const context = canvas.getContext("2d");
+    await pageProxy.render({
+      canvasContext: context,
+      viewport: viewport,
+      annotationMode: 0,
+    }).promise;
+
+    const overlay = document.createElement("div");
+    overlay.className = "page-overlay";
+    overlay.dataset.pageIndex = String(pageIndex);
+    pageShell.page.appendChild(overlay);
+    setupPageInteractions(overlay, pageIndex);
+
+    pdfPages.appendChild(pageShell.shell);
+  }
+
+  updateOverlayCursorState();
+  renderFieldsOnPages();
+  if (settings.anchor) {
+    restoreViewerAnchor(settings.anchor);
+  }
+  currentVisiblePageIndex = getCurrentVisiblePageIndex();
+}
+
+async function loadPdf(file) {
+  showLoading("Loading PDF...");
+  hideToasts();
+  clearInteractionState();
+  setSelectedTool(null);
+
+  try {
+    const arrayBuffer = await file.arrayBuffer();
+    syncPdfState(
+      arrayBufferToUint8Array(arrayBuffer),
+      file.name || "edited-form.pdf",
+      file,
+    );
+    updateDocumentName();
+    await refreshPdfDocumentFromState();
+    showLoading("Detecting fields with FormFyxer...");
+
+    const existingFields = await parseExistingFieldsLocally(
+      state.pdfBytes,
+      state.pageSizes,
+    );
+    const detectedFields = await detectExistingFieldsWithServer().catch(
+      function (_error) {
+        return existingFields;
+      },
+    );
+    replaceFields(detectedFields);
+    await inspectAccessibilityData(true).catch(function () {
+      state.accessibility.inspected = false;
+    });
+    setDirty(false);
+    updateAiUiState();
+    floatingToolPicker.classList.remove("hidden");
+    showPdfWorkspace();
+    showSuccess(
+      detectedFields.length
+        ? "Loaded " + detectedFields.length + " existing fields."
+        : "PDF loaded.",
+    );
+  } catch (error) {
+    console.error("Error loading PDF:", error);
+    hideLoading();
+
+    if (error && error.name === "PasswordException") {
+      tryAutoUnlock(file);
+      return;
+    }
+
+    showRepairPrompt(file, error);
+    return;
+  } finally {
+    hideLoading();
+  }
+}
+
+/**
+ * Attempt to unlock the PDF without a password via the server-side
+ * repair API.  If the blank-password unlock succeeds the repaired
+ * file is reloaded immediately.  Otherwise the password dialog is shown.
+ */
+async function tryAutoUnlock(file) {
+  showLoading("Trying to unlock PDF...");
+  try {
+    var formData = new FormData();
+    formData.append("file", file);
+    formData.append("action", "unlock");
+
+    var response = await fetch(apiUrl("/pdf-labeler/api/repair"), {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+    var result = await parseApiResponse(response);
+    if (result.success && result.data && result.data.pdf_base64) {
+      var binaryStr = atob(result.data.pdf_base64);
+      var bytes = new Uint8Array(binaryStr.length);
+      for (var i = 0; i < binaryStr.length; i++) {
+        bytes[i] = binaryStr.charCodeAt(i);
+      }
+      var unlockedFile = new File(
+        [bytes],
+        result.data.filename || state.fileName || "unlocked.pdf",
+        { type: "application/pdf" },
+      );
+      hideLoading();
+      showSuccess("PDF unlocked successfully.");
+      await loadPdf(unlockedFile);
+      return;
+    }
+  } catch (_err) {
+    // blank-password unlock failed — fall through to password dialog
+  }
+  hideLoading();
+  showPasswordDialog(file);
+}
+
+function showPasswordDialog(file) {
+  state._pendingPasswordFile = file;
+  passwordInput.value = "";
+  passwordError.classList.add("hidden");
+  passwordError.textContent = "";
+  passwordModal.classList.remove("hidden");
+  passwordInput.focus();
+}
+
+async function submitPassword() {
+  var file = state._pendingPasswordFile;
+  if (!file) return;
+  var pw = passwordInput.value;
+  if (!pw) {
+    passwordError.textContent = "Please enter a password.";
+    passwordError.classList.remove("hidden");
+    return;
+  }
+  passwordSubmitBtn.disabled = true;
+  passwordError.classList.add("hidden");
+  try {
+    var formData = new FormData();
+    formData.append("file", file);
+    formData.append("action", "unlock");
+    formData.append("password", pw);
+
+    var response = await fetch(apiUrl("/pdf-labeler/api/repair"), {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+    var result = await parseApiResponse(response);
+    if (!result.success) {
+      var errMsg =
+        (result.error && result.error.message) ||
+        "Incorrect password or unlock failed.";
+      throw new Error(errMsg);
+    }
+    var data = result.data || {};
+    if (!data.pdf_base64) throw new Error("No unlocked PDF was returned.");
+
+    var binaryStr = atob(data.pdf_base64);
+    var bytes = new Uint8Array(binaryStr.length);
+    for (var i = 0; i < binaryStr.length; i++) {
+      bytes[i] = binaryStr.charCodeAt(i);
+    }
+    var unlockedFile = new File(
+      [bytes],
+      data.filename || state.fileName || "unlocked.pdf",
+      { type: "application/pdf" },
+    );
+    passwordModal.classList.add("hidden");
+    state._pendingPasswordFile = null;
+    showSuccess("PDF unlocked successfully.");
+    await loadPdf(unlockedFile);
+  } catch (err) {
+    passwordError.textContent = err.message || "Failed to unlock PDF.";
+    passwordError.classList.remove("hidden");
+  } finally {
+    passwordSubmitBtn.disabled = false;
+  }
+}
+
+function showRepairPrompt(file, error) {
+  state._pendingRepairFile = file;
+  var msg = "This PDF could not be rendered.";
+  if (error && error.message) {
+    msg += " (" + error.message + ")";
+  }
+  msg += " Would you like to try repairing it?";
+  repairPromptMessage.textContent = msg;
+  pdfEmpty.classList.add("hidden");
+  repairPromptModal.classList.remove("hidden");
+}
+
+function deleteField(fieldId) {
+  state.fields = state.fields.filter(function (field) {
+    return field.id !== fieldId;
+  });
+  reconcileAccessibilityFieldOrder();
+  bumpFieldNamesVersion();
+  if (state.selectedFieldId === fieldId) {
+    state.selectedFieldId = state.fields[0] ? state.fields[0].id : null;
+  }
+  if (state.quickEditFieldId === fieldId) {
+    hideQuickFieldEditor();
+  }
+  setDirty(true);
+  renderFieldsList();
+  renderFieldsOnPages();
+  updateFieldCount();
+}
+
+function duplicateSelectedField() {
+  const field = getCurrentField();
+  if (!field) return;
+  const duplicate = {
+    id: generateId(),
+    name: ensureUniqueFieldName(field.name + "_copy", field.id),
+    type: field.type,
+    pageIndex: field.pageIndex,
+    x: clamp(field.x + 0.012, 0, 1 - field.width),
+    y: clamp(field.y + 0.012, 0, 1 - field.height),
+    width: field.width,
+    height: field.height,
+    font: field.font || getSessionDefault("font"),
+    fontSize: field.fontSize,
+    autoSize: field.autoSize !== false,
+    checkboxStyle: field.checkboxStyle,
+    checkboxExportValue: field.checkboxExportValue,
+    checkboxBorder: !!field.checkboxBorder,
+    checkboxBorderWidth: field.checkboxBorderWidth || "thin",
+    allowScroll: field.allowScroll !== false,
+    backgroundColor: field.backgroundColor,
+    options: Array.isArray(field.options) ? field.options.slice() : undefined,
+    tooltip:
+      String(field.tooltip || "").trim() ||
+      defaultTooltipFromFieldName(field.name),
+  };
+  state.fields.push(duplicate);
+  reconcileAccessibilityFieldOrder();
+  bumpFieldNamesVersion();
+  selectField(duplicate.id, { focusNameInput: false, scrollIntoView: false });
+  setDirty(true);
+  updateFieldCount();
+}
+
+function normalizeCurrentFieldName() {
+  const field = getCurrentField();
+  if (!field) return;
+  const normalized = ensureUniqueFieldName(field.name, field.id);
+  if (field.name === normalized) return;
+  field.name = normalized;
+  bumpFieldNamesVersion();
+  setDirty(true);
+  updateRenderedFieldName(field.id);
+  syncQuickFieldEditor();
+}
+
+function buildExportNameMap(options) {
+  const deduplicate = !!(options && options.deduplicate);
+  const exportNameMap = new Map();
+  const originalNames = state.fields.map(function (field) {
+    return field.name === null || field.name === undefined || field.name === ""
+      ? "field"
+      : String(field.name);
+  });
+  const reservedOriginalNames = new Set(originalNames);
+  const used = new Set();
+  const suffixByName = new Map();
+  state.fields.forEach(function (field, index) {
+    const base = originalNames[index];
+    let candidate = base;
+    if (deduplicate) {
+      let suffix = suffixByName.get(base) || 0;
+      while (used.has(candidate)) {
+        suffix += 1;
+        candidate = base + "__" + suffix;
+        while (reservedOriginalNames.has(candidate) || used.has(candidate)) {
+          suffix += 1;
+          candidate = base + "__" + suffix;
+        }
+      }
+      suffixByName.set(base, suffix);
+    }
+    used.add(candidate);
+    exportNameMap.set(field.id, candidate);
+  });
+  return exportNameMap;
+}
+
+function getRenamedFields(exportNameMap) {
+  const renames = [];
+  state.fields.forEach(function (field, index) {
+    const oldName =
+      field.name === null || field.name === undefined || field.name === ""
+        ? "field"
+        : String(field.name);
+    const newName = exportNameMap.get(field.id) || oldName;
+    if (newName !== oldName) {
+      renames.push({
+        index: index,
+        old_name: oldName,
+        new_name: newName,
+      });
+    }
+  });
+  return renames;
+}
+
+function showFieldRenameSummary(renames, contextText) {
+  if (!Array.isArray(renames) || renames.length === 0) return;
+  fieldRenameSummaryContext.textContent =
+    contextText || "The following exact duplicate field names were renamed.";
+  fieldRenameSummaryList.innerHTML = renames
+    .map(function (rename) {
+      return (
+        '<div class="border rounded p-2">' +
+        '<div class="small text-muted">Field ' +
+        String(Number(rename.index) + 1) +
+        "</div>" +
+        "<div><code>" +
+        escapeHtml(rename.old_name) +
+        "</code> &rarr; <code>" +
+        escapeHtml(rename.new_name) +
+        "</code></div>" +
+        "</div>"
+      );
+    })
+    .join("");
+  fieldRenameSummaryModal.classList.remove("hidden");
+}
+
+function buildUniqueExportNameMap() {
+  return buildExportNameMap({ deduplicate: true });
+}
+
+function convertFieldsToAbsoluteCoordinates(exportNameMap) {
+  const nameMap = exportNameMap || buildUniqueExportNameMap();
+  return state.fields.map(function (field) {
+    const pageSize = state.pageSizes[field.pageIndex];
+    const safeName =
+      nameMap.get(field.id) ||
+      (field.name === null || field.name === undefined || field.name === ""
+        ? "field"
+        : String(field.name));
+    return {
+      name: safeName,
+      type: field.type,
+      pageIndex: field.pageIndex,
+      x: field.x * pageSize.width,
+      y: (1 - field.y - field.height) * pageSize.height,
+      width: field.width * pageSize.width,
+      height: field.height * pageSize.height,
+      font: field.font || getSessionDefault("font"),
+      fontSize: field.fontSize,
+      autoSize: field.autoSize !== false,
+      checkboxStyle: field.checkboxStyle,
+      checkboxExportValue: field.checkboxExportValue,
+      checkboxBorder: !!field.checkboxBorder,
+      checkboxBorderWidth: field.checkboxBorderWidth || "thin",
+      allowScroll: field.allowScroll !== false,
+      backgroundColor: field.backgroundColor,
+      options: Array.isArray(field.options) ? field.options.slice() : undefined,
+      tooltip: String(field.tooltip || "").trim(),
+    };
+  });
+}
+
+async function applyNormalizationPass() {
+  if (!state.pdfBytes || state.fields.length === 0) {
+    showError("Load a PDF with fields before running normalization.");
+    return;
+  }
+  const settings = readNormalizationSettings();
+  normalizationModal.classList.add("hidden");
+  showLoading("Applying normalization pass...");
+  try {
+    await sleep(50);
+    const normalizedFields = buildNormalizedFields(settings);
+    replaceFields(normalizedFields, { preserveSelection: true });
+    setDirty(true);
+
+    if (settings.removeEmbeddedFonts && state.pdfBytes) {
+      showLoading("Removing embedded fonts...");
+      var formData = new FormData();
+      formData.append("file", getPdfFileForRequests());
+      var resp = await fetch(apiUrl("/pdf-labeler/api/strip-fonts"), {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: formData,
+      });
+      var data = await parseApiResponse(resp);
+      if (data.success && data.data && data.data.pdf_base64) {
+        var strippedBytes = base64ToUint8Array(data.data.pdf_base64);
+        syncPdfState(strippedBytes, state.fileName || "edited-form.pdf");
+        await refreshPdfDocumentFromState();
+        replaceFields(state.fields, { preserveSelection: true });
+      }
+    }
+
+    showPdfWorkspace();
+    showSuccess("Normalization pass applied.");
+  } catch (error) {
+    console.error("Error applying normalization pass:", error);
+    showPdfWorkspace();
+    showError(
+      "Normalization failed: " +
+        (error && error.message ? error.message : "Unknown error."),
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+async function autoDetectFields() {
+  if (!state.pdfBytes) return;
+  if (!state.auth.aiEnabled) {
+    showError("AI auto-detect requires login.");
+    return;
+  }
+
+  showLoading("Auto-detecting fields with AI...");
+  try {
+    const formData = new FormData();
+    formData.append("file", getPdfFileForRequests());
+    formData.append("normalize_fields", "true");
+    formData.append("model", state.model || state.defaultModel);
+
+    // Pass preferred variable names from Playground/installed interview
+    var effectiveVars = getEffectivePdfVariables();
+    if (state.usePlaygroundVariables && effectiveVars.length > 0) {
+      formData.append("use_playground_variables", "true");
+      formData.append(
+        "preferred_variable_names",
+        JSON.stringify(effectiveVars),
+      );
+      formData.append("interview_source_mode", state.interviewSourceMode);
+      if (state.interviewSourceMode === "playground") {
+        formData.append("playground_project", state.playground.selectedProject);
+        formData.append("playground_yaml_file", state.playground.selectedFile);
+      } else {
+        formData.append("installed_package", state.installed.selectedPackage);
+        formData.append("installed_yaml_file", state.installed.selectedFile);
+      }
+    }
+
+    const data = await requestAsyncLabelerAction(
+      "/pdf-labeler/api/auto-detect",
+      formData,
+      "Auto-detect is running in the background...",
+    );
+
+    applyReturnedPdfPayload(data, state.fileName || "edited-form.pdf");
+
+    const importedFields = Array.isArray(data && data.fields)
+      ? data.fields
+      : [];
+    let normalizedFields = [];
+    if (
+      importedFields.length &&
+      typeof importedFields[0] === "object" &&
+      importedFields[0] !== null &&
+      Object.prototype.hasOwnProperty.call(importedFields[0], "x")
+    ) {
+      normalizedFields = importedFields.map(function (field) {
+        const pageSize = state.pageSizes[field.pageIndex];
+        const fieldType = normalizeFieldType(field.type);
+        const width = pageSize
+          ? clamp(field.width / pageSize.width, 0.01, 1)
+          : 0.1;
+        const height = pageSize
+          ? clamp(field.height / pageSize.height, 0.01, 1)
+          : 0.03;
+        const x = pageSize ? clamp(field.x / pageSize.width, 0, 1 - width) : 0;
+        const y = pageSize
+          ? clamp(1 - (field.y + field.height) / pageSize.height, 0, 1 - height)
+          : 0;
         return {
-            left: left,
-            top: top,
-            right: Math.max(right, left + 1),
-            bottom: Math.max(bottom, top + 1)
+          id: generateId(),
+          name: ensureUniqueFieldName(
+            field.name || getDefaultFieldName(fieldType),
+            null,
+          ),
+          type: fieldType,
+          pageIndex: field.pageIndex,
+          x: x,
+          y: y,
+          width: width,
+          height: height,
+          font: field.font || getSessionDefault("font"),
+          fontSize: field.fontSize || getSessionDefault("fontSize"),
+          autoSize: field.autoSize !== false,
+          options: Array.isArray(field.options)
+            ? field.options.slice()
+            : undefined,
         };
+      });
+    } else {
+      normalizedFields = await detectExistingFieldsWithServer().catch(
+        function () {
+          return parseExistingFieldsLocally(state.pdfBytes, state.pageSizes);
+        },
+      );
     }
 
-    function getQuickFieldEditorWidth(_fieldEl, viewportRect) {
-        const nameLength = String(quickFieldNameInput.value || '').length;
-        const preferredWidth = Math.max(
-            260,
-            Math.min(720, 164 + (nameLength * 9))
+    replaceFields(normalizedFields);
+    setDirty(false);
+    showPdfWorkspace();
+    const detectedCount = normalizedFields.length;
+    showSuccess(
+      "Detected " +
+        detectedCount +
+        " field" +
+        (detectedCount === 1 ? "" : "s") +
+        ".",
+    );
+  } catch (error) {
+    console.error("Error auto-detecting:", error);
+    showPdfWorkspace();
+    showError(
+      "Auto-detection failed: " +
+        (error && error.message ? error.message : "Unknown error."),
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+async function relabelFields() {
+  if (!state.pdfBytes || state.fields.length === 0) return;
+  if (!state.auth.aiEnabled) {
+    showError("AI relabel requires login.");
+    return;
+  }
+  if (state.hasUnsavedChanges) {
+    const confirmed = window.confirm(
+      "AI relabel works on the PDF fields currently embedded in the document. Unsaved manual edits will be replaced. Continue?",
+    );
+    if (!confirmed) return;
+  }
+
+  showLoading("Relabeling fields with AI... this can take 2-3 minutes.");
+  try {
+    const formData = new FormData();
+    formData.append("file", getPdfFileForRequests());
+    formData.append("model", state.model || state.defaultModel);
+
+    const data = await requestAsyncLabelerAction(
+      "/pdf-labeler/api/relabel",
+      formData,
+      "AI relabel is running in the background (this can take 2-3 minutes)...",
+    );
+
+    const pdfWasUpdated = applyReturnedPdfPayload(
+      data,
+      state.fileName || "edited-form.pdf",
+    );
+    const detectedRelabeledFields =
+      await detectExistingFieldsWithServer().catch(function () {
+        return parseExistingFieldsLocally(state.pdfBytes, state.pageSizes);
+      });
+    const relabeledFields = reconcileRelabeledFields(
+      detectedRelabeledFields,
+      data,
+    );
+    logRelabelDebug(data, detectedRelabeledFields, relabeledFields);
+    replaceFields(relabeledFields);
+    setDirty(false);
+    showPdfWorkspace();
+    if (!pdfWasUpdated) {
+      throw new Error("AI relabel completed without returning an updated PDF.");
+    }
+    const renamedCount = getRelabelChangedCount(data);
+    if (renamedCount === 0) {
+      showError(
+        "AI relabel completed, but no field names changed. See the browser console for details.",
+        15000,
+      );
+      return;
+    }
+    showSuccess(
+      typeof renamedCount === "number"
+        ? "Relabeled " +
+            renamedCount +
+            " field" +
+            (renamedCount === 1 ? "" : "s") +
+            "."
+        : "Fields relabeled successfully.",
+      9000,
+    );
+  } catch (error) {
+    console.error("Error relabeling:", error);
+    showPdfWorkspace();
+    showError(
+      "Relabeling failed: " +
+        (error && error.message ? error.message : "Unknown error."),
+      15000,
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+async function exportPdf() {
+  if (!state.pdfBytes || state.fields.length === 0) {
+    showError("There are no fields to export.");
+    return;
+  }
+
+  const deduplicateFieldNames =
+    !exportDeduplicateFieldNamesInput ||
+    exportDeduplicateFieldNamesInput.checked;
+  const exportNameMap = buildExportNameMap({
+    deduplicate: deduplicateFieldNames,
+  });
+  const renamedFields = getRenamedFields(exportNameMap);
+
+  // A clean document already contains the exact PDF the user loaded. Sending
+  // it through FormFyxer would rebuild every widget, which can alter field
+  // appearance streams, checkbox geometry, and other PDF metadata even when
+  // the user made no edit. Keep a no-op export byte-for-byte non-destructive;
+  // duplicate names still go through the server so the export contract can
+  // enforce uniqueness when requested.
+  if (!state.hasUnsavedChanges && renamedFields.length === 0) {
+    const cleanFilename =
+      stripPdfExtension(state.fileName || "edited-form") + "-with-fields.pdf";
+    downloadBlob(
+      new Blob([state.pdfBytes], { type: "application/pdf" }),
+      cleanFilename,
+    );
+    showSuccess("PDF exported successfully.");
+    return;
+  }
+
+  showLoading("Exporting PDF...");
+  try {
+    const formData = new FormData();
+    formData.append("file", getPdfFileForRequests());
+    formData.append(
+      "fields",
+      JSON.stringify(convertFieldsToAbsoluteCoordinates(exportNameMap)),
+    );
+    formData.append(
+      "accessibility",
+      JSON.stringify(buildAccessibilityPayload(exportNameMap)),
+    );
+    formData.append(
+      "deduplicate_field_names",
+      deduplicateFieldNames ? "true" : "false",
+    );
+
+    const response = await fetch(apiUrl("/pdf-labeler/api/apply-fields"), {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+    const data = await parseApiResponse(response);
+    if (!data.success) {
+      throw new Error((data.error && data.error.message) || "Export failed.");
+    }
+
+    if (!data.data || !data.data.pdf_base64) {
+      throw new Error("The export endpoint did not return a PDF.");
+    }
+
+    const outputBytes = base64ToUint8Array(data.data.pdf_base64);
+    const filename =
+      data.data.filename ||
+      (state.fileName || "edited-form").replace(/\.pdf$/i, "") +
+        "-with-fields.pdf";
+
+    const blob = new Blob([outputBytes], { type: "application/pdf" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+
+    syncPdfState(outputBytes, filename);
+    updateDocumentName();
+    setDirty(false);
+    showPdfWorkspace();
+    showSuccess("PDF exported successfully.");
+    showFieldRenameSummary(
+      renamedFields,
+      "The exported PDF contains these renamed exact duplicate fields.",
+    );
+  } catch (error) {
+    console.error("Error exporting:", error);
+    showPdfWorkspace();
+    showError(
+      "Export failed: " +
+        (error && error.message ? error.message : "Unknown error."),
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+function createPageManagerDraftPage(sourceId, sourcePageIndex) {
+  return {
+    id: "page-" + generateId(),
+    sourceId: sourceId,
+    sourcePageIndex: Number(sourcePageIndex) || 0,
+    splitBefore: false,
+  };
+}
+
+function getPageManagerSource(sourceId) {
+  if (!pageManagerState || !pageManagerState.sources) return null;
+  return pageManagerState.sources[sourceId] || null;
+}
+
+function setPageManagerStatus(message, tone) {
+  if (!message) {
+    pageManagerStatus.className = "hidden alert small mb-3";
+    pageManagerStatus.textContent = "";
+    return;
+  }
+  const level = tone || "info";
+  pageManagerStatus.className = "alert alert-" + level + " small mb-3";
+  pageManagerStatus.textContent = message;
+  pageManagerStatus.classList.remove("hidden");
+}
+
+function hasPageManagerStructuralChanges() {
+  if (!pageManagerState) return false;
+  if (pageManagerState.draftPages.length !== state.pageCount) {
+    return true;
+  }
+  return pageManagerState.draftPages.some(function (page, index) {
+    return page.sourceId !== "active" || page.sourcePageIndex !== index;
+  });
+}
+
+function getPageManagerSplitGroups() {
+  if (!pageManagerState || !pageManagerState.draftPages.length) return [];
+  const groups = [];
+  let currentGroup = [];
+  pageManagerState.draftPages.forEach(function (page, index) {
+    if (index > 0 && page.splitBefore && currentGroup.length) {
+      groups.push(currentGroup);
+      currentGroup = [];
+    }
+    currentGroup.push(page);
+  });
+  if (currentGroup.length) {
+    groups.push(currentGroup);
+  }
+  return groups;
+}
+
+function syncPageManagerInsertPositionOptions() {
+  if (!pageManagerState) return;
+  const previousValue = pageManagerInsertPosition.value;
+  pageManagerInsertPosition.innerHTML = "";
+  const totalPages = pageManagerState.draftPages.length;
+  if (!totalPages) {
+    const option = document.createElement("option");
+    option.value = "0";
+    option.textContent = "At beginning";
+    pageManagerInsertPosition.appendChild(option);
+    return;
+  }
+  for (let index = 0; index <= totalPages; index += 1) {
+    const option = document.createElement("option");
+    option.value = String(index);
+    if (index === 0) {
+      option.textContent = "Before page 1";
+    } else if (index === totalPages) {
+      option.textContent = "After page " + totalPages;
+    } else {
+      option.textContent = "Between pages " + index + " and " + (index + 1);
+    }
+    pageManagerInsertPosition.appendChild(option);
+  }
+  if (
+    Array.from(pageManagerInsertPosition.options).some(function (option) {
+      return option.value === previousValue;
+    })
+  ) {
+    pageManagerInsertPosition.value = previousValue;
+  } else {
+    pageManagerInsertPosition.value = String(totalPages);
+  }
+}
+
+function renderPageManagerSummary() {
+  if (!pageManagerState) return;
+  const totalPages = pageManagerState.draftPages.length;
+  const insertedCount = pageManagerState.draftPages.filter(function (page) {
+    return page.sourceId !== "active";
+  }).length;
+  const splitCount = Math.max(getPageManagerSplitGroups().length - 1, 0);
+  const parts = [totalPages + " page" + (totalPages === 1 ? "" : "s")];
+  if (insertedCount) {
+    parts.push(insertedCount + " inserted");
+  }
+  if (splitCount) {
+    parts.push(splitCount + " split point" + (splitCount === 1 ? "" : "s"));
+  }
+  pageManagerSummary.textContent = parts.join(" • ");
+}
+
+function updatePageManagerControls() {
+  if (!pageManagerState) return;
+  const insertSource = getPageManagerSource(pageManagerState.insertSourceId);
+  const selectedInsertCount =
+    insertSource && pageManagerState.insertSelections
+      ? pageManagerState.insertSelections.size
+      : 0;
+  if (!insertSource) {
+    pageManagerInsertSelectionSummary.textContent = "No insert PDF loaded.";
+  } else if (!selectedInsertCount) {
+    pageManagerInsertSelectionSummary.textContent =
+      insertSource.name + " loaded. Select page cards to insert.";
+  } else {
+    pageManagerInsertSelectionSummary.textContent =
+      selectedInsertCount +
+      " page" +
+      (selectedInsertCount === 1 ? "" : "s") +
+      " selected from " +
+      insertSource.name +
+      ".";
+  }
+  pageManagerInsertRunBtn.disabled = !insertSource || selectedInsertCount === 0;
+  pageManagerApplyBtn.disabled =
+    !pageManagerState.draftPages.length || !hasPageManagerStructuralChanges();
+  pageManagerDownloadSplitsBtn.disabled =
+    getPageManagerSplitGroups().length < 2;
+  renderPageManagerSummary();
+  syncPageManagerInsertPositionOptions();
+}
+
+async function ensurePageManagerThumbnail(source, pageIndex) {
+  if (!source) return "";
+  if (!source.thumbCache) {
+    source.thumbCache = {};
+  }
+  if (source.thumbCache[pageIndex]) {
+    return source.thumbCache[pageIndex];
+  }
+  const page = await source.pdfDoc.getPage(pageIndex + 1);
+  const viewport = page.getViewport({ scale: 0.23 });
+  const canvas = document.createElement("canvas");
+  canvas.width = viewport.width;
+  canvas.height = viewport.height;
+  await page.render({
+    canvasContext: canvas.getContext("2d"),
+    viewport: viewport,
+    annotationMode: 0,
+  }).promise;
+  source.thumbCache[pageIndex] = canvas.toDataURL("image/png");
+  return source.thumbCache[pageIndex];
+}
+
+async function hydratePageManagerThumb(thumbEl, sourceId, pageIndex) {
+  const source = getPageManagerSource(sourceId);
+  if (!thumbEl || !source || !source.pdfDoc) return;
+  thumbEl.innerHTML =
+    '<div class="page-manager-thumb-placeholder">Rendering preview…</div>';
+  try {
+    const imageUrl = await ensurePageManagerThumbnail(source, pageIndex);
+    if (!thumbEl.isConnected) return;
+    const image = document.createElement("img");
+    image.src = imageUrl;
+    image.alt = "Page preview";
+    thumbEl.innerHTML = "";
+    thumbEl.appendChild(image);
+  } catch (_error) {
+    if (!thumbEl.isConnected) return;
+    thumbEl.innerHTML =
+      '<div class="page-manager-thumb-placeholder">Preview unavailable</div>';
+  }
+}
+
+function clearPageManagerDropTargets() {
+  pageManagerPages
+    .querySelectorAll(".page-manager-page.drop-target")
+    .forEach(function (card) {
+      card.classList.remove("drop-target");
+    });
+  pageManagerDropzone.classList.remove("drop-target");
+}
+
+function movePageManagerDraftPage(pageId, nextIndex) {
+  if (!pageManagerState) return;
+  const currentIndex = pageManagerState.draftPages.findIndex(function (page) {
+    return page.id === pageId;
+  });
+  if (currentIndex < 0) return;
+  const boundedIndex = clamp(nextIndex, 0, pageManagerState.draftPages.length);
+  if (currentIndex === boundedIndex) return;
+  const movedPage = pageManagerState.draftPages.splice(currentIndex, 1)[0];
+  const adjustedIndex =
+    boundedIndex > currentIndex ? boundedIndex - 1 : boundedIndex;
+  pageManagerState.draftPages.splice(adjustedIndex, 0, movedPage);
+  renderPageManagerPages();
+}
+
+function renderPageManagerPages() {
+  if (!pageManagerState) return;
+  pageManagerPages.innerHTML = "";
+  pageManagerState.draftPages.forEach(function (page, index) {
+    const source = getPageManagerSource(page.sourceId);
+    const card = document.createElement("div");
+    card.className = "page-manager-page";
+    card.draggable = true;
+    card.dataset.pageId = page.id;
+
+    const header = document.createElement("div");
+    header.className = "page-manager-page-header";
+    header.innerHTML =
+      "<div>" +
+      '<div class="page-manager-page-title">Page ' +
+      (index + 1) +
+      "</div>" +
+      '<div class="page-manager-page-subtitle">Source page ' +
+      (page.sourcePageIndex + 1) +
+      "</div>" +
+      "</div>" +
+      '<span class="page-manager-source-badge">' +
+      escapeHtml(
+        source && source.kind === "active" ? "Active PDF" : "Inserted PDF",
+      ) +
+      "</span>";
+    card.appendChild(header);
+
+    const thumb = document.createElement("div");
+    thumb.className = "page-manager-thumb";
+    thumb.innerHTML =
+      '<div class="page-manager-thumb-placeholder">Rendering preview…</div>';
+    card.appendChild(thumb);
+    void hydratePageManagerThumb(thumb, page.sourceId, page.sourcePageIndex);
+
+    const actions = document.createElement("div");
+    actions.className = "page-manager-page-actions";
+    actions.innerHTML =
+      '<div class="form-check mb-0">' +
+      '<input class="form-check-input page-manager-split-toggle"' +
+      (index === 0 ? " disabled" : "") +
+      ' type="checkbox" data-page-id="' +
+      escapeHtml(page.id) +
+      '"' +
+      (page.splitBefore ? " checked" : "") +
+      ' id="page-manager-split-' +
+      escapeHtml(page.id) +
+      '">' +
+      '<label class="form-check-label small" for="page-manager-split-' +
+      escapeHtml(page.id) +
+      '">Start new document here</label>' +
+      "</div>" +
+      '<button type="button" class="btn btn-outline-danger btn-sm" data-page-manager-action="remove" data-page-id="' +
+      escapeHtml(page.id) +
+      '">Remove</button>';
+    card.appendChild(actions);
+
+    pageManagerPages.appendChild(card);
+  });
+  updatePageManagerControls();
+}
+
+function renderPageManagerInsertPages() {
+  pageManagerInsertPages.innerHTML = "";
+  if (!pageManagerState) return;
+  const insertSource = getPageManagerSource(pageManagerState.insertSourceId);
+  if (!insertSource) {
+    updatePageManagerControls();
+    return;
+  }
+  for (
+    let pageIndex = 0;
+    pageIndex < insertSource.pdfDoc.numPages;
+    pageIndex += 1
+  ) {
+    const selected = pageManagerState.insertSelections.has(pageIndex);
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className =
+      "insert-page-card text-start" + (selected ? " selected" : "");
+    card.dataset.insertPageIndex = String(pageIndex);
+    card.innerHTML =
+      '<div class="d-flex justify-content-between align-items-center gap-2 mb-2">' +
+      '<div class="small fw-semibold">Page ' +
+      (pageIndex + 1) +
+      "</div>" +
+      '<input type="checkbox" class="form-check-input m-0" tabindex="-1"' +
+      (selected ? " checked" : "") +
+      ">" +
+      "</div>";
+    const thumb = document.createElement("div");
+    thumb.className = "page-manager-thumb mb-0";
+    thumb.innerHTML =
+      '<div class="page-manager-thumb-placeholder">Rendering preview…</div>';
+    card.appendChild(thumb);
+    void hydratePageManagerThumb(thumb, insertSource.id, pageIndex);
+    pageManagerInsertPages.appendChild(card);
+  }
+  updatePageManagerControls();
+}
+
+function renderPageManager() {
+  renderPageManagerPages();
+  renderPageManagerInsertPages();
+  updatePageManagerControls();
+}
+
+function buildFreshPageManagerState() {
+  return {
+    sources: {
+      active: {
+        id: "active",
+        kind: "active",
+        name: state.fileName || "active.pdf",
+        bytes: clonePdfBytes(state.pdfBytes),
+        pdfDoc: state.pdfDoc,
+        thumbCache: {},
+      },
+    },
+    draftPages: Array.from(
+      { length: state.pageCount },
+      function (_unused, index) {
+        return createPageManagerDraftPage("active", index);
+      },
+    ),
+    insertSourceId: null,
+    insertSelections: new Set(),
+  };
+}
+
+function openPageManager() {
+  if (!state.pdfBytes || !state.pdfDoc) return;
+  pageManagerState = buildFreshPageManagerState();
+  pageManagerInsertFileInput.value = "";
+  pageManagerInsertFileName.textContent = "";
+  pageManagerDragPageId = null;
+  setPageManagerStatus("", "info");
+  renderPageManager();
+  pageManagerModal.classList.remove("hidden");
+}
+
+function closePageManager() {
+  pageManagerModal.classList.add("hidden");
+  pageManagerState = null;
+  pageManagerDragPageId = null;
+  setPageManagerStatus("", "info");
+}
+
+async function loadPageManagerInsertSource(file) {
+  if (!pageManagerState || !file) return;
+  setPageManagerStatus("Loading insert PDF...", "info");
+  try {
+    const bytes = clonePdfBytes(
+      arrayBufferToUint8Array(await file.arrayBuffer()),
+    );
+    const pdfDoc = await pdfjsLib.getDocument({ data: clonePdfBytes(bytes) })
+      .promise;
+    const sourceId = "insert-" + Date.now();
+    pageManagerState.sources[sourceId] = {
+      id: sourceId,
+      kind: "insert",
+      name: file.name || "insert.pdf",
+      bytes: bytes,
+      pdfDoc: pdfDoc,
+      thumbCache: {},
+    };
+    pageManagerState.insertSourceId = sourceId;
+    pageManagerState.insertSelections = new Set();
+    pageManagerInsertFileName.textContent = file.name || "insert.pdf";
+    renderPageManagerInsertPages();
+    setPageManagerStatus("Insert PDF loaded.", "success");
+  } catch (error) {
+    console.error("Error loading insert PDF:", error);
+    setPageManagerStatus(
+      "Could not load insert PDF: " +
+        (error && error.message ? error.message : "Unknown error."),
+      "danger",
+    );
+  }
+}
+
+function togglePageManagerInsertSelection(pageIndex) {
+  if (!pageManagerState) return;
+  if (pageManagerState.insertSelections.has(pageIndex)) {
+    pageManagerState.insertSelections.delete(pageIndex);
+  } else {
+    pageManagerState.insertSelections.add(pageIndex);
+  }
+  renderPageManagerInsertPages();
+}
+
+function insertSelectedPagesIntoManager() {
+  if (!pageManagerState) return;
+  const source = getPageManagerSource(pageManagerState.insertSourceId);
+  const selectedPages = Array.from(pageManagerState.insertSelections).sort(
+    function (left, right) {
+      return left - right;
+    },
+  );
+  if (!source || !selectedPages.length) return;
+  const insertAt = clamp(
+    Number(
+      pageManagerInsertPosition.value || pageManagerState.draftPages.length,
+    ),
+    0,
+    pageManagerState.draftPages.length,
+  );
+  const draftPages = selectedPages.map(function (pageIndex) {
+    return createPageManagerDraftPage(source.id, pageIndex);
+  });
+  pageManagerState.draftPages.splice(insertAt, 0, ...draftPages);
+  pageManagerState.insertSelections = new Set();
+  renderPageManager();
+  setPageManagerStatus(
+    "Inserted " +
+      selectedPages.length +
+      " page" +
+      (selectedPages.length === 1 ? "" : "s") +
+      ".",
+    "success",
+  );
+}
+
+async function buildPdfBytesFromPageDescriptors(pages) {
+  if (!PDFLibGlobal.PDFDocument) {
+    throw new Error("Page management requires pdf-lib in the browser.");
+  }
+  const outputDoc = await PDFLibGlobal.PDFDocument.create();
+  const sourceDocs = {};
+  for (const page of pages) {
+    const source = getPageManagerSource(page.sourceId);
+    if (!source || !source.bytes) {
+      throw new Error("A source PDF is missing for one or more pages.");
+    }
+    if (!sourceDocs[source.id]) {
+      sourceDocs[source.id] = await PDFLibGlobal.PDFDocument.load(
+        clonePdfBytes(source.bytes),
+      );
+    }
+    const copiedPages = await outputDoc.copyPages(sourceDocs[source.id], [
+      page.sourcePageIndex,
+    ]);
+    outputDoc.addPage(copiedPages[0]);
+  }
+  return new Uint8Array(await outputDoc.save());
+}
+
+function remapFieldsForPageManagerDraft() {
+  const fieldsByPageIndex = new Map();
+  state.fields.forEach(function (field) {
+    if (!fieldsByPageIndex.has(field.pageIndex)) {
+      fieldsByPageIndex.set(field.pageIndex, []);
+    }
+    fieldsByPageIndex.get(field.pageIndex).push(field);
+  });
+
+  const nextFields = [];
+  pageManagerState.draftPages.forEach(function (page, newPageIndex) {
+    if (page.sourceId !== "active") return;
+    const sourceFields = fieldsByPageIndex.get(page.sourcePageIndex) || [];
+    sourceFields.forEach(function (field) {
+      nextFields.push(Object.assign({}, field, { pageIndex: newPageIndex }));
+    });
+  });
+  return nextFields;
+}
+
+async function applyPageManagerChanges() {
+  if (!pageManagerState || !pageManagerState.draftPages.length) {
+    setPageManagerStatus("Keep at least one page in the document.", "danger");
+    return;
+  }
+  showLoading("Applying page changes...");
+  try {
+    const nextPdfBytes = await buildPdfBytesFromPageDescriptors(
+      pageManagerState.draftPages,
+    );
+    const nextFields = remapFieldsForPageManagerDraft();
+    syncPdfState(nextPdfBytes, state.fileName || "edited-form.pdf");
+    updateDocumentName();
+    await refreshPdfDocumentFromState();
+    replaceFields(nextFields, { preserveSelection: true });
+    setDirty(true);
+    closePageManager();
+    showPdfWorkspace();
+    showSuccess("Page changes applied to the workspace.");
+  } catch (error) {
+    console.error("Error applying page changes:", error);
+    setPageManagerStatus(
+      "Could not apply page changes: " +
+        (error && error.message ? error.message : "Unknown error."),
+      "danger",
+    );
+  } finally {
+    hideLoading();
+  }
+}
+
+async function downloadSplitDocumentsFromManager() {
+  if (!pageManagerState) return;
+  const groups = getPageManagerSplitGroups();
+  if (groups.length < 2) {
+    setPageManagerStatus(
+      "Add at least one split point before downloading multiple documents.",
+      "warning",
+    );
+    return;
+  }
+  if (state.fields.length > 0 && state.hasUnsavedChanges) {
+    const confirmed = window.confirm(
+      "Split downloads use the current PDF pages only. Unsaved field overlay edits will not be embedded. Continue?",
+    );
+    if (!confirmed) return;
+  }
+  showLoading("Preparing split PDFs...");
+  try {
+    const baseName = sanitizeFilenameSegment(
+      stripPdfExtension(state.fileName || "document"),
+      "document",
+    );
+    const outputs = [];
+    for (let index = 0; index < groups.length; index += 1) {
+      const bytes = await buildPdfBytesFromPageDescriptors(groups[index]);
+      outputs.push({
+        name: baseName + "-part-" + String(index + 1).padStart(2, "0") + ".pdf",
+        bytes: bytes,
+      });
+    }
+    if (JSZipGlobal) {
+      const zip = new JSZipGlobal();
+      outputs.forEach(function (output) {
+        zip.file(output.name, output.bytes);
+      });
+      const zipBlob = await zip.generateAsync({ type: "blob" });
+      downloadBlob(zipBlob, baseName + "-split-pdfs.zip");
+    } else {
+      outputs.forEach(function (output) {
+        downloadBlob(
+          new Blob([output.bytes], { type: "application/pdf" }),
+          output.name,
         );
-        return clamp(preferredWidth, 260, viewportRect.right - viewportRect.left);
+      });
     }
+    setPageManagerStatus(
+      "Downloaded " +
+        outputs.length +
+        " split PDF" +
+        (outputs.length === 1 ? "" : "s") +
+        ".",
+      "success",
+    );
+    showSuccess("Split PDFs downloaded.");
+  } catch (error) {
+    console.error("Error downloading split PDFs:", error);
+    setPageManagerStatus(
+      "Could not split the PDF: " +
+        (error && error.message ? error.message : "Unknown error."),
+      "danger",
+    );
+  } finally {
+    hideLoading();
+  }
+}
 
-    function positionQuickFieldEditor() {
-        if (quickFieldEditor.classList.contains('hidden')) return;
-        const field = getQuickEditField();
-        if (!field) {
-            hideQuickFieldEditor();
-            return;
-        }
-        const fieldEl = document.querySelector('.field-box[data-field-id="' + field.id + '"]');
-        const viewportRect = getVisiblePdfViewportRect();
-        const editorWidth = getQuickFieldEditorWidth(fieldEl, viewportRect);
-        quickFieldEditor.style.width = Math.round(editorWidth) + 'px';
-        const editorRect = quickFieldEditor.getBoundingClientRect();
-        const margin = 12;
-        let top = viewportRect.top + margin;
-        let left = viewportRect.left + margin;
+document.addEventListener("pointermove", function (event) {
+  if (draftState) {
+    const overlay = getOverlayForPage(draftState.pageIndex);
+    if (!overlay) return;
+    const rect = overlay.getBoundingClientRect();
+    draftState.currentX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    draftState.currentY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+    renderDraftRect();
+    return;
+  }
+  if (dragState) {
+    handleDragMove(event);
+    return;
+  }
+  if (resizeState) {
+    handleResizeMove(event);
+  }
+});
 
-        if (fieldEl) {
-            const fieldRect = fieldEl.getBoundingClientRect();
-            const fieldVisible = fieldRect.bottom > viewportRect.top &&
-                fieldRect.top < viewportRect.bottom &&
-                fieldRect.right > viewportRect.left &&
-                fieldRect.left < viewportRect.right;
-            const preferredTop = fieldVisible
-                ? fieldRect.top - 2
-                : ((fieldRect.top + fieldRect.bottom) / 2) - (editorRect.height / 2);
-            const alignedLeft = clamp(fieldRect.left, viewportRect.left, viewportRect.right - editorRect.width);
-
-            top = clamp(preferredTop, viewportRect.top, viewportRect.bottom - editorRect.height);
-            if (fieldVisible) {
-                left = alignedLeft;
-            } else {
-                left = alignedLeft;
-            }
-        }
-
-        quickFieldEditor.style.top = Math.round(top) + 'px';
-        quickFieldEditor.style.left = Math.round(left) + 'px';
+document.addEventListener("pointerup", function () {
+  if (draftState && state.selectedTool) {
+    const width = Math.abs(draftState.currentX - draftState.startX);
+    const height = Math.abs(draftState.currentY - draftState.startY);
+    if (width >= 0.01 && height >= 0.01) {
+      createFieldFromTool(
+        draftState.pageIndex,
+        Math.min(draftState.startX, draftState.currentX),
+        Math.min(draftState.startY, draftState.currentY),
+        width,
+        height,
+      );
     }
+  }
+  clearInteractionState();
+});
 
-    function updateRenderedFieldName(fieldId) {
-        const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        const fieldEl = document.querySelector('.field-box[data-field-id="' + field.id + '"]');
-        if (fieldEl) {
-            const chip = fieldEl.querySelector('.field-chip');
-            const chipName = chip && chip.querySelector('.field-chip-name');
-            if (chipName) {
-                chipName.textContent = field.name || '';
-            }
-            if (chip) {
-                applyFieldChipLayout(fieldEl, chip);
-            }
-        }
-        const listItem = fieldsList.querySelector('.field-list-item[data-field-id="' + field.id + '"]');
-        if (listItem) {
-            const title = listItem.querySelector('.field-list-name');
-            if (title && !title.classList.contains('field-list-name-preview')) {
-                title.textContent = field.name || '';
-            }
-            const sidebarInput = listItem.querySelector('[data-action="field-name"]');
-            if (sidebarInput && document.activeElement !== sidebarInput) {
-                sidebarInput.value = field.name || '';
-            }
-            const help = listItem.querySelector('.field-card-help');
-            if (help) {
-                const nameHelp = getFieldNameHelp(field);
-                help.className = 'field-card-help ' + nameHelp.level;
-                help.innerHTML = nameHelp.html;
-            }
-        }
+fileInput.addEventListener("change", function (event) {
+  const file = event.target.files && event.target.files[0];
+  if (file) {
+    loadPdf(file);
+  }
+  fileInput.value = "";
+});
+
+pdfZoomOutBtn.addEventListener("click", function () {
+  void updateViewerZoom(state.viewerZoom - 0.15);
+});
+pdfZoomInBtn.addEventListener("click", function () {
+  void updateViewerZoom(state.viewerZoom + 0.15);
+});
+pdfZoomResetBtn.addEventListener("click", function () {
+  void updateViewerZoom(1);
+});
+
+pdfContainer.addEventListener("dragover", function (event) {
+  event.preventDefault();
+  pdfContainer.classList.add("drag-over");
+});
+
+pdfContainer.addEventListener("dragleave", function () {
+  pdfContainer.classList.remove("drag-over");
+});
+
+pdfContainer.addEventListener("drop", function (event) {
+  event.preventDefault();
+  pdfContainer.classList.remove("drag-over");
+  const file = event.dataTransfer.files && event.dataTransfer.files[0];
+  if (file && file.type === "application/pdf") {
+    loadPdf(file);
+  }
+});
+pdfContainer.addEventListener("scroll", function () {
+  currentVisiblePageIndex = getCurrentVisiblePageIndex();
+  positionQuickFieldEditor();
+});
+pdfContainer.addEventListener(
+  "wheel",
+  function (event) {
+    if (!state.pdfBytes || !(event.ctrlKey || event.metaKey)) return;
+    if (event.cancelable) {
+      event.preventDefault();
     }
+    void updateViewerZoom(state.viewerZoom + (event.deltaY < 0 ? 0.1 : -0.1));
+  },
+  { passive: false },
+);
+fieldsList.addEventListener("scroll", function () {
+  if (fieldsListProgrammaticScroll) return;
+});
+fieldSearchInput.addEventListener("input", function () {
+  state.fieldSearch = fieldSearchInput.value || "";
+  refreshFieldsListFromControls();
+});
+fieldTypeFilterInput.addEventListener("change", function () {
+  state.fieldTypeFilter = fieldTypeFilterInput.value || "";
+  refreshFieldsListFromControls();
+});
+fieldSortInput.addEventListener("change", function () {
+  state.fieldSort = fieldSortInput.value || "position";
+  refreshFieldsListFromControls();
+});
+fieldsModeInputs.forEach(function (input) {
+  input.addEventListener("change", function () {
+    setFieldsPanelMode(input.value);
+  });
+});
+bulkRenameTypeInput.addEventListener("change", function () {
+  state.bulkRenameType =
+    bulkRenameTypeInput.value === "regex" ? "regex" : "pattern";
+  invalidateBulkRenamePreview();
+  refreshFieldsListFromControls();
+});
+bulkRenamePatternInput.addEventListener("input", function () {
+  state.bulkRenamePattern = bulkRenamePatternInput.value || "";
+  invalidateBulkRenamePreview();
+  refreshFieldsListFromControls();
+});
+bulkRenameReplacementInput.addEventListener("input", function () {
+  state.bulkRenameReplacement = bulkRenameReplacementInput.value || "";
+  invalidateBulkRenamePreview();
+  refreshFieldsListFromControls();
+});
+bulkRenameApplyBtn.addEventListener("click", applyBulkRename);
+window.addEventListener("resize", function () {
+  currentVisiblePageIndex = getCurrentVisiblePageIndex();
+  positionQuickFieldEditor();
+});
 
-    function commitFieldNameChange(fieldId, nextValue, source) {
-        const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        if (field.name === nextValue) return;
-        const previousName = String(field.name || '');
-        const previousDefaultTooltip = defaultTooltipFromFieldName(previousName);
-        field.name = nextValue;
-        const currentTooltip = String(field.tooltip || '').trim();
-        if (!currentTooltip || currentTooltip === previousDefaultTooltip) {
-            field.tooltip = defaultTooltipFromFieldName(nextValue);
-        }
-        bumpFieldNamesVersion();
-        reconcileAccessibilityFieldOrder();
-        setDirty(true);
-        if (state.fieldsPanelMode === 'rename') {
-            renderFieldsList();
-        }
-        updateRenderedFieldName(fieldId);
-        if (source !== 'quick') {
-            const quickField = getQuickEditField();
-            if (quickField && quickField.id === fieldId && document.activeElement !== quickFieldNameInput) {
-                quickFieldNameInput.value = field.name || '';
-            }
-        }
-        syncQuickFieldEditor({ preserveInput: source === 'quick' });
-        updateDuplicateFieldWarning();
+Object.keys(toolButtons).forEach(function (tool) {
+  toolButtons[tool].addEventListener("click", function () {
+    setSelectedTool(state.selectedTool === tool ? null : tool);
+    if (state.selectedTool) {
+      selectField(null, { focusNameInput: false, scrollIntoView: false });
     }
+  });
+});
 
-    function syncQuickFieldEditor(options) {
-        const settings = options || {};
-        const field = getQuickEditField();
-        if (!field || field.id !== state.selectedFieldId) {
-            hideQuickFieldEditor();
-            return;
+normalizePassBtn.addEventListener("click", function () {
+  if (!state.pdfBytes || state.fields.length === 0) return;
+  // Pre-populate normalization modal with session defaults
+  var sessionDefs = _loadSessionDefaults();
+  document.getElementById("norm-font-name").value =
+    sessionDefs.font || "Helvetica";
+  document.getElementById("norm-font-size").value = String(
+    sessionDefs.fontSize || 10,
+  );
+  document.getElementById("norm-checkbox-style").value =
+    sessionDefs.checkboxStyle || "cross";
+  normalizationModal.classList.remove("hidden");
+});
+repairBtn.addEventListener("click", function () {
+  if (!state.pdfBytes) return;
+  repairStatus.classList.add("hidden");
+  repairModal.querySelectorAll(".repair-run-btn").forEach(function (btn) {
+    btn.disabled = false;
+  });
+  repairModal.classList.remove("hidden");
+});
+managePagesBtn.addEventListener("click", function () {
+  openPageManager();
+});
+closePageManagerBtn.addEventListener("click", function () {
+  closePageManager();
+});
+pageManagerResetBtn.addEventListener("click", function () {
+  if (!state.pdfBytes) return;
+  pageManagerState = buildFreshPageManagerState();
+  pageManagerInsertFileInput.value = "";
+  pageManagerInsertFileName.textContent = "";
+  setPageManagerStatus("Page arrangement reset to the active PDF.", "info");
+  renderPageManager();
+});
+pageManagerInsertFileInput.addEventListener("change", function (event) {
+  const file = event.target.files && event.target.files[0];
+  if (file) {
+    void loadPageManagerInsertSource(file);
+  }
+  pageManagerInsertFileInput.value = "";
+});
+pageManagerInsertRunBtn.addEventListener("click", function () {
+  insertSelectedPagesIntoManager();
+});
+pageManagerApplyBtn.addEventListener("click", function () {
+  void applyPageManagerChanges();
+});
+pageManagerDownloadSplitsBtn.addEventListener("click", function () {
+  void downloadSplitDocumentsFromManager();
+});
+pageManagerInsertPages.addEventListener("click", function (event) {
+  const card = event.target.closest("[data-insert-page-index]");
+  if (!card || !pageManagerState) return;
+  togglePageManagerInsertSelection(Number(card.dataset.insertPageIndex || 0));
+});
+pageManagerPages.addEventListener("click", function (event) {
+  const removeBtn = event.target.closest(
+    '[data-page-manager-action="remove"][data-page-id]',
+  );
+  if (!removeBtn || !pageManagerState) return;
+  if (pageManagerState.draftPages.length <= 1) {
+    setPageManagerStatus(
+      "The document must keep at least one page.",
+      "warning",
+    );
+    return;
+  }
+  const pageId = removeBtn.dataset.pageId;
+  pageManagerState.draftPages = pageManagerState.draftPages.filter(
+    function (page) {
+      return page.id !== pageId;
+    },
+  );
+  renderPageManagerPages();
+});
+pageManagerPages.addEventListener("change", function (event) {
+  const toggle = event.target.closest(
+    ".page-manager-split-toggle[data-page-id]",
+  );
+  if (!toggle || !pageManagerState) return;
+  const page = pageManagerState.draftPages.find(function (candidate) {
+    return candidate.id === toggle.dataset.pageId;
+  });
+  if (!page) return;
+  page.splitBefore = !!toggle.checked;
+  updatePageManagerControls();
+});
+pageManagerPages.addEventListener("dragstart", function (event) {
+  const card = event.target.closest(".page-manager-page[data-page-id]");
+  if (!card || !pageManagerState) return;
+  pageManagerDragPageId = card.dataset.pageId;
+  card.classList.add("dragging");
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+  }
+});
+pageManagerPages.addEventListener("dragend", function () {
+  pageManagerDragPageId = null;
+  pageManagerPages
+    .querySelectorAll(".page-manager-page.dragging")
+    .forEach(function (card) {
+      card.classList.remove("dragging");
+    });
+  clearPageManagerDropTargets();
+});
+pageManagerPages.addEventListener("dragover", function (event) {
+  const card = event.target.closest(".page-manager-page[data-page-id]");
+  if (
+    !card ||
+    !pageManagerState ||
+    !pageManagerDragPageId ||
+    card.dataset.pageId === pageManagerDragPageId
+  )
+    return;
+  event.preventDefault();
+  clearPageManagerDropTargets();
+  card.classList.add("drop-target");
+});
+pageManagerPages.addEventListener("drop", function (event) {
+  const card = event.target.closest(".page-manager-page[data-page-id]");
+  if (
+    !card ||
+    !pageManagerState ||
+    !pageManagerDragPageId ||
+    card.dataset.pageId === pageManagerDragPageId
+  )
+    return;
+  event.preventDefault();
+  const nextIndex = pageManagerState.draftPages.findIndex(function (page) {
+    return page.id === card.dataset.pageId;
+  });
+  movePageManagerDraftPage(pageManagerDragPageId, nextIndex);
+  clearPageManagerDropTargets();
+});
+pageManagerDropzone.addEventListener("dragover", function (event) {
+  if (!pageManagerState || !pageManagerDragPageId) return;
+  event.preventDefault();
+  clearPageManagerDropTargets();
+  pageManagerDropzone.classList.add("drop-target");
+});
+pageManagerDropzone.addEventListener("drop", function (event) {
+  if (!pageManagerState || !pageManagerDragPageId) return;
+  event.preventDefault();
+  movePageManagerDraftPage(
+    pageManagerDragPageId,
+    pageManagerState.draftPages.length,
+  );
+  clearPageManagerDropTargets();
+});
+closeRepairBtn.addEventListener("click", function () {
+  repairModal.classList.add("hidden");
+});
+
+/* --------------- Utilities modal --------------- */
+var utilCopySourceBytes = null;
+var utilCopySourceName = "";
+var utilCopyDestBytes = null;
+var utilCopyDestName = "";
+
+function updateUtilCopyRunState() {
+  document.getElementById("util-copy-run").disabled = !(
+    utilCopySourceBytes && utilCopyDestBytes
+  );
+}
+function updateUtilActiveButtons() {
+  var hasPdf = !!state.pdfBytes;
+  document.getElementById("util-copy-source-active").disabled = !hasPdf;
+  document.getElementById("util-copy-dest-active").disabled = !hasPdf;
+}
+
+previewBtn.addEventListener("click", function () {
+  state.previewMode = !state.previewMode;
+  previewBtn.classList.toggle("active", state.previewMode);
+  document
+    .getElementById("preview-icon-open")
+    .classList.toggle("hidden", state.previewMode);
+  document
+    .getElementById("preview-icon-closed")
+    .classList.toggle("hidden", !state.previewMode);
+  renderFieldsOnPages();
+});
+
+utilitiesBtn.addEventListener("click", function () {
+  utilCopySourceBytes = null;
+  utilCopySourceName = "";
+  utilCopyDestBytes = null;
+  utilCopyDestName = "";
+  document.getElementById("util-copy-source-name").textContent = "";
+  document.getElementById("util-copy-dest-name").textContent = "";
+  document.getElementById("util-copy-source-file").value = "";
+  document.getElementById("util-copy-dest-file").value = "";
+  document.getElementById("util-copy-status").classList.add("hidden");
+  document.getElementById("util-bulk-status").classList.add("hidden");
+  document.getElementById("util-bulk-size-warning").classList.add("hidden");
+  document.getElementById("util-bulk-files").value = "";
+  document.getElementById("util-attachment-status").classList.add("hidden");
+  document.getElementById("util-attachment-output").value = "";
+  document.getElementById("util-attachment-generate").disabled =
+    state.fields.length === 0;
+  document.getElementById("util-attachment-copy").disabled = true;
+  bulkFiles = [];
+  updateBulkState();
+  updateUtilActiveButtons();
+  updateUtilCopyRunState();
+  utilitiesModal.classList.remove("hidden");
+});
+utilitiesCloseBtn.addEventListener("click", function () {
+  utilitiesModal.classList.add("hidden");
+});
+[
+  document.getElementById("field-rename-summary-close"),
+  document.getElementById("field-rename-summary-done"),
+].forEach(function (button) {
+  button.addEventListener("click", function () {
+    fieldRenameSummaryModal.classList.add("hidden");
+  });
+});
+
+document
+  .getElementById("util-attachment-generate")
+  .addEventListener("click", function () {
+    var statusEl = document.getElementById("util-attachment-status");
+    var outputEl = document.getElementById("util-attachment-output");
+    var copyBtn = document.getElementById("util-attachment-copy");
+    statusEl.className = "alert alert-info small mb-2";
+    statusEl.textContent = "Generating attachment block...";
+    statusEl.classList.remove("hidden");
+    fetch(apiUrl("/pdf-labeler/api/attachment-block"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        field_names: state.fields.map(function (field) {
+          return field.name;
+        }),
+        filename: state.fileName || "template.pdf",
+      }),
+    })
+      .then(function (response) {
+        return parseApiResponse(response);
+      })
+      .then(function (data) {
+        if (!data.success || !data.data) {
+          throw new Error(
+            (data.error && data.error.message) || "Generation failed.",
+          );
         }
+        outputEl.value = data.data.attachment_block || "fields:";
+        copyBtn.disabled = false;
+        statusEl.className = "alert alert-success small mb-2";
+        statusEl.textContent = "Attachment block generated.";
+      })
+      .catch(function (error) {
+        statusEl.className = "alert alert-danger small mb-2";
+        statusEl.textContent =
+          "Error: " +
+          (error && error.message ? error.message : "Unknown error.");
+      });
+  });
+document
+  .getElementById("util-attachment-copy")
+  .addEventListener("click", function () {
+    var outputEl = document.getElementById("util-attachment-output");
+    var copyPromise =
+      navigator.clipboard && navigator.clipboard.writeText
+        ? navigator.clipboard.writeText(outputEl.value)
+        : Promise.reject(new Error("Clipboard API unavailable"));
+    copyPromise
+      .then(function () {
+        showSuccess("Attachment fields block copied.");
+      })
+      .catch(function () {
+        outputEl.focus();
+        outputEl.select();
+        document.execCommand("copy");
+        showSuccess("Attachment fields block copied.");
+      });
+  });
 
-        const meta = getFieldTypeMeta(field.type);
-        quickFieldTypeBadge.innerHTML = meta.icon;
-        if (!settings.preserveInput || document.activeElement !== quickFieldNameInput) {
-            quickFieldNameInput.value = field.name || '';
-        }
-        quickFieldNameInput.dataset.fieldId = field.id;
-        renderQuickFieldSuggestions(field);
-        quickFieldEditor.classList.remove('hidden');
-        positionQuickFieldEditor();
+document
+  .getElementById("util-copy-source-file")
+  .addEventListener("change", function (e) {
+    var fileTarget = /** @type {any} */ (e.target);
+    var file = fileTarget.files && fileTarget.files[0];
+    if (!file) return;
+    file.arrayBuffer().then(function (buf) {
+      utilCopySourceBytes = new Uint8Array(buf);
+      utilCopySourceName = file.name || "source.pdf";
+      document.getElementById("util-copy-source-name").textContent =
+        utilCopySourceName;
+      updateUtilCopyRunState();
+    });
+  });
+document
+  .getElementById("util-copy-dest-file")
+  .addEventListener("change", function (e) {
+    var fileTarget = /** @type {any} */ (e.target);
+    var file = fileTarget.files && fileTarget.files[0];
+    if (!file) return;
+    file.arrayBuffer().then(function (buf) {
+      utilCopyDestBytes = new Uint8Array(buf);
+      utilCopyDestName = file.name || "destination.pdf";
+      document.getElementById("util-copy-dest-name").textContent =
+        utilCopyDestName;
+      updateUtilCopyRunState();
+    });
+  });
+document
+  .getElementById("util-copy-source-active")
+  .addEventListener("click", function () {
+    if (!state.pdfBytes) return;
+    utilCopySourceBytes = state.pdfBytes;
+    utilCopySourceName = state.fileName || "active.pdf";
+    document.getElementById("util-copy-source-name").textContent =
+      utilCopySourceName + " (active)";
+    updateUtilCopyRunState();
+  });
+document
+  .getElementById("util-copy-dest-active")
+  .addEventListener("click", function () {
+    if (!state.pdfBytes) return;
+    utilCopyDestBytes = state.pdfBytes;
+    utilCopyDestName = state.fileName || "active.pdf";
+    document.getElementById("util-copy-dest-name").textContent =
+      utilCopyDestName + " (active)";
+    updateUtilCopyRunState();
+  });
 
-        if (state.quickEditFocusPending) {
-            window.requestAnimationFrame(function () {
-                quickFieldNameInput.focus();
-                quickFieldNameInput.select();
-            });
-            state.quickEditFocusPending = false;
-        }
-    }
+document.getElementById("util-copy-run").addEventListener("click", function () {
+  if (!utilCopySourceBytes || !utilCopyDestBytes) return;
+  var statusEl = document.getElementById("util-copy-status");
+  statusEl.className = "alert alert-info small mb-3";
+  statusEl.textContent = "Copying fields...";
+  statusEl.classList.remove("hidden");
+  document.getElementById("util-copy-run").disabled = true;
 
-    function renderQuickFieldSuggestions(field) {
-        const detectedSuggestions = Array.isArray(field && field.nameSuggestions) ? field.nameSuggestions : [];
-        // Merge in playground/installed variable names that match the current input
-        const varHints = getEffectivePdfVariables();
-        const currentVal = (quickFieldNameInput.value || '').trim().toLowerCase();
-        const usedNames = new Set(state.fields.map(function(f) { return f.name; }));
-        const detectedNames = new Set(detectedSuggestions.map(function(s) { return s.name; }));
-        const extraSuggestions = [];
-        if (varHints.length > 0 && currentVal) {
-            varHints.forEach(function(v) {
-                if (!detectedNames.has(v) && v.toLowerCase().indexOf(currentVal) !== -1) {
-                    extraSuggestions.push({ name: v, text: 'From interview variables' });
-                }
-            });
-        }
-        const allSuggestions = detectedSuggestions.concat(extraSuggestions.slice(0, 10));
-        quickFieldSuggestions.innerHTML = '';
-        if (!allSuggestions.length) {
-            quickFieldSuggestions.classList.add('hidden');
-            return;
-        }
-        allSuggestions.forEach(function (suggestion) {
-            const button = document.createElement('button');
-            button.type = 'button';
-            button.className = 'quick-field-suggestion btn btn-outline-secondary btn-sm';
-            button.dataset.suggestedName = suggestion.name;
-            button.title = suggestion.text ? ('From nearby text: ' + suggestion.text) : suggestion.name;
-            button.textContent = suggestion.name;
-            if (normalizePdfFieldName(suggestion.name) === normalizePdfFieldName(field.name)) {
-                button.classList.add('active');
-            }
-            quickFieldSuggestions.appendChild(button);
-        });
-        quickFieldSuggestions.classList.remove('hidden');
-    }
+  var formData = new FormData();
+  formData.append(
+    "source",
+    new Blob([utilCopySourceBytes], { type: "application/pdf" }),
+    utilCopySourceName,
+  );
+  formData.append(
+    "destination",
+    new Blob([utilCopyDestBytes], { type: "application/pdf" }),
+    utilCopyDestName,
+  );
 
-    function updateOverlayCursorState() {
-        document.querySelectorAll('.page-overlay').forEach(function (overlay) {
-            overlay.classList.toggle('tool-active', !!state.selectedTool);
-            overlay.classList.toggle('point-insert', !!state.selectedTool && POINT_INSERT_TYPES.has(state.selectedTool));
-        });
-    }
+  fetch(apiUrl("/pdf-labeler/api/copy-fields"), {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    body: formData,
+  })
+    .then(function (resp) {
+      return parseApiResponse(resp);
+    })
+    .then(function (data) {
+      if (!data.success) {
+        throw new Error((data.error && data.error.message) || "Copy failed.");
+      }
+      if (!data.data || !data.data.pdf_base64) {
+        throw new Error("Server did not return a PDF.");
+      }
+      var outputBytes = base64ToUint8Array(data.data.pdf_base64);
+      var outputName = data.data.filename || "result-with-fields.pdf";
 
-    function setSelectedTool(tool) {
-        state.selectedTool = tool ? normalizeFieldType(tool) : null;
-        Object.keys(toolButtons).forEach(function (key) {
-            toolButtons[key].classList.toggle('active', key === state.selectedTool);
-        });
-        updateToolHint();
-        updateOverlayCursorState();
-    }
+      statusEl.className = "alert alert-success small mb-3";
+      statusEl.textContent = "Fields copied successfully.";
 
-    function applyBranding() {
-        if (pageTitle) {
-            pageTitle.textContent = BRANDING.pdf_page_title || BRANDING.pdf_header_title || 'PDF Labeler';
-            document.title = pageTitle.textContent;
-        }
-        if (pageFavicon && BRANDING.favicon_url) {
-            pageFavicon.href = BRANDING.favicon_url;
-        }
-        if (brandLogo && BRANDING.logo_url) {
-            brandLogo.src = BRANDING.logo_url;
-        }
-        if (brandLogo && BRANDING.logo_alt) {
-            brandLogo.alt = BRANDING.logo_alt;
-        }
-        if (brandPdfTitle) {
-            brandPdfTitle.textContent = BRANDING.pdf_header_title || 'PDF Labeler';
-        }
-        if (brandPdfSubtitle) {
-            brandPdfSubtitle.textContent = BRANDING.pdf_header_subtitle || 'Add, inspect, rename, and export PDF form fields';
-        }
-    }
-
-    function renderAuthControls() {
-        if (!authControls) return;
-        if (state.auth.isAuthenticated) {
-            const emailText = state.auth.email || 'Account';
-            const menuItems = Array.isArray(state.auth.menuItems) && state.auth.menuItems.length
-                ? state.auth.menuItems
-                : [{ label: 'Sign Out', url: state.auth.logoutUrl || '/user/sign-out' }];
-            authControls.innerHTML =
-                '<button id="auth-menu-btn" class="btn btn-outline-light btn-sm dropdown-toggle" type="button" aria-expanded="false">' + escapeHtml(emailText) + '</button>' +
-                '<div id="auth-menu" class="dropdown-menu dropdown-menu-end header-auth-menu">' +
-                    menuItems.map(function (item) {
-                        return '<a class="dropdown-item" href="' + escapeHtml(item.url || '#') + '">' + escapeHtml(item.label || '') + '</a>';
-                    }).join('') +
-                '</div>';
-            const menuBtn = document.getElementById('auth-menu-btn');
-            const menu = document.getElementById('auth-menu');
-            menuBtn.addEventListener('click', function (event) {
-                event.stopPropagation();
-                menu.classList.toggle('show');
-            });
-        } else {
-            authControls.innerHTML =
-                '<a class="btn btn-outline-light btn-sm" href="' + escapeHtml(state.auth.loginUrl || '/user/sign-in') + '">Log in</a>';
-        }
-    }
-
-    function updateAiUiState() {
-        const aiEnabled = !!state.auth.aiEnabled;
-        autoDetectBtn.disabled = !state.pdfBytes || !aiEnabled;
-        if (relabelBtn) {
-            relabelBtn.disabled = !state.pdfBytes || state.fields.length === 0 || !aiEnabled;
-        }
-        if (sidebarRelabelBtn) {
-            sidebarRelabelBtn.disabled = !state.pdfBytes || state.fields.length === 0 || !aiEnabled;
-        }
-        if (!aiEnabled) {
-            aiAuthNotice.classList.remove('hidden');
-            aiAuthNotice.innerHTML = 'AI features require login. <a href="' + escapeHtml(state.auth.loginUrl || '/user/sign-in') + '">Log in</a> to use auto-detect and AI relabel.';
-        } else {
-            aiAuthNotice.classList.add('hidden');
-        }
-        savePlaygroundBtn.classList.toggle('hidden', !state.auth.isAuthenticated);
-        openPlaygroundBtn.classList.toggle('hidden', !state.auth.isAuthenticated);
-    }
-
-    async function fetchModelCatalog() {
-        try {
-            const response = await fetch(apiUrl('/labeler/api/models'), { method: 'GET' });
-            const data = await response.json();
-            if (!data.success || !data.data) return;
-            state.defaultModel = data.data.default_model || state.defaultModel;
-            state.recommendedModels = Array.isArray(data.data.recommended_models) && data.data.recommended_models.length
-                ? data.data.recommended_models
-                : [state.defaultModel];
-            state.availableModels = Array.isArray(data.data.available_models) ? data.data.available_models : [];
-            state.model = state.defaultModel;
-            aiModelInput.value = state.model;
-        } catch (_error) {
-            aiModelInput.value = state.model;
-        }
-    }
-
-    async function fetchAuthStatus() {
-        try {
-            const nextTarget = window.location.pathname + window.location.search;
-            const response = await fetch(apiUrl('/labeler/api/auth-status') + '?next=' + encodeURIComponent(nextTarget), { method: 'GET' });
-            const data = await response.json();
-            if (data.success && data.data) {
-                state.auth.isAuthenticated = !!data.data.is_authenticated;
-                state.auth.email = data.data.email || '';
-                state.auth.loginUrl = data.data.login_url || '/user/sign-in';
-                state.auth.logoutUrl = data.data.logout_url || '/user/sign-out';
-                state.auth.aiEnabled = !!data.data.ai_enabled;
-                state.auth.menuItems = Array.isArray(data.data.menu_items) ? data.data.menu_items : [];
-            }
-        } catch (_error) {
-            state.auth = {
-                isAuthenticated: false,
-                email: '',
-                loginUrl: '/user/sign-in',
-                logoutUrl: '/user/sign-out',
-                aiEnabled: false,
-                menuItems: []
-            };
-        }
-        renderAuthControls();
-        updateAiUiState();
-        if (state.auth.isAuthenticated) {
-            await fetchPdfPlaygroundProjects();
-            await maybeOpenInitialPlaygroundTemplate();
-        }
-    }
-
-    async function maybeOpenInitialPlaygroundTemplate() {
-        if (!state.auth.isAuthenticated) return;
-        if (state.initialPlaygroundSource.attempted) return;
-        var project = state.initialPlaygroundSource.project;
-        var filename = state.initialPlaygroundSource.filename;
-        if (!project || !filename) {
-            state.initialPlaygroundSource.attempted = true;
-            return;
-        }
-        state.initialPlaygroundSource.attempted = true;
-        if (state.playground.projects.indexOf(project) === -1) return;
-        state.playground.selectedProject = project;
-        renderPdfInterviewPicker();
-        await openPdfTemplateFromPlayground(project, filename, { showSuccess: false });
-    }
-
-    // ================================================================
-    // Playground integration (variable hints, open, save)
-    // ================================================================
-
-    async function fetchPdfPlaygroundProjects() {
-        if (!state.auth.isAuthenticated) {
-            state.playground.projects = [];
-            state.playground.files = [];
-            return;
-        }
-        try {
-            var response = await fetch(apiUrl('/labeler/api/playground-projects'), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            state.playground.projects =
-                data && data.success && data.data && Array.isArray(data.data.projects)
-                    ? data.data.projects : [];
-            if (state.playground.projects.indexOf(state.playground.selectedProject) === -1)
-                state.playground.selectedProject = state.playground.projects[0] || 'default';
-            await fetchPdfPlaygroundFiles();
-        } catch (_e) {
-            state.playground.projects = [];
-        }
-        renderPdfInterviewPicker();
-    }
-
-    async function fetchPdfPlaygroundFiles() {
-        if (!state.playground.selectedProject) { state.playground.files = []; renderPdfInterviewPicker(); return; }
-        try {
-            var response = await fetch(apiUrl('/labeler/api/playground-files?project=' + encodeURIComponent(state.playground.selectedProject)), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            var files = data && data.success && data.data && Array.isArray(data.data.files) ? data.data.files : [];
-            state.playground.files = files;
-            var exists = files.some(function(f) { return f.filename === state.playground.selectedFile; });
-            state.playground.selectedFile = exists ? state.playground.selectedFile : (files[0] ? files[0].filename : '');
-            await fetchPdfPlaygroundVariables();
-        } catch (_e) {
-            state.playground.files = [];
-            state.playground.variables = [];
-            state.playground.topLevelNames = [];
-        }
-        renderPdfInterviewPicker();
-    }
-
-    async function fetchPdfPlaygroundVariables() {
-        if (!state.playground.selectedProject || !state.playground.selectedFile) {
-            state.playground.variables = [];
-            state.playground.topLevelNames = [];
-            renderPdfInterviewPicker();
-            return;
-        }
-        try {
-            var response = await fetch(apiUrl('/labeler/api/playground-variables?project=' + encodeURIComponent(state.playground.selectedProject) + '&filename=' + encodeURIComponent(state.playground.selectedFile)), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            state.playground.variables =
-                data && data.success && data.data && Array.isArray(data.data.all_names) ? data.data.all_names : [];
-            state.playground.topLevelNames =
-                data && data.success && data.data && Array.isArray(data.data.top_level_names) ? data.data.top_level_names : [];
-        } catch (_e) {
-            state.playground.variables = [];
-            state.playground.topLevelNames = [];
-        }
-        renderPdfInterviewPicker();
-    }
-
-    async function fetchPdfInstalledPackages() {
-        if (!state.auth.isAuthenticated) { state.installed.packages = []; return; }
-        try {
-            var response = await fetch(apiUrl('/labeler/api/installed-packages'), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            state.installed.packages = data && data.success && data.data && Array.isArray(data.data.packages) ? data.data.packages : [];
-            if (state.installed.packages.indexOf(state.installed.selectedPackage) === -1)
-                state.installed.selectedPackage = state.installed.packages[0] || '';
-            await fetchPdfInstalledFiles();
-        } catch (_e) {
-            state.installed.packages = [];
-        }
-        renderPdfInterviewPicker();
-    }
-
-    async function fetchPdfInstalledFiles() {
-        if (!state.installed.selectedPackage) { state.installed.files = []; renderPdfInterviewPicker(); return; }
-        try {
-            var response = await fetch(apiUrl('/labeler/api/installed-files?package=' + encodeURIComponent(state.installed.selectedPackage)), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            var files = data && data.success && data.data && Array.isArray(data.data.files) ? data.data.files : [];
-            state.installed.files = files;
-            var exists = files.some(function(f) { return f.filename === state.installed.selectedFile; });
-            state.installed.selectedFile = exists ? state.installed.selectedFile : (files[0] ? files[0].filename : '');
-            await fetchPdfInstalledVariables();
-        } catch (_e) { state.installed.files = []; state.installed.variables = []; state.installed.topLevelNames = []; }
-        renderPdfInterviewPicker();
-    }
-
-    async function fetchPdfInstalledVariables() {
-        if (!state.installed.selectedPackage || !state.installed.selectedFile) {
-            state.installed.variables = []; state.installed.topLevelNames = []; renderPdfInterviewPicker(); return;
-        }
-        try {
-            var path = state.installed.selectedPackage + ':' + state.installed.selectedFile;
-            var response = await fetch(apiUrl('/labeler/api/installed-variables?interview_path=' + encodeURIComponent(path)), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            state.installed.variables = data && data.success && data.data && Array.isArray(data.data.all_names) ? data.data.all_names : [];
-            state.installed.topLevelNames = data && data.success && data.data && Array.isArray(data.data.top_level_names) ? data.data.top_level_names : [];
-        } catch (_e) { state.installed.variables = []; state.installed.topLevelNames = []; }
-        renderPdfInterviewPicker();
-    }
-
-    function renderPdfInterviewPicker() {
-        pdfInterviewPicker.classList.toggle('hidden', !state.usePlaygroundVariables);
-        var isPlayground = state.interviewSourceMode === 'playground';
-        pdfPlaygroundFields.classList.toggle('hidden', !isPlayground);
-        pdfInstalledFields.classList.toggle('hidden', isPlayground);
-        pdfInterviewSourceModeInputs.forEach(function(inp) { inp.checked = inp.value === state.interviewSourceMode; });
-
-        // Populate playground selects
-        pdfPlaygroundProjectSelect.innerHTML = '';
-        state.playground.projects.forEach(function(proj) {
-            var opt = document.createElement('option');
-            opt.value = proj; opt.textContent = proj;
-            opt.selected = proj === state.playground.selectedProject;
-            pdfPlaygroundProjectSelect.appendChild(opt);
-        });
-        pdfPlaygroundYamlFileSelect.innerHTML = '';
-        state.playground.files.forEach(function(f) {
-            var opt = document.createElement('option');
-            opt.value = f.filename; opt.textContent = f.filename;
-            opt.selected = f.filename === state.playground.selectedFile;
-            pdfPlaygroundYamlFileSelect.appendChild(opt);
-        });
-
-        // Populate installed selects
-        pdfInstalledPackageSelect.innerHTML = '';
-        state.installed.packages.forEach(function(pkg) {
-            var opt = document.createElement('option');
-            opt.value = pkg; opt.textContent = pkg;
-            opt.selected = pkg === state.installed.selectedPackage;
-            pdfInstalledPackageSelect.appendChild(opt);
-        });
-        pdfInstalledYamlFileSelect.innerHTML = '';
-        state.installed.files.forEach(function(f) {
-            var opt = document.createElement('option');
-            opt.value = f.filename; opt.textContent = f.filename;
-            opt.selected = f.filename === state.installed.selectedFile;
-            pdfInstalledYamlFileSelect.appendChild(opt);
-        });
-
-        // Variable summary
-        var vars = getEffectivePdfVariables();
-        if (vars.length > 0) {
-            pdfInterviewVariableSummary.textContent = vars.length + ' variable name' + (vars.length === 1 ? '' : 's') + ' loaded.';
-            pdfInterviewVariableSummary.classList.remove('hidden');
-        } else {
-            pdfInterviewVariableSummary.classList.add('hidden');
-        }
-    }
-
-    function getEffectivePdfVariables() {
-        if (!state.usePlaygroundVariables) return [];
-        if (state.interviewSourceMode === 'installed')
-            return state.installed.variables || [];
-        return state.playground.variables || [];
-    }
-
-    // Open from Playground modal
-    async function openPlaygroundModal() {
-        if (!state.auth.isAuthenticated) { showError('Login required to access Playground.'); return; }
-        // Show modal immediately with loading states
-        var openPgProject = document.getElementById('open-pg-project');
-        var openPgTemplate = document.getElementById('open-pg-template');
-        openPgProject.innerHTML = '<option value="">Loading projects...</option>';
-        openPgTemplate.innerHTML = '<option value="">Waiting for projects...</option>';
-        openPlaygroundModalEl.classList.remove('hidden');
-        // Load data in background
-        (async function() {
-            try {
-                await fetchPdfPlaygroundProjects();
-                openPgProject.innerHTML = '';
-                state.playground.projects.forEach(function(proj) {
-                    var opt = document.createElement('option');
-                    opt.value = proj; opt.textContent = proj;
-                    opt.selected = proj === state.playground.selectedProject;
-                    openPgProject.appendChild(opt);
-                });
-                await fetchOpenPlaygroundTemplates();
-            } catch (e) {
-                console.error('Error loading playground data:', e);
-                openPgProject.innerHTML = '<option value="">(error loading projects)</option>';
-                openPgTemplate.innerHTML = '<option value="">(error loading templates)</option>';
-            }
-        })();
-    }
-
-    async function fetchOpenPlaygroundTemplates() {
-        var openPgProject = document.getElementById('open-pg-project');
-        var openPgTemplate = document.getElementById('open-pg-template');
-        var project = openPgProject.value || 'default';
-        openPgTemplate.innerHTML = '<option value="">Loading...</option>';
-        try {
-            var response = await fetch(apiUrl('/labeler/api/playground-templates?project=' + encodeURIComponent(project) + '&type=pdf'), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            var templates = data && data.success && data.data && Array.isArray(data.data.templates) ? data.data.templates : [];
-            openPgTemplate.innerHTML = '';
-            if (templates.length === 0) {
-                var opt = document.createElement('option');
-                opt.value = ''; opt.textContent = '(no PDF templates found)';
-                openPgTemplate.appendChild(opt);
-                return;
-            }
-            templates.forEach(function(t) {
-                var opt = document.createElement('option');
-                opt.value = t.filename; opt.textContent = t.filename + (t.size ? ' (' + Math.round(t.size / 1024) + ' KB)' : '');
-                openPgTemplate.appendChild(opt);
-            });
-        } catch (_e) {
-            openPgTemplate.innerHTML = '<option value="">(error loading templates)</option>';
-        }
-    }
-
-    async function confirmOpenFromPlayground() {
-        var openPgProject = document.getElementById('open-pg-project');
-        var openPgTemplate = document.getElementById('open-pg-template');
-        var project = openPgProject.value || 'default';
-        var filename = openPgTemplate.value;
-        if (!filename) { showError('Select a template file.'); return; }
-        openPlaygroundModalEl.classList.add('hidden');
-        await openPdfTemplateFromPlayground(project, filename);
-    }
-
-    async function openPdfTemplateFromPlayground(project, filename, options) {
-        options = options || {};
-        showLoading('Loading ' + filename + ' from Playground...');
-        try {
-            var response = await fetch(apiUrl('/labeler/api/playground-templates/load?project=' + encodeURIComponent(project) + '&filename=' + encodeURIComponent(filename)), { method: 'GET', credentials: 'same-origin' });
-            var data = await response.json();
-            if (!data.success || !data.data || !data.data.file_content_base64) {
-                throw new Error((data.error && data.error.message) || 'Failed to load template.');
-            }
-            var bytes = base64ToUint8Array(data.data.file_content_base64);
-            var file = new File([bytes], filename, { type: 'application/pdf' });
-            state.playgroundSource = { project: project, filename: filename };
-            savePlaygroundBtn.classList.remove('hidden');
-            await loadPdf(file);
-            if (options.showSuccess !== false) {
-                showSuccess('Opened ' + filename + ' from Playground.');
-            }
-        } catch (error) {
-            showPdfWorkspace();
-            showError('Failed to load from Playground: ' + (error.message || 'Unknown error.'));
-        } finally { hideLoading(); }
-    }
-
-    // Save to Playground modal
-    async function openSavePlaygroundModal() {
-        if (!state.auth.isAuthenticated) { showError('Login required to save to Playground.'); return; }
-        if (!state.pdfBytes) { showError('No PDF loaded.'); return; }
-        // Show modal immediately
-        var savePgProject = document.getElementById('save-pg-project');
-        var savePgFilename = document.getElementById('save-pg-filename');
-        var savePgStatus = document.getElementById('save-pg-status');
-        savePgProject.innerHTML = '<option value="">Loading projects...</option>';
-        savePgFilename.value = state.playgroundSource.filename || state.fileName || 'template.pdf';
-        if (!savePgFilename.value.toLowerCase().endsWith('.pdf'))
-            savePgFilename.value += '.pdf';
-        var duplicateNames = getDuplicateFieldNames();
-        var saveDedupeInput = document.getElementById('save-pg-deduplicate-field-names');
-        var saveDuplicateWarning = document.getElementById('save-pg-duplicate-warning');
-        if (saveDedupeInput) {
-            saveDedupeInput.checked = !exportDeduplicateFieldNamesInput || exportDeduplicateFieldNamesInput.checked;
-        }
-        if (saveDuplicateWarning) {
-            saveDuplicateWarning.classList.toggle('hidden', duplicateNames.length === 0);
-            if (duplicateNames.length) {
-                saveDuplicateWarning.textContent = 'Duplicate PDF field names detected: ' + duplicateNames.slice(0, 5).join(', ') + (duplicateNames.length > 5 ? ' ...' : '') + '. Some PDF viewers handle duplicate names unpredictably.';
-            }
-        }
-        savePgStatus.classList.add('hidden');
-        savePlaygroundModalEl.classList.remove('hidden');
-        // Load projects in background
-        (async function() {
-            try {
-                await fetchPdfPlaygroundProjects();
-                savePgProject.innerHTML = '';
-                state.playground.projects.forEach(function(proj) {
-                    var opt = document.createElement('option');
-                    opt.value = proj; opt.textContent = proj;
-                    opt.selected = proj === (state.playgroundSource.project || state.playground.selectedProject);
-                    savePgProject.appendChild(opt);
-                });
-            } catch (e) {
-                console.error('Error loading projects:', e);
-                savePgProject.innerHTML = '<option value="">(error loading projects)</option>';
-            }
-        })();
-    }
-
-    async function confirmSaveToPlayground() {
-        var savePgProject = document.getElementById('save-pg-project');
-        var savePgFilename = document.getElementById('save-pg-filename');
-        var savePgStatus = document.getElementById('save-pg-status');
-        var project = savePgProject.value || 'default';
-        var filename = savePgFilename.value.trim();
-        if (!filename || !filename.toLowerCase().endsWith('.pdf')) {
-            savePgStatus.textContent = 'Filename must end with .pdf'; savePgStatus.classList.remove('hidden'); return;
-        }
-        savePlaygroundModalEl.classList.add('hidden');
-        showLoading('Saving to Playground...');
-        try {
-            // First export to get the latest PDF with field changes applied
-            var pdfContent;
-            var saveRenamedFields = [];
-            var saveDeduplicateFieldNames = document.getElementById('save-pg-deduplicate-field-names').checked;
-            if (state.fields.length > 0 && (state.hasUnsavedChanges || saveDeduplicateFieldNames)) {
-                var formData = new FormData();
-                formData.append('file', getPdfFileForRequests());
-                var saveNameMap = buildExportNameMap({
-                    deduplicate: saveDeduplicateFieldNames
-                });
-                saveRenamedFields = getRenamedFields(saveNameMap);
-                formData.append('fields', JSON.stringify(convertFieldsToAbsoluteCoordinates(saveNameMap)));
-                formData.append('accessibility', JSON.stringify(buildAccessibilityPayload(saveNameMap)));
-                formData.append('deduplicate_field_names', saveDeduplicateFieldNames ? 'true' : 'false');
-                var exportResponse = await fetch(apiUrl('/pdf-labeler/api/apply-fields'), { method: 'POST', headers: { 'Accept': 'application/json' }, body: formData });
-                var exportData = await parseApiResponse(exportResponse);
-                if (!exportData.success || !exportData.data || !exportData.data.pdf_base64) {
-                    throw new Error('Failed to apply fields before saving.');
-                }
-                pdfContent = exportData.data.pdf_base64;
-            } else {
-                // Use current PDF bytes as-is
-                var raw = '';
-                var bytes = new Uint8Array(state.pdfBytes);
-                for (var i = 0; i < bytes.length; i++) raw += String.fromCharCode(bytes[i]);
-                pdfContent = window.btoa(raw);
-            }
-
-            var response = await fetch(apiUrl('/labeler/api/playground-templates/save'), {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-                body: JSON.stringify({ project: project, filename: filename, file_content_base64: pdfContent }),
-                credentials: 'same-origin'
-            });
-            var data = await response.json();
-            if (!data.success) throw new Error((data.error && data.error.message) || 'Save failed.');
-            state.playgroundSource = { project: project, filename: filename };
-            savePlaygroundBtn.classList.remove('hidden');
-            setDirty(false);
-            showPdfWorkspace();
-            showSuccess((data.data && data.data.created ? 'Created' : 'Updated') + ' ' + filename + ' in Playground.');
-            showFieldRenameSummary(
-                saveRenamedFields,
-                'The PDF was saved after these exact duplicate field names were made unique.'
-            );
-        } catch (error) {
-            showPdfWorkspace();
-            showError('Save to Playground failed: ' + (error.message || 'Unknown error.'));
-        } finally { hideLoading(); }
-    }
-
-    function renderModelSuggestions(filterText) {
-        const filter = (filterText || '').trim().toLowerCase();
-        const source = filter
-            ? (state.availableModels.length ? state.availableModels : state.recommendedModels)
-            : state.recommendedModels;
-        const models = source.filter(function (name) {
-            return !filter || name.toLowerCase().includes(filter);
-        }).slice(0, 20);
-        aiModelSuggestions.innerHTML = '';
-        if (models.length === 0) {
-            aiModelSuggestions.classList.add('hidden');
-            return;
-        }
-        models.forEach(function (name) {
-            const button = document.createElement('button');
-            button.type = 'button';
-            button.className = 'model-suggestion-btn font-monospace';
-            button.textContent = name;
-            button.addEventListener('click', function () {
-                aiModelInput.value = name;
-                state.model = name;
-                aiModelSuggestions.classList.add('hidden');
-            });
-            aiModelSuggestions.appendChild(button);
-        });
-        aiModelSuggestions.classList.remove('hidden');
-    }
-
-    function arrayBufferToUint8Array(buffer) {
-        return new Uint8Array(buffer);
-    }
-
-    function base64ToUint8Array(base64String) {
-        const binaryString = window.atob(base64String);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let index = 0; index < binaryString.length; index += 1) {
-            bytes[index] = binaryString.charCodeAt(index);
-        }
-        return bytes;
-    }
-
-    function clonePdfBytes(pdfBytes) {
-        if (!pdfBytes) return null;
-        if (pdfBytes instanceof Uint8Array) {
-            return new Uint8Array(pdfBytes);
-        }
-        if (ArrayBuffer.isView(pdfBytes)) {
-            return new Uint8Array(pdfBytes.buffer.slice(pdfBytes.byteOffset, pdfBytes.byteOffset + pdfBytes.byteLength));
-        }
-        if (pdfBytes instanceof ArrayBuffer) {
-            return new Uint8Array(pdfBytes.slice(0));
-        }
-        return new Uint8Array(pdfBytes);
-    }
-
-    function looksLikePdfBytes(pdfBytes) {
-        if (!pdfBytes || pdfBytes.length < 5) return false;
-        return pdfBytes[0] === 0x25 &&
-            pdfBytes[1] === 0x50 &&
-            pdfBytes[2] === 0x44 &&
-            pdfBytes[3] === 0x46 &&
-            pdfBytes[4] === 0x2d;
-    }
-
-    function applyReturnedPdfPayload(data, fallbackName) {
-        if (!data || !data.pdf_base64) {
-            return false;
-        }
-        const nextPdfBytes = base64ToUint8Array(data.pdf_base64);
-        if (!looksLikePdfBytes(nextPdfBytes)) {
-            throw new Error('AI relabel returned output that was not a valid PDF.');
-        }
-        syncPdfState(
-            nextPdfBytes,
-            data.output_filename || data.filename || fallbackName || state.fileName || 'edited-form.pdf'
-        );
-        return true;
-    }
-
-    function didRelabelChangeFieldNames(data) {
-        const previous = Array.isArray(data && data.fields_old) ? data.fields_old : [];
-        const next = Array.isArray(data && data.fields) ? data.fields : [];
-        if (!previous.length || previous.length !== next.length) return null;
-        return previous.some(function (name, index) {
-            return String(name || '') !== String(next[index] || '');
-        });
-    }
-
-    function getRelabelChangedCount(data) {
-        const previous = Array.isArray(data && data.fields_old) ? data.fields_old : [];
-        const next = Array.isArray(data && data.fields) ? data.fields : [];
-        if (!previous.length || previous.length !== next.length) return null;
-        let changedCount = 0;
-        previous.forEach(function (name, index) {
-            if (String(name || '') !== String(next[index] || '')) {
-                changedCount += 1;
-            }
-        });
-        return changedCount;
-    }
-
-    function reconcileRelabeledFields(fields, data) {
-        const expectedNames = Array.isArray(data && data.fields)
-            ? data.fields.map(function (name) { return String(name || ''); })
-            : [];
-        const previousNames = Array.isArray(data && data.fields_old)
-            ? data.fields_old.map(function (name) { return String(name || ''); })
-            : [];
-
-        if (!expectedNames.length) {
-            return Array.isArray(fields) ? fields : [];
-        }
-
-        const baseFields = Array.isArray(fields) && fields.length
-            ? fields.map(function (field) { return Object.assign({}, field); })
-            : state.fields.map(function (field) { return Object.assign({}, field); });
-
-        if (baseFields.length !== expectedNames.length) {
-            return baseFields;
-        }
-
-        if (previousNames.length === expectedNames.length) {
-            const renameMap = new Map();
-            previousNames.forEach(function (name, index) {
-                renameMap.set(name, expectedNames[index]);
-            });
-            return baseFields.map(function (field, index) {
-                const nextName = renameMap.get(String(field.name || '')) || expectedNames[index];
-                return Object.assign({}, field, { name: nextName || field.name });
-            });
-        }
-
-        return baseFields.map(function (field, index) {
-            return Object.assign({}, field, { name: expectedNames[index] || field.name });
-        });
-    }
-
-    function logRelabelDebug(data, detectedFields, relabeledFields) {
-        const previousNames = Array.isArray(data && data.fields_old) ? data.fields_old.slice() : [];
-        const nextNames = Array.isArray(data && data.fields) ? data.fields.slice() : [];
-        const renamedCount = getRelabelChangedCount(data);
-        const detectedNames = Array.isArray(detectedFields)
-            ? detectedFields.map(function (field) { return field.name; })
-            : [];
-        const finalNames = Array.isArray(relabeledFields)
-            ? relabeledFields.map(function (field) { return field.name; })
-            : [];
-        console.groupCollapsed('[pdf-labeler] AI relabel result');
-        console.info('renamedCount:', renamedCount);
-        console.info('worker fields_old:', previousNames);
-        console.info('worker fields:', nextNames);
-        console.info('detected field names after relabel:', detectedNames);
-        console.info('final field names rendered in UI:', finalNames);
-        console.info('raw relabel payload:', data);
-        console.groupEnd();
-    }
-
-    function updateRequestPdfFile(pdfBytes, fileName, originalFile) {
-        const nextName = fileName || state.fileName || 'edited-form.pdf';
-        if (originalFile instanceof File && originalFile.size > 0) {
-            if (originalFile.name === nextName) {
-                state.requestPdfFile = originalFile;
-            } else {
-                state.requestPdfFile = new File([originalFile], nextName, { type: 'application/pdf' });
-            }
-            return;
-        }
-        if (pdfBytes && pdfBytes.length) {
-            state.requestPdfFile = new File([pdfBytes], nextName, { type: 'application/pdf' });
-            return;
-        }
-        state.requestPdfFile = null;
-    }
-
-    function syncPdfState(pdfBytes, fileName, originalFile) {
-        state.pdfBytes = clonePdfBytes(pdfBytes);
-        if (fileName) {
-            state.fileName = fileName;
-        }
-        state.accessibility.inspected = false;
-        state.accessibility.images = [];
-        state.accessibility.tagStructure = null;
-        updateRequestPdfFile(state.pdfBytes, state.fileName, originalFile);
-    }
-
-    async function refreshPdfDocumentFromState(renderOptions) {
-        state.pdfDoc = await pdfjsLib.getDocument({ data: clonePdfBytes(state.pdfBytes) }).promise;
-        state.pageCount = state.pdfDoc.numPages;
-        state.pageSizes = [];
-        state.pageTextBoxes = [];
-
-        for (let index = 1; index <= state.pageCount; index += 1) {
-            const page = await state.pdfDoc.getPage(index);
-            const viewport = page.getViewport({ scale: 1 });
-            state.pageSizes.push({ width: viewport.width, height: viewport.height });
-            state.pageTextBoxes.push(await extractTextBoxesFromPage(page));
-        }
-
-        await renderPages(renderOptions);
-    }
-
-    function stripPdfExtension(fileName) {
-        return String(fileName || 'document').replace(/\.pdf$/i, '');
-    }
-
-    function sanitizeFilenameSegment(value, fallbackValue) {
-        const cleaned = String(value || '')
-            .replace(/[^a-z0-9._-]+/gi, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-+|-+$/g, '');
-        return cleaned || fallbackValue || 'document';
-    }
-
-    function downloadBlob(blob, fileName) {
-        const url = URL.createObjectURL(blob);
-        const anchor = document.createElement('a');
+      var shouldLoad = document.getElementById("util-copy-load-result").checked;
+      if (shouldLoad) {
+        utilitiesModal.classList.add("hidden");
+        const blob = new Blob([outputBytes], { type: "application/pdf" });
+        var file = new File([blob], outputName, { type: "application/pdf" });
+        loadPdf(file);
+      } else {
+        const blob = new Blob([outputBytes], { type: "application/pdf" });
+        var url = URL.createObjectURL(blob);
+        var anchor = document.createElement("a");
         anchor.href = url;
-        anchor.download = fileName;
+        anchor.download = outputName;
         document.body.appendChild(anchor);
         anchor.click();
         document.body.removeChild(anchor);
         URL.revokeObjectURL(url);
-    }
-
-    function getPdfFileForRequests() {
-        if (state.requestPdfFile && state.requestPdfFile.size > 0) {
-            return state.requestPdfFile;
-        }
-        updateRequestPdfFile(state.pdfBytes, state.fileName);
-        if (state.requestPdfFile && state.requestPdfFile.size > 0) {
-            return state.requestPdfFile;
-        }
-        return new File([], state.fileName || 'edited-form.pdf', { type: 'application/pdf' });
-    }
-
-    async function parseApiResponse(response) {
-        const text = await response.text();
-        let data = null;
-        try {
-            data = text ? JSON.parse(text) : {};
-        } catch (_error) {
-            const returnedHtml = text.trim().startsWith('<');
-            const statusText = response.status ? ('HTTP ' + response.status) : 'request';
-            const finalUrl = response.url ? (' from ' + response.url) : '';
-            if (returnedHtml && response.redirected && response.url && response.url.indexOf('/user/sign-in') !== -1) {
-                throw new Error('Login required for this AI action.');
-            }
-            throw new Error(returnedHtml
-                ? ('The server returned HTML instead of JSON (' + statusText + finalUrl + ').')
-                : ('The server returned invalid JSON (' + statusText + finalUrl + ').'));
-        }
-        if (!response.ok) {
-            throw new Error((data && data.error && data.error.message) ? data.error.message : ('Request failed (' + response.status + ').'));
-        }
-        return data;
-    }
-
-    function sleep(milliseconds) {
-        return new Promise(function (resolve) {
-            window.setTimeout(resolve, milliseconds);
-        });
-    }
-
-    async function pollLabelerJob(jobUrl, progressMessage) {
-        const startedAt = Date.now();
-        const timeoutMs = 8 * 60 * 1000;
-        while ((Date.now() - startedAt) < timeoutMs) {
-            await sleep(1500);
-            const response = await fetch(jobUrl, {
-                method: 'GET',
-                headers: { 'Accept': 'application/json' }
-            });
-            const payload = await parseApiResponse(response);
-            if (payload.status === 'queued' || payload.status === 'running') {
-                showLoading(progressMessage);
-                continue;
-            }
-            if (payload.status === 'failed') {
-                throw new Error((payload.error && payload.error.message) || 'Background job failed.');
-            }
-            if (payload.status === 'succeeded') {
-                return payload.data || {};
-            }
-            throw new Error('Unexpected background job status.');
-        }
-        throw new Error('The background job timed out before it completed.');
-    }
-
-    async function requestAsyncLabelerAction(endpointPath, formData, progressMessage) {
-        formData.append('mode', 'async');
-        const response = await fetch(apiUrl(endpointPath), {
-            method: 'POST',
-            headers: { 'Accept': 'application/json' },
-            body: formData
-        });
-        const payload = await parseApiResponse(response);
-        if (payload.status === 'queued' && payload.job_url) {
-            showLoading(progressMessage);
-            return pollLabelerJob(payload.job_url, progressMessage);
-        }
-        return (payload && payload.data) ? payload.data : {};
-    }
-
-    function normalizeExistingRect(rect, pageSize) {
-        const normalizedWidth = clamp(rect.width / pageSize.width, 0.01, 1);
-        const normalizedHeight = clamp(rect.height / pageSize.height, 0.01, 1);
-        const normalizedX = clamp(rect.x / pageSize.width, 0, 1 - normalizedWidth);
-        const normalizedY = clamp(1 - (rect.y + rect.height) / pageSize.height, 0, 1 - normalizedHeight);
-        return {
-            x: normalizedX,
-            y: normalizedY,
-            width: normalizedWidth,
-            height: normalizedHeight
-        };
-    }
-
-    async function parseExistingFieldsLocally(pdfBytes, pageSizes) {
-        if (!PDFLibGlobal.PDFDocument) {
-            return [];
-        }
-        const fields = [];
-        try {
-            const pdfDoc = await PDFLibGlobal.PDFDocument.load(clonePdfBytes(pdfBytes));
-            const form = pdfDoc.getForm();
-            const pdfPages = pdfDoc.getPages();
-
-            form.getFields().forEach(function (field) {
-                let type = null;
-                let options = undefined;
-
-                if (PDFLibGlobal.PDFTextField && field instanceof PDFLibGlobal.PDFTextField) {
-                    type = field.isMultiline() ? 'multiline' : 'text';
-                } else if (PDFLibGlobal.PDFCheckBox && field instanceof PDFLibGlobal.PDFCheckBox) {
-                    type = 'checkbox';
-                } else if (PDFLibGlobal.PDFSignature && field instanceof PDFLibGlobal.PDFSignature) {
-                    type = 'signature';
-                } else if (PDFLibGlobal.PDFRadioGroup && field instanceof PDFLibGlobal.PDFRadioGroup) {
-                    type = 'radio';
-                    options = typeof field.getOptions === 'function' ? field.getOptions() : DEFAULT_OPTION_LIST.slice();
-                } else if (PDFLibGlobal.PDFDropdown && field instanceof PDFLibGlobal.PDFDropdown) {
-                    type = 'dropdown';
-                    options = typeof field.getOptions === 'function' ? field.getOptions() : DEFAULT_OPTION_LIST.slice();
-                } else if (PDFLibGlobal.PDFOptionList && field instanceof PDFLibGlobal.PDFOptionList) {
-                    type = 'listbox';
-                    options = typeof field.getOptions === 'function' ? field.getOptions() : DEFAULT_OPTION_LIST.slice();
-                }
-
-                if (!type) return;
-
-                const widgets = field.acroField.getWidgets();
-                widgets.forEach(function (widget) {
-                    const rect = widget.getRectangle();
-                    if (!rect) return;
-
-                    const pageRef = widget.P();
-                    let pageIndex = 0;
-                    if (pageRef) {
-                        const foundIndex = pdfPages.findIndex(function (page) {
-                            return ((page.ref || null) === pageRef);
-                        });
-                        if (foundIndex >= 0) {
-                            pageIndex = foundIndex;
-                        }
-                    }
-                    const pageSize = pageSizes[pageIndex] || pdfPages[pageIndex].getSize();
-                    const normalizedRect = normalizeExistingRect(rect, pageSize);
-                    fields.push({
-                        id: generateId(),
-                        name: field.getName() || getDefaultFieldName(type),
-                        type: type,
-                        pageIndex: pageIndex,
-                        x: normalizedRect.x,
-                        y: normalizedRect.y,
-                        width: normalizedRect.width,
-                        height: normalizedRect.height,
-                        font: getSessionDefault('font'),
-                        fontSize: getSessionDefault('fontSize'),
-                        autoSize: true,
-                        options: Array.isArray(options) ? options.slice() : undefined
-                    });
-                });
-            });
-            return fields;
-        } catch (error) {
-            console.warn('Unable to parse existing PDF fields locally', error);
-            return [];
-        }
-    }
-
-    async function detectExistingFieldsWithServer() {
-        if (!state.pdfBytes) return [];
-        const formData = new FormData();
-        formData.append('file', getPdfFileForRequests());
-        const response = await fetch(apiUrl('/pdf-labeler/api/detect-fields'), {
-            method: 'POST',
-            headers: { 'Accept': 'application/json' },
-            body: formData
-        });
-        const data = await parseApiResponse(response);
-        const importedFields = Array.isArray(data.data && data.data.fields) ? data.data.fields : [];
-        return importedFields.map(function (field) {
-            const pageSize = state.pageSizes[field.pageIndex];
-            const fieldType = normalizeFieldType(field.type);
-            const width = pageSize ? clamp(field.width / pageSize.width, 0.01, 1) : 0.1;
-            const height = pageSize ? clamp(field.height / pageSize.height, 0.01, 1) : 0.03;
-            const x = pageSize ? clamp(field.x / pageSize.width, 0, 1 - width) : 0;
-            const y = pageSize ? clamp(1 - ((field.y + field.height) / pageSize.height), 0, 1 - height) : 0;
-            return {
-                id: generateId(),
-                name: field.name || getDefaultFieldName(fieldType),
-                type: fieldType,
-                pageIndex: field.pageIndex,
-                x: x,
-                y: y,
-                width: width,
-                height: height,
-                font: field.font || getSessionDefault('font'),
-                fontSize: field.fontSize || getSessionDefault('fontSize'),
-                autoSize: field.autoSize !== false,
-                checkboxStyle: field.checkboxStyle || (fieldType === 'checkbox' ? (getSessionDefault('checkboxStyle') || 'cross') : undefined),
-                checkboxExportValue: field.checkboxExportValue || undefined,
-                checkboxBorder: !!field.checkboxBorder,
-                checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
-                options: Array.isArray(field.options) ? field.options.slice() : undefined
-            };
-        });
-    }
-
-    async function runRepairAction(action) {
-        if (!state.pdfBytes) return;
-        var allBtns = repairModal.querySelectorAll('.repair-run-btn');
-        allBtns.forEach(function (b) { b.disabled = true; });
-        repairStatus.className = 'alert alert-info small mb-3';
-        repairStatusText.textContent = 'Running ' + action + '...';
-        repairStatus.classList.remove('hidden');
-
-        try {
-            var formData = new FormData();
-            formData.append('file', getPdfFileForRequests());
-            formData.append('action', action);
-
-            if (action === 'ghostscript_reprint') {
-                var preserve = document.getElementById('repair-gs-preserve').checked;
-                formData.append('preserve_fields', preserve ? 'true' : 'false');
-                var pdfOpt = document.getElementById('repair-gs-optimization').value || 'prepress';
-                formData.append('pdf_optimization', pdfOpt);
-            } else if (action === 'unlock') {
-                var pw = document.getElementById('repair-unlock-pw').value;
-                if (pw) formData.append('password', pw);
-            } else if (action === 'ocr') {
-                var lang = document.getElementById('repair-ocr-lang').value.trim() || 'eng';
-                formData.append('language', lang);
-                var skip = document.getElementById('repair-ocr-skip').checked;
-                formData.append('skip_text', skip ? 'true' : 'false');
-            }
-
-            var response = await fetch(apiUrl('/pdf-labeler/api/repair'), {
-                method: 'POST',
-                headers: { 'Accept': 'application/json' },
-                body: formData
-            });
-            var result = await parseApiResponse(response);
-            if (!result.success) {
-                var errMsg = (result.error && result.error.message) || 'Repair failed.';
-                throw new Error(errMsg);
-            }
-
-            var data = result.data || {};
-            var pdfBase64 = data.pdf_base64;
-            if (!pdfBase64) throw new Error('No repaired PDF was returned.');
-
-            // Decode base64 to Uint8Array
-            var binaryStr = atob(pdfBase64);
-            var bytes = new Uint8Array(binaryStr.length);
-            for (var i = 0; i < binaryStr.length; i++) {
-                bytes[i] = binaryStr.charCodeAt(i);
-            }
-
-            // Reload the repaired PDF into the editor
-            var repairedFile = new File([bytes], data.filename || state.fileName || 'repaired.pdf', { type: 'application/pdf' });
-            repairModal.classList.add('hidden');
-            await loadPdf(repairedFile);
-
-            var repairResult = data.repair_result || {};
-            var summaryParts = [action + ' completed'];
-            if (repairResult.fields_restored) {
-                summaryParts.push(repairResult.fields_restored + ' fields restored');
-            }
-            if (repairResult.appearances_restored) {
-                summaryParts.push(repairResult.appearances_restored + ' appearances restored');
-            }
-            if (repairResult.warnings && repairResult.warnings.length) {
-                summaryParts.push(repairResult.warnings.join('; '));
-            }
-            showSuccess(summaryParts.join('. ') + '.');
-        } catch (err) {
-            repairStatus.className = 'alert alert-danger small mb-3';
-            repairStatusText.textContent = err.message || 'Repair failed.';
-            allBtns.forEach(function (b) { b.disabled = false; });
-        }
-    }
-
-    function getFieldNameHelp(field) {
-        const rawName = String(field.name || '').trim();
-        const normalized = normalizePdfFieldName(rawName);
-        const duplicateExists = state.fields.some(function (candidate) {
-            return candidate.id !== field.id && String(candidate.name || '') === String(field.name || '');
-        });
-
-        if (!rawName) {
-            return {
-                level: 'warning',
-                html: 'Field labels are required.'
-            };
-        }
-        if (duplicateExists) {
-            return {
-                level: 'warning',
-                html: 'Another field already uses this PDF label. Some PDF viewers handle duplicate names unpredictably.'
-            };
-        }
-        if (rawName !== normalized && /[\[\].()]/.test(rawName)) {
-            return {
-                level: 'info',
-                html: 'This looks like DOCX/Jinja syntax. PDFs should use labels like <code>' + escapeHtml(normalized) + '</code>.'
-            };
-        }
-        return {
-            level: 'info',
-            html: 'AssemblyLine PDF labels use underscores and inline list numbers, for example <code>users1_name_full</code>.'
-        };
-    }
-
-    function renderFontOptions(selectedFont) {
-        return FONT_OPTIONS.map(function (font) {
-            return '<option value="' + escapeHtml(font) + '"' + (font === selectedFont ? ' selected' : '') + '>' + escapeHtml(font) + '</option>';
-        }).join('');
-    }
-
-    function ptToNormalizedLength(points, pageIndex, axis) {
-        const pageSize = state.pageSizes[pageIndex] || { width: 612, height: 792 };
-        const dimension = axis === 'x' ? pageSize.width : pageSize.height;
-        return clamp(Number(points) / dimension, 0.001, 1);
-    }
-
-    function looksLikeNameOrAddressField(fieldName) {
-        return /(name|address|street|city|state|zip|postal|phone|phone_number|email|cell)/i.test(String(fieldName || ''));
-    }
-
-    function isYesNoOption(optionLabel) {
-        const normalized = String(optionLabel || '').trim().toLowerCase();
-        return normalized === 'yes' || normalized === 'true' || normalized === 'no' || normalized === 'false';
-    }
-
-    function getRadioOptionSuffixes(options) {
-        const normalized = options.map(function (option) {
-            return String(option || '').trim().toLowerCase();
-        });
-        if (normalized.length === 2) {
-            const yesIndex = normalized.findIndex(function (option) {
-                return option === 'yes' || option === 'true';
-            });
-            const noIndex = normalized.findIndex(function (option) {
-                return option === 'no' || option === 'false';
-            });
-            if (yesIndex >= 0 && noIndex >= 0) {
-                return normalized.map(function (_option, index) {
-                    return index === yesIndex ? 'yes' : 'no';
-                });
-            }
-        }
-        return normalized.map(function (_option, index) {
-            return index === 0 ? 'opt' : ('opt' + String(index + 1));
-        });
-    }
-
-    function dedupeNormalizedFieldNames(fields) {
-        const used = new Set();
-        return fields.map(function (field) {
-            const updated = Object.assign({}, field);
-            const baseName = normalizePdfFieldName(updated.name);
-            let candidate = baseName;
-            let suffix = 1;
-            while (used.has(candidate)) {
-                candidate = baseName + '__' + suffix;
-                suffix += 1;
-            }
-            used.add(candidate);
-            updated.name = candidate;
-            return updated;
-        });
-    }
-
-    function alignFieldsByRow(fields, thresholdPoints) {
-        const groupedByPage = {};
-        fields.forEach(function (field) {
-            if (!(field.type === 'text' || field.type === 'multiline' || field.type === 'checkbox')) return;
-            if (!groupedByPage[field.pageIndex]) {
-                groupedByPage[field.pageIndex] = [];
-            }
-            groupedByPage[field.pageIndex].push(field);
-        });
-
-        Object.keys(groupedByPage).forEach(function (pageKey) {
-            const pageIndex = Number(pageKey);
-            const threshold = ptToNormalizedLength(thresholdPoints, pageIndex, 'y');
-            const pageFields = groupedByPage[pageKey].slice().sort(function (left, right) {
-                return (left.y + (left.height / 2)) - (right.y + (right.height / 2));
-            });
-            let cluster = [];
-            pageFields.forEach(function (field) {
-                const centerY = field.y + (field.height / 2);
-                if (!cluster.length) {
-                    cluster = [field];
-                    return;
-                }
-                const clusterCenter = cluster.reduce(function (sum, item) {
-                    return sum + item.y + (item.height / 2);
-                }, 0) / cluster.length;
-                if (Math.abs(centerY - clusterCenter) <= threshold) {
-                    cluster.push(field);
-                    return;
-                }
-                if (cluster.length > 1) {
-                    const targetCenter = cluster.reduce(function (sum, item) {
-                        return sum + item.y + (item.height / 2);
-                    }, 0) / cluster.length;
-                    cluster.forEach(function (item) {
-                        item.y = clamp(targetCenter - (item.height / 2), 0, 1 - item.height);
-                    });
-                }
-                cluster = [field];
-            });
-            if (cluster.length > 1) {
-                const targetCenter = cluster.reduce(function (sum, item) {
-                    return sum + item.y + (item.height / 2);
-                }, 0) / cluster.length;
-                cluster.forEach(function (item) {
-                    item.y = clamp(targetCenter - (item.height / 2), 0, 1 - item.height);
-                });
-            }
-        });
-    }
-
-    function alignFieldsByColumn(fields, thresholdPoints) {
-        const groupedByPage = {};
-        fields.forEach(function (field) {
-            if (!(field.type === 'text' || field.type === 'multiline' || field.type === 'checkbox')) return;
-            if (!groupedByPage[field.pageIndex]) {
-                groupedByPage[field.pageIndex] = [];
-            }
-            groupedByPage[field.pageIndex].push(field);
-        });
-
-        Object.keys(groupedByPage).forEach(function (pageKey) {
-            const pageIndex = Number(pageKey);
-            const threshold = ptToNormalizedLength(thresholdPoints, pageIndex, 'x');
-            const pageFields = groupedByPage[pageKey].slice().sort(function (left, right) {
-                return left.x - right.x;
-            });
-            let cluster = [];
-            pageFields.forEach(function (field) {
-                if (!cluster.length) {
-                    cluster = [field];
-                    return;
-                }
-                const clusterLeft = cluster.reduce(function (sum, item) {
-                    return sum + item.x;
-                }, 0) / cluster.length;
-                if (Math.abs(field.x - clusterLeft) <= threshold) {
-                    cluster.push(field);
-                    return;
-                }
-                if (cluster.length > 1) {
-                    var targetLeft = cluster.reduce(function (sum, item) {
-                        return sum + item.x;
-                    }, 0) / cluster.length;
-                    cluster.forEach(function (item) {
-                        item.x = clamp(targetLeft, 0, 1 - item.width);
-                    });
-                }
-                cluster = [field];
-            });
-            if (cluster.length > 1) {
-                var targetLeft = cluster.reduce(function (sum, item) {
-                    return sum + item.x;
-                }, 0) / cluster.length;
-                cluster.forEach(function (item) {
-                    item.x = clamp(targetLeft, 0, 1 - item.width);
-                });
-            }
-        });
-    }
-
-    function readNormalizationSettings() {
-        return {
-            normalizeCheckboxStyle: document.getElementById('norm-checkbox-style-enable').checked,
-            checkboxStyle: document.getElementById('norm-checkbox-style').value || '',
-            checkboxExportValue: String(document.getElementById('norm-checkbox-export-value').value || '').trim() || 'Yes',
-            uniformCheckboxSize: document.getElementById('norm-checkbox-uniform').checked,
-            checkboxSizePt: Number(document.getElementById('norm-checkbox-size').value || 12),
-            normalizeFont: document.getElementById('norm-font-normalize').checked,
-            normalizeFontSize: document.getElementById('norm-fontsize-normalize').checked,
-            fontName: document.getElementById('norm-font-name').value || getSessionDefault('font'),
-            fontSizePt: Number(document.getElementById('norm-font-size').value || getSessionDefault('fontSize')),
-            dropdownsToText: document.getElementById('norm-dropdowns-to-text').checked,
-            radiosToCheckboxes: document.getElementById('norm-radios-to-checkboxes').checked,
-            alignRows: document.getElementById('norm-align-rows').checked,
-            alignThresholdPt: Number(document.getElementById('norm-align-threshold').value || 6),
-            alignColumns: document.getElementById('norm-align-columns').checked,
-            alignColumnThresholdPt: Number(document.getElementById('norm-align-col-threshold').value || 6),
-            autoSizeNameAddress: document.getElementById('norm-autosize-name-address').checked,
-            fixedTextHeightPt: Number(document.getElementById('norm-text-height').value || 14),
-            disableAutoScroll: document.getElementById('norm-disable-scroll').checked,
-            multilineTallFields: document.getElementById('norm-multiline-tall').checked,
-            multilineThresholdLines: Number(document.getElementById('norm-multiline-lines').value || 2.2),
-            multilineWhiteBackground: document.getElementById('norm-multiline-white').checked,
-            removeEmbeddedFonts: document.getElementById('norm-remove-embedded-fonts').checked,
-            lowercaseNames: document.getElementById('norm-lowercase-names').checked
-        };
-    }
-
-    function buildNormalizedFields(settings) {
-        const transformed = [];
-        state.fields.forEach(function (field) {
-            const nextField = Object.assign({}, field);
-            nextField.font = nextField.font || getSessionDefault('font');
-            nextField.fontSize = Number(nextField.fontSize) || getSessionDefault('fontSize');
-
-            if (settings.dropdownsToText && nextField.type === 'dropdown') {
-                nextField.type = 'text';
-                delete nextField.options;
-            }
-
-            if (settings.radiosToCheckboxes && nextField.type === 'radio') {
-                const options = Array.isArray(nextField.options) && nextField.options.length
-                    ? nextField.options.slice()
-                    : ['Yes', 'No'];
-                const suffixes = getRadioOptionSuffixes(options);
-                const boxWidth = ptToNormalizedLength(settings.checkboxSizePt, nextField.pageIndex, 'x');
-                const boxHeight = ptToNormalizedLength(settings.checkboxSizePt, nextField.pageIndex, 'y');
-                const gap = ptToNormalizedLength(Math.max(4, settings.checkboxSizePt * 0.35), nextField.pageIndex, 'x');
-                const totalWidth = (options.length * boxWidth) + ((options.length - 1) * gap);
-                const startX = clamp(nextField.x + Math.max(0, (nextField.width - totalWidth) / 2), 0, 1 - boxWidth);
-                const targetY = clamp((nextField.y + (nextField.height / 2)) - (boxHeight / 2), 0, 1 - boxHeight);
-                const baseName = normalizePdfFieldName(nextField.name);
-                options.forEach(function (_option, index) {
-                    transformed.push({
-                        id: generateId(),
-                        name: baseName + '_' + suffixes[index],
-                        type: 'checkbox',
-                        pageIndex: nextField.pageIndex,
-                        x: clamp(startX + (index * (boxWidth + gap)), 0, 1 - boxWidth),
-                        y: targetY,
-                        width: boxWidth,
-                        height: boxHeight,
-                        font: settings.normalizeFont ? settings.fontName : nextField.font,
-                        fontSize: settings.normalizeFontSize ? settings.fontSizePt : nextField.fontSize,
-                        autoSize: false,
-                        checkboxStyle: (settings.normalizeCheckboxStyle && settings.checkboxStyle) || nextField.checkboxStyle || 'cross',
-                        checkboxExportValue: (settings.normalizeCheckboxStyle && settings.checkboxExportValue) || nextField.checkboxExportValue || 'Yes',
-                        allowScroll: false
-                    });
-                });
-                return;
-            }
-
-            if (settings.normalizeFont && (nextField.type === 'text' || nextField.type === 'multiline' || nextField.type === 'signature')) {
-                nextField.font = settings.fontName;
-            }
-            if (settings.normalizeFontSize && (nextField.type === 'text' || nextField.type === 'multiline' || nextField.type === 'signature')) {
-                nextField.fontSize = settings.fontSizePt;
-            }
-
-            if (settings.normalizeCheckboxStyle && nextField.type === 'checkbox' && settings.checkboxStyle) {
-                nextField.checkboxStyle = settings.checkboxStyle;
-            }
-
-            if (settings.normalizeCheckboxStyle && nextField.type === 'checkbox' && settings.checkboxExportValue) {
-                nextField.checkboxExportValue = settings.checkboxExportValue;
-            }
-
-            if (settings.uniformCheckboxSize && nextField.type === 'checkbox') {
-                nextField.width = ptToNormalizedLength(settings.checkboxSizePt, nextField.pageIndex, 'x');
-                nextField.height = ptToNormalizedLength(settings.checkboxSizePt, nextField.pageIndex, 'y');
-            }
-
-            if (settings.disableAutoScroll && (nextField.type === 'text' || nextField.type === 'multiline')) {
-                nextField.allowScroll = false;
-            }
-
-            if (nextField.type === 'text' || nextField.type === 'multiline') {
-                nextField.autoSize = false;
-            }
-
-            if (!settings.normalizeFontSize && settings.autoSizeNameAddress && nextField.type === 'text' && looksLikeNameOrAddressField(nextField.name)) {
-                nextField.autoSize = true;
-            }
-            if (settings.autoSizeNameAddress && nextField.type === 'text' && looksLikeNameOrAddressField(nextField.name)) {
-                nextField.height = ptToNormalizedLength(settings.fixedTextHeightPt, nextField.pageIndex, 'y');
-            }
-
-            if (settings.multilineTallFields && nextField.type === 'text') {
-                const lineHeightPt = settings.fontSizePt * 1.2;
-                const fieldHeightPt = nextField.height * (state.pageSizes[nextField.pageIndex] ? state.pageSizes[nextField.pageIndex].height : 792);
-                if ((fieldHeightPt / lineHeightPt) >= settings.multilineThresholdLines) {
-                    nextField.type = 'multiline';
-                }
-            }
-
-            if (settings.multilineWhiteBackground && nextField.type === 'multiline') {
-                nextField.backgroundColor = '#ffffff';
-            }
-
-            transformed.push(nextField);
-        });
-
-        if (settings.alignRows) {
-            alignFieldsByRow(transformed, settings.alignThresholdPt);
-        }
-        if (settings.alignColumns) {
-            alignFieldsByColumn(transformed, settings.alignColumnThresholdPt);
-        }
-        if (settings.lowercaseNames) {
-            transformed.forEach(function (field) { field.name = field.name.toLowerCase(); });
-        }
-        return dedupeNormalizedFieldNames(transformed);
-    }
-
-    function renderFieldEditor(field) {
-        const meta = getFieldTypeMeta(field.type);
-        const nameHelp = getFieldNameHelp(field);
-        const optionsValue = Array.isArray(field.options) && field.options.length
-            ? field.options.join(', ')
-            : DEFAULT_OPTION_LIST.join(', ');
-        const isTextLike = field.type === 'text' || field.type === 'multiline';
-        const autoSize = field.autoSize !== false;
-        return '' +
-            '<div class="field-card-editor">' +
-                '<div class="d-flex align-items-center justify-content-between gap-2 mb-3">' +
-                    '<div class="field-type-badge">' + meta.icon + '<span>' + escapeHtml(meta.label) + '</span></div>' +
-                    '<div class="field-card-subtext">Editing selected field</div>' +
-                '</div>' +
-                '<div class="mb-3">' +
-                    '<label class="form-label small text-muted fw-semibold mb-1" for="field-name-' + escapeHtml(field.id) + '">PDF field label</label>' +
-                    '<div class="d-flex gap-2">' +
-                        '<input type="text" id="field-name-' + escapeHtml(field.id) + '" class="form-control form-control-sm font-monospace" data-action="field-name" data-field-id="' + escapeHtml(field.id) + '" value="' + escapeHtml(field.name) + '">' +
-                        '<button type="button" class="btn btn-outline-secondary btn-sm" data-action="normalize-name" data-field-id="' + escapeHtml(field.id) + '">Normalize</button>' +
-                    '</div>' +
-                    '<div class="field-card-help ' + escapeHtml(nameHelp.level) + '">' + nameHelp.html + '</div>' +
-                '</div>' +
-                '<div class="mb-3">' +
-                    '<label class="form-label small text-muted fw-semibold mb-1" for="field-type-' + escapeHtml(field.id) + '">Field type</label>' +
-                    '<select id="field-type-' + escapeHtml(field.id) + '" class="form-select form-select-sm" data-action="field-type" data-field-id="' + escapeHtml(field.id) + '">' +
-                        '<option value="text"' + (field.type === 'text' ? ' selected' : '') + '>Single-line Text</option>' +
-                        '<option value="multiline"' + (field.type === 'multiline' ? ' selected' : '') + '>Multi-line Text</option>' +
-                        '<option value="checkbox"' + (field.type === 'checkbox' ? ' selected' : '') + '>Checkbox</option>' +
-                        '<option value="signature"' + (field.type === 'signature' ? ' selected' : '') + '>Signature</option>' +
-                        '<option value="radio"' + (field.type === 'radio' ? ' selected' : '') + '>Radio Group</option>' +
-                        '<option value="dropdown"' + (field.type === 'dropdown' ? ' selected' : '') + '>Dropdown</option>' +
-                        '<option value="listbox"' + (field.type === 'listbox' ? ' selected' : '') + '>List Box</option>' +
-                    '</select>' +
-                '</div>' +
-                (isTextLike
-                    ? '<div class="mb-3">' +
-                        '<label class="form-label small text-muted fw-semibold mb-1">Font and size</label>' +
-                        '<div class="font-row">' +
-                            '<div>' +
-                                '<select class="form-select form-select-sm" data-action="field-font" data-field-id="' + escapeHtml(field.id) + '">' +
-                                    renderFontOptions(field.font || getSessionDefault('font')) +
-                                '</select>' +
-                            '</div>' +
-                            '<label class="auto-size-wrap form-check small mb-0 mt-1">' +
-                                '<input class="form-check-input" type="checkbox" data-action="field-auto-size" data-field-id="' + escapeHtml(field.id) + '"' + (autoSize ? ' checked' : '') + '>' +
-                                '<span class="form-check-label">Auto size</span>' +
-                            '</label>' +
-                            '<div>' +
-                                '<input type="number" min="4" max="72" step="1" class="form-control form-control-sm" data-action="field-font-size" data-field-id="' + escapeHtml(field.id) + '" value="' + escapeHtml(String(field.fontSize || getSessionDefault('fontSize'))) + '"' + (autoSize ? ' disabled' : '') + '>' +
-                            '</div>' +
-                        '</div>' +
-                    '</div>'
-                    : '') +
-                (field.type === 'checkbox'
-                    ? '<div class="mb-3">' +
-                        '<label class="form-label small text-muted fw-semibold mb-1">Checkbox settings</label>' +
-                        '<div class="normalization-inline-2">' +
-                            '<div>' +
-                                '<label class="form-label small text-muted mb-1" for="field-checkbox-style-' + escapeHtml(field.id) + '">Style</label>' +
-                                '<select id="field-checkbox-style-' + escapeHtml(field.id) + '" class="form-select form-select-sm" data-action="field-checkbox-style" data-field-id="' + escapeHtml(field.id) + '">' +
-                                    '<option value="cross"' + ((field.checkboxStyle || 'cross') === 'cross' ? ' selected' : '') + '>Cross</option>' +
-                                    '<option value="check"' + ((field.checkboxStyle || 'cross') === 'check' ? ' selected' : '') + '>Check</option>' +
-                                    '<option value="circle"' + (field.checkboxStyle === 'circle' ? ' selected' : '') + '>Circle</option>' +
-                                    '<option value="star"' + (field.checkboxStyle === 'star' ? ' selected' : '') + '>Star</option>' +
-                                    '<option value="diamond"' + (field.checkboxStyle === 'diamond' ? ' selected' : '') + '>Diamond</option>' +
-                                    '<option value="square"' + (field.checkboxStyle === 'square' ? ' selected' : '') + '>Square</option>' +
-                                '</select>' +
-                            '</div>' +
-                            '<div>' +
-                                '<label class="form-label small text-muted mb-1" for="field-checkbox-export-value-' + escapeHtml(field.id) + '">Export value</label>' +
-                                '<input id="field-checkbox-export-value-' + escapeHtml(field.id) + '" type="text" class="form-control form-control-sm font-monospace" data-action="field-checkbox-export-value" data-field-id="' + escapeHtml(field.id) + '" value="' + escapeHtml(String(field.checkboxExportValue || 'Yes')) + '">' +
-                            '</div>' +
-                            '<label class="form-check small mb-0 align-self-end">' +
-                                '<input class="form-check-input" type="checkbox" data-action="field-checkbox-border" data-field-id="' + escapeHtml(field.id) + '"' + (field.checkboxBorder ? ' checked' : '') + '>' +
-                                '<span class="form-check-label">Border</span>' +
-                            '</label>' +
-                            '<div>' +
-                                '<label class="form-label small text-muted mb-1" for="field-checkbox-border-width-' + escapeHtml(field.id) + '">Border width</label>' +
-                                '<select id="field-checkbox-border-width-' + escapeHtml(field.id) + '" class="form-select form-select-sm" data-action="field-checkbox-border-width" data-field-id="' + escapeHtml(field.id) + '"' + (field.checkboxBorder ? '' : ' disabled') + '>' +
-                                    '<option value="thin"' + ((field.checkboxBorderWidth || 'thin') === 'thin' ? ' selected' : '') + '>Thin</option>' +
-                                    '<option value="medium"' + (field.checkboxBorderWidth === 'medium' ? ' selected' : '') + '>Medium</option>' +
-                                    '<option value="thick"' + (field.checkboxBorderWidth === 'thick' ? ' selected' : '') + '>Thick</option>' +
-                                '</select>' +
-                            '</div>' +
-                        '</div>' +
-                    '</div>'
-                    : '') +
-                (OPTION_TYPES.has(field.type)
-                    ? '<div class="mb-3">' +
-                        '<label class="form-label small text-muted fw-semibold mb-1" for="field-options-' + escapeHtml(field.id) + '">Options</label>' +
-                        '<textarea id="field-options-' + escapeHtml(field.id) + '" rows="3" class="form-control form-control-sm" data-action="field-options" data-field-id="' + escapeHtml(field.id) + '">' + escapeHtml(optionsValue) + '</textarea>' +
-                        '<div class="form-text small">Separate each option with a comma.</div>' +
-                    '</div>'
-                    : '') +
-                '<div class="field-card-actions">' +
-                    '<button type="button" class="btn btn-outline-secondary btn-sm" data-action="duplicate-field" data-field-id="' + escapeHtml(field.id) + '">Duplicate</button>' +
-                    '<button type="button" class="btn btn-outline-danger btn-sm" data-action="delete-field" data-field-id="' + escapeHtml(field.id) + '">Delete</button>' +
-                    '<select class="form-select form-select-sm d-inline-block w-auto ms-1" data-action="move-field-page" data-field-id="' + escapeHtml(field.id) + '" aria-label="Move to page">' +
-                        '<option value="">Move to page...</option>' +
-                        Array.apply(null, Array(state.pageCount)).map(function (_, i) { return '<option value="' + i + '"' + (field.pageIndex === i ? ' disabled' : '') + '>Page ' + (i + 1) + '</option>'; }).join('') +
-                    '</select>' +
-                '</div>' +
-            '</div>';
-    }
-
-    function renderFieldsList() {
-        updateBulkRenameUiState();
-        updateFieldCount();
-        if (state.fields.length === 0) {
-            fieldsList.innerHTML = '';
-            return;
-        }
-        const showPageGroups = state.pageCount > 1 && state.fieldSort === 'position';
-        const orderedFields = getDisplayedFields();
-        const renamePreview = state.fieldsPanelMode === 'rename' ? getBulkRenamePreview() : null;
-        fieldsList.innerHTML = '';
-        if (orderedFields.length === 0) {
-            fieldsList.innerHTML = '<div class="text-muted small px-1 py-2">No fields match the current filter.</div>';
-            return;
-        }
-        const fragment = document.createDocumentFragment();
-        let currentGroup = null;
-        let currentPage = null;
-
-        orderedFields.forEach(function (field) {
-            const meta = getFieldTypeMeta(field.type);
-            if (!currentGroup || (showPageGroups && currentPage !== field.pageIndex)) {
-                currentPage = field.pageIndex;
-                currentGroup = document.createElement('section');
-                currentGroup.className = 'field-list-page';
-                if (showPageGroups) {
-                    currentGroup.dataset.pageIndex = String(field.pageIndex);
-                }
-                if (showPageGroups) {
-                    const divider = document.createElement('div');
-                    divider.className = 'field-page-divider';
-                    divider.textContent = 'Page ' + (field.pageIndex + 1);
-                    currentGroup.appendChild(divider);
-                }
-                fragment.appendChild(currentGroup);
-            }
-            const item = document.createElement('div');
-            item.className = 'field-list-item' + (field.id === state.selectedFieldId ? ' selected' : '');
-            item.dataset.fieldId = field.id;
-            const renameChange = renamePreview ? renamePreview.renamedById.get(field.id) : null;
-            const displayNameHtml = renameChange
-                ? (
-                    '<div class="field-list-name field-list-name-preview" title="' + escapeHtml(renameChange.oldName + ' -> ' + renameChange.newName) + '">' +
-                        '<span class="rename-old">' + escapeHtml(renameChange.oldName) + '</span>' +
-                        '<span class="rename-arrow">-></span>' +
-                        '<span class="rename-new">' + escapeHtml(renameChange.newName) + '</span>' +
-                    '</div>'
-                )
-                : ('<div class="field-list-name" title="' + escapeHtml(field.name) + '">' + escapeHtml(field.name) + '</div>');
-            item.innerHTML =
-                '<div class="field-list-row">' +
-                    '<div class="field-list-icon" aria-hidden="true">' + meta.icon + '</div>' +
-                    displayNameHtml +
-                '</div>' +
-                (field.id === state.selectedFieldId ? renderFieldEditor(field) : '');
-            item.addEventListener('click', function (event) {
-                if (event.target.closest('input, select, textarea, button')) {
-                    return;
-                }
-                selectField(field.id, { focusNameInput: false, scrollIntoView: true });
-            });
-            item.querySelectorAll('input, select, textarea').forEach(function (control) {
-                control.addEventListener('click', function (event) {
-                    event.stopPropagation();
-                });
-            });
-            currentGroup.appendChild(item);
-        });
-        fieldsList.appendChild(fragment);
-    }
-
-    function renderDraftRect() {
-        document.querySelectorAll('.draft-rect').forEach(function (node) { node.remove(); });
-        if (!draftState) return;
-        const overlay = getOverlayForPage(draftState.pageIndex);
-        if (!overlay) return;
-        const draftRect = document.createElement('div');
-        draftRect.className = 'draft-rect';
-        draftRect.style.left = (Math.min(draftState.startX, draftState.currentX) * 100) + '%';
-        draftRect.style.top = (Math.min(draftState.startY, draftState.currentY) * 100) + '%';
-        draftRect.style.width = (Math.abs(draftState.currentX - draftState.startX) * 100) + '%';
-        draftRect.style.height = (Math.abs(draftState.currentY - draftState.startY) * 100) + '%';
-        overlay.appendChild(draftRect);
-    }
-
-    function getFieldBoxClasses(field) {
-        return 'field-box' + (field.id === state.selectedFieldId ? ' selected' : '');
-    }
-
-    function applyFieldChipLayout(fieldEl, labelEl) {
-        const width = fieldEl.offsetWidth;
-        const height = fieldEl.offsetHeight;
-        labelEl.classList.remove('hide-name', 'icon-only', 'wrap-name', 'compact');
-
-        if (width < 20 || height < 11) {
-            labelEl.classList.add('hide-name', 'icon-only');
-            return;
-        }
-
-        if (width < 34) {
-            labelEl.classList.add('hide-name', 'icon-only');
-            return;
-        }
-
-        if (height < 16) {
-            if (width >= 60) {
-                labelEl.classList.add('compact');
-                return;
-            }
-            labelEl.classList.add('hide-name', 'icon-only');
-            return;
-        }
-
-        if (width >= 96 && height >= 24) {
-            labelEl.classList.add('wrap-name');
-        }
-    }
-
-    function renderFieldsOnPages() {
-        document.querySelectorAll('.field-box').forEach(function (node) {
-            node.remove();
-        });
-        state.fields.forEach(function (field) {
-            const overlay = getOverlayForPage(field.pageIndex);
-            if (!overlay) return;
-
-            const meta = getFieldTypeMeta(field.type);
-            const fieldEl = document.createElement('div');
-            fieldEl.className = getFieldBoxClasses(field);
-            fieldEl.dataset.fieldId = field.id;
-            fieldEl.dataset.fieldType = field.type;
-            fieldEl.style.left = (field.x * 100) + '%';
-            fieldEl.style.top = (field.y * 100) + '%';
-            fieldEl.style.width = (field.width * 100) + '%';
-            fieldEl.style.height = (field.height * 100) + '%';
-            if (field.backgroundColor) {
-                fieldEl.style.background = field.backgroundColor;
-            }
-
-            const label = document.createElement('div');
-            label.className = 'field-chip';
-            label.innerHTML =
-                meta.icon +
-                '<span class="field-chip-name">' + escapeHtml(field.name) + '</span>';
-            fieldEl.appendChild(label);
-
-            // --- Preview mode content ---
-            if (state.previewMode) {
-                fieldEl.classList.add('previewing');
-                var previewDiv = document.createElement('div');
-                previewDiv.className = 'field-preview-content';
-
-                if (field.type === 'checkbox' || field.type === 'radio') {
-                    previewDiv.classList.add('preview-checkbox');
-                    var glyph = CHECKBOX_PREVIEW_GLYPHS[field.checkboxStyle || getSessionDefault('checkboxStyle')] || '\u2713';
-                    previewDiv.textContent = glyph;
-                    // Scale the glyph to fit the box
-                    var overlayEl = getOverlayForPage(field.pageIndex);
-                    var boxPx = overlayEl ? Math.min(field.width * overlayEl.offsetWidth, field.height * overlayEl.offsetHeight) : 20;
-                    previewDiv.style.fontSize = Math.max(8, boxPx * 0.8) + 'px';
-                    previewDiv.style.lineHeight = '1';
-                    previewDiv.style.color = '#000';
-                    if (field.checkboxBorder) {
-                        var borderWidths = { thin: 1, medium: 2, thick: 3 };
-                        previewDiv.style.border = (borderWidths[field.checkboxBorderWidth || 'thin'] || 1) + 'px solid #000';
-                    }
-                } else if (field.type === 'signature') {
-                    previewDiv.classList.add('preview-signature');
-                    if (_signatureDataUrl) {
-                        var sigImg = document.createElement('img');
-                        sigImg.src = _signatureDataUrl;
-                        sigImg.alt = 'Signature preview';
-                        previewDiv.appendChild(sigImg);
-                    }
-                } else {
-                    // text, multiline, dropdown, listbox — render the field name
-                    var css = pdfFontToCss(field.font || getSessionDefault('font'));
-                    var ptSize = field.fontSize || getSessionDefault('fontSize') || 10;
-                    // 1 PDF pt = renderScale CSS px on the scaled canvas overlay
-                    var pxSize = ptSize * getViewerRenderScale();
-                    previewDiv.style.fontFamily = css.family;
-                    previewDiv.style.fontWeight = css.weight;
-                    previewDiv.style.lineHeight = '1.15';
-                    previewDiv.style.color = '#000';
-                    previewDiv.style.whiteSpace = field.type === 'multiline' ? 'pre-wrap' : 'nowrap';
-                    previewDiv.textContent = field.name || '';
-
-                    // Apply auto-sizing: adjust font to fit field dimensions
-                    if (field.autoSize && field.name && field.type === 'text') {
-                        var pageSize = state.pageSizes[field.pageIndex] || { width: 612, height: 792 };
-                        var fieldWidthPx = field.width * (pageSize.width * getViewerRenderScale());
-                        var fieldHeightPx = field.height * (pageSize.height * getViewerRenderScale());
-                        
-                        // Max font size based on field height (single-line text, ~15% padding)
-                        var maxPxSize = fieldHeightPx * 0.85 / 1.15;  // Account for line-height
-                        
-                        // PDF auto-size derives its starting size from the widget height.
-                        pxSize = maxPxSize;
-                        
-                        // Now check if text width fits; scale down if needed
-                        var fontStr = css.weight + ' ' + Math.round(pxSize) + 'px ' + css.family;
-                        var canvas = document.createElement('canvas');
-                        var ctx = canvas.getContext('2d');
-                        if (ctx) {
-                            ctx.font = fontStr;
-                            var textWidth = ctx.measureText(previewDiv.textContent).width;
-                            var padding = 4;  // Left/right padding in PDF viewer
-                            
-                            // Scale down if text exceeds field width
-                            if (textWidth + padding > fieldWidthPx && textWidth > 0) {
-                                pxSize = pxSize * (fieldWidthPx - padding) / textWidth;
-                            }
-                        }
-                    }
-
-                    previewDiv.style.fontSize = pxSize + 'px';
-                }
-                fieldEl.appendChild(previewDiv);
-            }
-
-            if (field.id === state.selectedFieldId) {
-                ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'].forEach(function (handleName) {
-                    const handle = document.createElement('div');
-                    handle.className = 'resize-handle ' + handleName;
-                    handle.dataset.handle = handleName;
-                    fieldEl.appendChild(handle);
-                });
-            }
-
-            fieldEl.addEventListener('pointerdown', function (event) {
-                event.stopPropagation();
-                setSelectedTool(null);
-
-                const target = event.target;
-                if (target && target.dataset && target.dataset.handle) {
-                    selectField(field.id, { focusNameInput: false, scrollIntoView: false });
-                    startResize(field.id, target.dataset.handle, event, overlay);
-                    return;
-                }
-                startDrag(field.id, event, overlay);
-            });
-
-            fieldEl.addEventListener('click', function (event) {
-                const target = event.target;
-                if (target && target.dataset && target.dataset.handle) {
-                    return;
-                }
-                event.stopPropagation();
-                // First click selects (handles only); second click on
-                // already-selected field opens the quick editor.
-                if (state.selectedFieldId === field.id) {
-                    selectField(field.id, { focusNameInput: true, scrollIntoView: false });
-                } else {
-                    selectField(field.id, { focusNameInput: false, scrollIntoView: false });
-                }
-            });
-
-            fieldEl.addEventListener('dblclick', function (event) {
-                event.stopPropagation();
-                selectField(field.id, { focusNameInput: true, scrollIntoView: false });
-            });
-
-            overlay.appendChild(fieldEl);
-            applyFieldChipLayout(fieldEl, label);
-        });
-        renderDraftRect();
-        syncQuickFieldEditor({ preserveInput: true });
-    }
-
-    function selectField(fieldId, options) {
-        const settings = options || {};
-        state.selectedFieldId = fieldId;
-        if (!fieldId) {
-            hideQuickFieldEditor();
-        } else if (settings.focusNameInput) {
-            state.quickEditFieldId = fieldId;
-            state.quickEditFocusPending = true;
-        } else if (state.quickEditFieldId && state.quickEditFieldId !== fieldId) {
-            hideQuickFieldEditor();
-        }
-        renderFieldsList();
-        renderFieldsOnPages();
-        if (fieldId && settings.scrollIntoView) {
-            const fieldEl = document.querySelector('.field-box[data-field-id="' + fieldId + '"]');
-            if (fieldEl) {
-                fieldEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }
-        }
-        if (fieldId) {
-            scrollSelectedFieldIntoView(fieldId);
-        }
-        syncQuickFieldEditor({ preserveInput: true });
-    }
-
-    function replaceFields(fields, options) {
-        const settings = options || {};
-        state.fields = fields.map(function (field) {
-            const width = clamp(Number(field.width), 0.01, 1);
-            const height = clamp(Number(field.height), 0.01, 1);
-            return {
-                id: field.id || generateId(),
-                name: field.name,
-                type: normalizeFieldType(field.type),
-                pageIndex: Number(field.pageIndex) || 0,
-                x: clamp(Number(field.x), 0, 1 - width),
-                y: clamp(Number(field.y), 0, 1 - height),
-                width: width,
-                height: height,
-                font: field.font || getSessionDefault('font'),
-                fontSize: Number(field.fontSize) || getSessionDefault('fontSize'),
-                autoSize: field.autoSize !== false,
-                checkboxStyle: field.checkboxStyle || undefined,
-                checkboxExportValue: field.checkboxExportValue || undefined,
-                checkboxBorder: !!field.checkboxBorder,
-                checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
-                allowScroll: field.allowScroll !== false,
-                backgroundColor: field.backgroundColor || undefined,
-                options: Array.isArray(field.options) ? field.options.slice() : undefined,
-                tooltip: String(field.tooltip || '').trim()
-            };
-        });
-        refreshAccessibilityFromFields();
-        bumpFieldNamesVersion();
-        state.selectedFieldId = settings.preserveSelection && state.fields.some(function (field) {
-            return field.id === state.selectedFieldId;
-        }) ? state.selectedFieldId : (state.fields[0] ? state.fields[0].id : null);
-        if (!state.fields.some(function (field) { return field.id === state.quickEditFieldId; })) {
-            hideQuickFieldEditor();
-        }
-        renderFieldsList();
-        renderFieldsOnPages();
-        updateFieldCount();
-    }
-
-    function markDirtyAndRender(skipListRefresh) {
-        setDirty(true);
-        renderFieldsOnPages();
-        if (!skipListRefresh) {
-            renderFieldsList();
-        }
-        updateFieldCount();
-        syncQuickFieldEditor({ preserveInput: true });
-    }
-
-    function createFieldFromTool(pageIndex, x, y, width, height) {
-        if (!state.selectedTool) return;
-        const type = normalizeFieldType(state.selectedTool);
-        const rect = {
-            x: clamp(x, 0, 1 - clamp(width, 0.01, 1)),
-            y: clamp(y, 0, 1 - clamp(height, 0.01, 1)),
-            width: clamp(width, 0.01, 1),
-            height: clamp(height, 0.01, 1)
-        };
-        const nameSuggestions = buildFieldNameSuggestions(pageIndex, rect, type, null);
-        const field = {
-            id: generateId(),
-            name: nameSuggestions[0] ? nameSuggestions[0].name : getDefaultFieldName(type),
-            type: type,
-            pageIndex: pageIndex,
-            x: 0,
-            y: 0,
-            width: rect.width,
-            height: rect.height,
-            font: getSessionDefault('font'),
-            fontSize: getSessionDefault('fontSize'),
-            autoSize: type === 'text' && looksLikeSingleLineAutoSizeField(
-                nameSuggestions[0] ? nameSuggestions[0].name : getDefaultFieldName(type)
-            ),
-            checkboxStyle: type === 'checkbox' ? (getSessionDefault('checkboxStyle') || 'cross') : undefined,
-            checkboxExportValue: type === 'checkbox' ? getSessionDefault('checkboxExportValue') : undefined,
-            checkboxBorder: false,
-            checkboxBorderWidth: 'thin',
-            options: OPTION_TYPES.has(type) ? DEFAULT_OPTION_LIST.slice() : undefined,
-            nameSuggestions: nameSuggestions,
-            tooltip: ''
-        };
-        field.x = rect.x;
-        field.y = rect.y;
-        ensureFieldAccessibilityDefaults(field);
-        state.fields.push(field);
-        reconcileAccessibilityFieldOrder();
-        bumpFieldNamesVersion();
-        selectField(field.id, { focusNameInput: true, scrollIntoView: false });
-        setDirty(true);
-        updateFieldCount();
-        renderFieldsList();
-        renderFieldsOnPages();
-    }
-
-    function createPointField(pageIndex, pointX, pointY) {
-        const meta = getFieldTypeMeta(state.selectedTool);
-        const width = meta.defaultWidth || 0.032;
-        const height = meta.defaultHeight || 0.032;
-        const x = clamp(pointX - (width / 2), 0, 1 - width);
-        const y = clamp(pointY - (height / 2), 0, 1 - height);
-        createFieldFromTool(pageIndex, x, y, width, height);
-    }
-
-    function startDrag(fieldId, event, overlay) {
-        const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        const rect = overlay.getBoundingClientRect();
-        const pointerX = (event.clientX - rect.left) / rect.width;
-        const pointerY = (event.clientY - rect.top) / rect.height;
-        dragState = {
-            fieldId: fieldId,
-            pageIndex: field.pageIndex,
-            startClientX: event.clientX,
-            startClientY: event.clientY,
-            startPointerX: pointerX,
-            startPointerY: pointerY,
-            originX: field.x,
-            originY: field.y,
-            moved: false
-        };
-    }
-
-    function startResize(fieldId, handle, event, overlay) {
-        const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        const rect = overlay.getBoundingClientRect();
-        resizeState = {
-            fieldId: fieldId,
-            handle: handle,
-            startX: (event.clientX - rect.left) / rect.width,
-            startY: (event.clientY - rect.top) / rect.height,
-            originX: field.x,
-            originY: field.y,
-            originWidth: field.width,
-            originHeight: field.height
-        };
-    }
-
-    function handleDragMove(event) {
-        if (!dragState) return;
-        const dragDistance = Math.hypot(
-            event.clientX - dragState.startClientX,
-            event.clientY - dragState.startClientY
+      }
+    })
+    .catch(function (err) {
+      statusEl.className = "alert alert-danger small mb-3";
+      statusEl.textContent =
+        "Error: " + (err && err.message ? err.message : "Unknown error.");
+    })
+    .finally(function () {
+      updateUtilCopyRunState();
+    });
+});
+
+/* --------------- Bulk normalize --------------- */
+var bulkFiles = [];
+var BULK_WARN_BYTES = 16 * 1024 * 1024;
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+  return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+function updateBulkState() {
+  document.getElementById("util-bulk-run").disabled = bulkFiles.length === 0;
+  document.getElementById("util-bulk-file-count").textContent = bulkFiles.length
+    ? bulkFiles.length +
+      " file" +
+      (bulkFiles.length === 1 ? "" : "s") +
+      " selected"
+    : "";
+  var totalSize = bulkFiles.reduce(function (sum, f) {
+    return sum + f.size;
+  }, 0);
+  var sizeWarning = document.getElementById("util-bulk-size-warning");
+  if (totalSize > BULK_WARN_BYTES) {
+    document.getElementById("util-bulk-size-display").textContent =
+      formatBytes(totalSize);
+    sizeWarning.classList.remove("hidden");
+  } else {
+    sizeWarning.classList.add("hidden");
+  }
+}
+
+document
+  .getElementById("util-bulk-files")
+  .addEventListener("change", function (e) {
+    var fileTarget = /** @type {any} */ (e.target);
+    bulkFiles = fileTarget.files ? Array.from(fileTarget.files) : [];
+    updateBulkState();
+  });
+
+document.getElementById("util-bulk-run").addEventListener("click", function () {
+  if (!bulkFiles.length) return;
+  var statusEl = document.getElementById("util-bulk-status");
+  statusEl.className = "alert alert-info small mb-3";
+  statusEl.textContent =
+    "Normalizing " +
+    bulkFiles.length +
+    " PDF" +
+    (bulkFiles.length === 1 ? "" : "s") +
+    "...";
+  statusEl.classList.remove("hidden");
+  document.getElementById("util-bulk-run").disabled = true;
+
+  var options = {
+    normalizeFont: document.getElementById("util-bulk-norm-font").checked,
+    fontName: document.getElementById("util-bulk-norm-font-name").value,
+    normalizeFontSize: document.getElementById("util-bulk-norm-fontsize")
+      .checked,
+    fontSizePt: Number(
+      document.getElementById("util-bulk-norm-fontsize-val").value || 10,
+    ),
+    normalizeCheckboxStyle: document.getElementById(
+      "util-bulk-norm-checkbox-style",
+    ).checked,
+    checkboxStyle: document.getElementById("util-bulk-norm-checkbox-style-val")
+      .value,
+    checkboxExportValue: "Yes",
+    uniformCheckboxSize: document.getElementById("util-bulk-norm-checkbox-size")
+      .checked,
+    checkboxSizePt: Number(
+      document.getElementById("util-bulk-norm-checkbox-size-val").value || 12,
+    ),
+    removeEmbeddedFonts: document.getElementById("util-bulk-norm-strip-fonts")
+      .checked,
+  };
+
+  var formData = new FormData();
+  formData.append("options", JSON.stringify(options));
+  bulkFiles.forEach(function (file) {
+    formData.append("files", file, file.name);
+  });
+
+  fetch(apiUrl("/pdf-labeler/api/bulk-normalize"), {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    body: formData,
+  })
+    .then(function (resp) {
+      return parseApiResponse(resp);
+    })
+    .then(function (data) {
+      if (!data.success) {
+        throw new Error(
+          (data.error && data.error.message) || "Bulk normalize failed.",
         );
-        if (!dragState.moved) {
-            if (dragDistance < 4) {
-                return;
-            }
-            dragState.moved = true;
-            if (state.selectedFieldId !== dragState.fieldId) {
-                selectField(dragState.fieldId, { focusNameInput: false, scrollIntoView: false });
-            }
-        }
-        const overlay = getOverlayForPage(dragState.pageIndex);
-        if (!overlay) return;
-        const rect = overlay.getBoundingClientRect();
-        const pointerX = (event.clientX - rect.left) / rect.width;
-        const pointerY = (event.clientY - rect.top) / rect.height;
-        const field = state.fields.find(function (candidate) { return candidate.id === dragState.fieldId; });
-        if (!field) return;
-        field.x = clamp(dragState.originX + (pointerX - dragState.startPointerX), 0, 1 - field.width);
-        field.y = clamp(dragState.originY + (pointerY - dragState.startPointerY), 0, 1 - field.height);
-        markDirtyAndRender(true);
+      }
+      if (!data.data || !data.data.zip_base64) {
+        throw new Error("Server did not return a .zip file.");
+      }
+      var zipBytes = base64ToUint8Array(data.data.zip_base64);
+      var zipName = data.data.filename || "normalized-pdfs.zip";
+
+      var summary =
+        "Normalized " +
+        data.data.processed +
+        "/" +
+        data.data.total +
+        " PDF" +
+        (data.data.total === 1 ? "" : "s") +
+        ".";
+      if (data.data.errors && data.data.errors.length) {
+        summary += " Errors: " + data.data.errors.join("; ");
+        statusEl.className = "alert alert-warning small mb-3";
+      } else {
+        statusEl.className = "alert alert-success small mb-3";
+      }
+      statusEl.textContent = summary;
+
+      var blob = new Blob([zipBytes], { type: "application/zip" });
+      var url = URL.createObjectURL(blob);
+      var anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = zipName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    })
+    .catch(function (err) {
+      statusEl.className = "alert alert-danger small mb-3";
+      statusEl.textContent =
+        "Error: " + (err && err.message ? err.message : "Unknown error.");
+    })
+    .finally(function () {
+      updateBulkState();
+    });
+});
+
+repairModal.querySelectorAll(".repair-run-btn").forEach(function (btn) {
+  btn.addEventListener("click", function () {
+    var action = btn.dataset.repairAction;
+    if (!action || !state.pdfBytes) return;
+    runRepairAction(action);
+  });
+});
+passwordSubmitBtn.addEventListener("click", submitPassword);
+passwordInput.addEventListener("keydown", function (e) {
+  if (e.key === "Enter") submitPassword();
+});
+passwordCancelBtn.addEventListener("click", function () {
+  passwordModal.classList.add("hidden");
+  state._pendingPasswordFile = null;
+  pdfEmpty.classList.remove("hidden");
+});
+repairPromptFixBtn.addEventListener("click", function () {
+  repairPromptModal.classList.add("hidden");
+  if (state._pendingRepairFile || state.pdfBytes) {
+    runRepairAction("auto");
+  } else {
+    repairStatus.classList.add("hidden");
+    repairModal.querySelectorAll(".repair-run-btn").forEach(function (btn) {
+      btn.disabled = false;
+    });
+    repairBtn.disabled = false;
+    repairModal.classList.remove("hidden");
+  }
+});
+repairPromptCancelBtn.addEventListener("click", function () {
+  repairPromptModal.classList.add("hidden");
+  state._pendingRepairFile = null;
+  pdfEmpty.classList.remove("hidden");
+});
+accessibilityBtn.addEventListener("click", async function () {
+  if (!state.pdfBytes) return;
+  await inspectAccessibilityData(false).catch(function () {
+    showError("Could not inspect accessibility metadata for this PDF.");
+  });
+  renderAccessibilityModal();
+  accessibilityModal.classList.remove("hidden");
+});
+closeAccessibilityBtn.addEventListener("click", function () {
+  updateAccessibilityMetadataFromInputs();
+  accessibilityModal.classList.add("hidden");
+});
+a11yEnableInput.addEventListener("change", function () {
+  state.accessibility.enabled = !!a11yEnableInput.checked;
+});
+a11yImageModeInput.addEventListener("change", function () {
+  state.accessibility.imageMode = !!a11yImageModeInput.checked;
+  renderAccessibilityImages();
+});
+a11yAutofillTooltipsBtn.addEventListener("click", function () {
+  state.fields.forEach(function (field) {
+    if (!String(field.tooltip || "").trim()) {
+      field.tooltip = defaultTooltipFromFieldName(field.name);
     }
+  });
+  renderAccessibilityFieldList();
+  setDirty(true);
+});
+[a11yMetaLanguage, a11yMetaTitle, a11yMetaAuthor, a11yMetaSubject].forEach(
+  function (input) {
+    input.addEventListener("input", function () {
+      updateAccessibilityMetadataFromInputs();
+      setDirty(true);
+    });
+  },
+);
+a11yFieldList.addEventListener("input", function (event) {
+  var target = event.target;
+  if (!target || !target.dataset) return;
+  if (target.dataset.a11yAction !== "tooltip") return;
+  var fieldId = target.dataset.fieldId;
+  var field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  field.tooltip = String(target.value || "");
+  setDirty(true);
+});
+a11yFieldList.addEventListener("click", function (event) {
+  var actionTarget = event.target.closest("[data-a11y-action]");
+  if (!actionTarget) return;
+  var action = actionTarget.dataset.a11yAction;
+  var fieldId = actionTarget.dataset.fieldId;
+  if (!fieldId || (action !== "move-up" && action !== "move-down")) return;
+  var order = state.accessibility.fieldOrder.slice();
+  var index = order.indexOf(fieldId);
+  if (index < 0) return;
+  var swapWith = action === "move-up" ? index - 1 : index + 1;
+  if (swapWith < 0 || swapWith >= order.length) return;
+  var temp = order[swapWith];
+  order[swapWith] = order[index];
+  order[index] = temp;
+  state.accessibility.fieldOrder = order;
+  renderAccessibilityFieldList();
+  setDirty(true);
+});
+a11yFieldList.addEventListener("dragstart", function (event) {
+  if (!event.target.closest(".a11y-drag-handle")) return;
+  var row = event.target.closest("[data-field-id]");
+  if (!row) return;
+  a11yDragFieldId = row.dataset.fieldId;
+  row.classList.add("a11y-dragging");
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+  }
+});
+a11yFieldList.addEventListener("dragend", function () {
+  a11yDragFieldId = null;
+  a11yFieldList
+    .querySelectorAll(".a11y-dragging, .a11y-drag-over")
+    .forEach(function (el) {
+      el.classList.remove("a11y-dragging", "a11y-drag-over");
+    });
+});
+a11yFieldList.addEventListener("dragover", function (event) {
+  if (!a11yDragFieldId) return;
+  event.preventDefault();
+  var row = event.target.closest("[data-field-id]");
+  a11yFieldList.querySelectorAll(".a11y-drag-over").forEach(function (el) {
+    el.classList.remove("a11y-drag-over");
+  });
+  if (row && row.dataset.fieldId !== a11yDragFieldId) {
+    row.classList.add("a11y-drag-over");
+  }
+});
+a11yFieldList.addEventListener("drop", function (event) {
+  if (!a11yDragFieldId) return;
+  event.preventDefault();
+  var targetRow = event.target.closest("[data-field-id]");
+  var order = state.accessibility.fieldOrder.slice();
+  var fromIndex = order.indexOf(a11yDragFieldId);
+  if (fromIndex < 0) return;
+  var toIndex;
+  if (targetRow && targetRow.dataset.fieldId !== a11yDragFieldId) {
+    toIndex = order.indexOf(targetRow.dataset.fieldId);
+    if (toIndex < 0) return;
+  } else if (!targetRow) {
+    toIndex = order.length;
+  } else {
+    return;
+  }
+  order.splice(fromIndex, 1);
+  var adjustedIndex = toIndex > fromIndex ? toIndex - 1 : toIndex;
+  order.splice(adjustedIndex, 0, a11yDragFieldId);
+  state.accessibility.fieldOrder = order;
+  a11yDragFieldId = null;
+  renderAccessibilityFieldList();
+  setDirty(true);
+});
+a11yImageList.addEventListener("input", function (event) {
+  var target = event.target;
+  if (!target || !target.dataset) return;
+  if (target.dataset.a11yAction !== "image-alt") return;
+  var assetId = String(target.dataset.assetId || "");
+  if (!assetId) return;
+  var imageAsset = state.accessibility.images.find(function (item) {
+    return String(item.assetId || "") === assetId;
+  });
+  if (!imageAsset) return;
+  imageAsset.altText = String(target.value || "");
+  setDirty(true);
+});
+settingsBtn.addEventListener("click", function () {
+  aiModelInput.value = state.model || state.defaultModel;
+  renderModelSuggestions("");
+  // Load session defaults into settings UI
+  var sessionDefs = _loadSessionDefaults();
+  document.getElementById("settings-default-font").value =
+    sessionDefs.font || "Helvetica";
+  document.getElementById("settings-default-font-size").value = String(
+    sessionDefs.fontSize || 10,
+  );
+  document.getElementById("settings-default-checkbox-style").value =
+    sessionDefs.checkboxStyle || "cross";
+  settingsModal.classList.remove("hidden");
+});
+closeSettingsBtn.addEventListener("click", function () {
+  settingsModal.classList.add("hidden");
+  aiModelSuggestions.classList.add("hidden");
+});
+closeNormalizationBtn.addEventListener("click", function () {
+  normalizationModal.classList.add("hidden");
+});
+applyNormalizationBtn.addEventListener("click", applyNormalizationPass);
+saveSettingsBtn.addEventListener("click", function () {
+  state.model = aiModelInput.value.trim() || state.defaultModel;
+  // Save session defaults
+  setSessionDefault(
+    "font",
+    document.getElementById("settings-default-font").value || "Helvetica",
+  );
+  setSessionDefault(
+    "fontSize",
+    Number(document.getElementById("settings-default-font-size").value) || 10,
+  );
+  setSessionDefault(
+    "checkboxStyle",
+    document.getElementById("settings-default-checkbox-style").value || "cross",
+  );
+  settingsModal.classList.add("hidden");
+  aiModelSuggestions.classList.add("hidden");
+});
+resetSettingsBtn.addEventListener("click", function () {
+  state.model = state.defaultModel;
+  aiModelInput.value = state.defaultModel;
+  // Reset session defaults to hard defaults
+  _saveSessionDefaults(Object.assign({}, HARD_DEFAULTS));
+  document.getElementById("settings-default-font").value = HARD_DEFAULTS.font;
+  document.getElementById("settings-default-font-size").value = String(
+    HARD_DEFAULTS.fontSize,
+  );
+  document.getElementById("settings-default-checkbox-style").value =
+    HARD_DEFAULTS.checkboxStyle;
+  renderModelSuggestions("");
+});
+aiModelInput.addEventListener("input", function () {
+  state.model = aiModelInput.value.trim() || state.defaultModel;
+  renderModelSuggestions(aiModelInput.value);
+});
+aiModelInput.addEventListener("focus", function () {
+  renderModelSuggestions(aiModelInput.value);
+});
+quickFieldCloseBtn.addEventListener("click", function () {
+  hideQuickFieldEditor();
+});
 
-    function handleResizeMove(event) {
-        if (!resizeState) return;
-        const field = state.fields.find(function (candidate) { return candidate.id === resizeState.fieldId; });
-        if (!field) return;
-        const overlay = getOverlayForPage(field.pageIndex);
-        if (!overlay) return;
-        const rect = overlay.getBoundingClientRect();
-        const pointerX = (event.clientX - rect.left) / rect.width;
-        const pointerY = (event.clientY - rect.top) / rect.height;
-        const deltaX = pointerX - resizeState.startX;
-        const deltaY = pointerY - resizeState.startY;
-        let newX = resizeState.originX;
-        let newY = resizeState.originY;
-        let newWidth = resizeState.originWidth;
-        let newHeight = resizeState.originHeight;
-        const minSize = 0.01;
-
-        if (resizeState.handle.includes('e')) {
-            newWidth = resizeState.originWidth + deltaX;
-        }
-        if (resizeState.handle.includes('s')) {
-            newHeight = resizeState.originHeight + deltaY;
-        }
-        if (resizeState.handle.includes('w')) {
-            newWidth = resizeState.originWidth - deltaX;
-            newX = resizeState.originX + deltaX;
-        }
-        if (resizeState.handle.includes('n')) {
-            newHeight = resizeState.originHeight - deltaY;
-            newY = resizeState.originY + deltaY;
-        }
-
-        newWidth = Math.max(minSize, newWidth);
-        newHeight = Math.max(minSize, newHeight);
-        newX = clamp(newX, 0, 1 - newWidth);
-        newY = clamp(newY, 0, 1 - newHeight);
-
-        if (resizeState.handle.includes('w')) {
-            newWidth = Math.min(newWidth, resizeState.originX + resizeState.originWidth - newX);
-        }
-        if (resizeState.handle.includes('n')) {
-            newHeight = Math.min(newHeight, resizeState.originY + resizeState.originHeight - newY);
-        }
-
-        field.x = newX;
-        field.y = newY;
-        field.width = clamp(newWidth, minSize, 1 - field.x);
-        field.height = clamp(newHeight, minSize, 1 - field.y);
-        markDirtyAndRender(true);
+// Close quick editor when clicking outside it, but keep the field selected
+document.addEventListener(
+  "mousedown",
+  function (event) {
+    if (
+      state.quickEditFieldId &&
+      !quickFieldEditor.contains(event.target) &&
+      !(
+        /** @type {any} */ (event.target).closest(
+          '.field-box[data-field-id="' + state.quickEditFieldId + '"]',
+        )
+      )
+    ) {
+      hideQuickFieldEditor();
     }
+  },
+  true,
+);
+quickFieldDeleteBtn.addEventListener("click", function () {
+  const field = getQuickEditField();
+  if (!field) return;
+  deleteField(field.id);
+});
+quickFieldNameInput.addEventListener("input", function () {
+  const field = getQuickEditField();
+  if (!field) return;
+  commitFieldNameChange(field.id, quickFieldNameInput.value, "quick");
+});
+quickFieldNameInput.addEventListener("keydown", function (event) {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    hideQuickFieldEditor();
+    return;
+  }
+  if (event.key === "Enter") {
+    event.preventDefault();
+    hideQuickFieldEditor();
+  }
+});
+quickFieldSuggestions.addEventListener("click", function (event) {
+  const button = event.target.closest("[data-suggested-name]");
+  const field = getQuickEditField();
+  if (!button || !field) return;
+  const nextName = button.dataset.suggestedName || "";
+  if (!nextName) return;
+  event.preventDefault();
+  commitFieldNameChange(field.id, nextName, "quick");
+  quickFieldNameInput.value = nextName;
+  renderQuickFieldSuggestions(field);
+  quickFieldNameInput.focus();
+  quickFieldNameInput.select();
+});
 
-    function clearInteractionState() {
-        draftState = null;
-        dragState = null;
-        resizeState = null;
-        renderDraftRect();
+document.addEventListener("mousedown", function (event) {
+  if (
+    !aiModelSuggestions.contains(event.target) &&
+    event.target !== aiModelInput &&
+    !settingsModal.contains(event.target)
+  ) {
+    aiModelSuggestions.classList.add("hidden");
+  }
+  const authMenu = document.getElementById("auth-menu");
+  if (authMenu && !authControls.contains(event.target)) {
+    authMenu.classList.remove("show");
+  }
+  if (
+    !settingsModal.classList.contains("hidden") &&
+    event.target === settingsModal
+  ) {
+    settingsModal.classList.add("hidden");
+    aiModelSuggestions.classList.add("hidden");
+  }
+  if (
+    !accessibilityModal.classList.contains("hidden") &&
+    event.target === accessibilityModal
+  ) {
+    updateAccessibilityMetadataFromInputs();
+    accessibilityModal.classList.add("hidden");
+  }
+  if (
+    !normalizationModal.classList.contains("hidden") &&
+    event.target === normalizationModal
+  ) {
+    normalizationModal.classList.add("hidden");
+  }
+  if (
+    !repairModal.classList.contains("hidden") &&
+    event.target === repairModal
+  ) {
+    repairModal.classList.add("hidden");
+  }
+  if (
+    !pageManagerModal.classList.contains("hidden") &&
+    event.target === pageManagerModal
+  ) {
+    closePageManager();
+  }
+});
+
+fieldsList.addEventListener("input", function (event) {
+  const target = event.target;
+  if (!target || !target.dataset) return;
+  const fieldId = target.dataset.fieldId;
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  if (target.dataset.action === "field-name") {
+    commitFieldNameChange(fieldId, target.value, "sidebar");
+    return;
+  }
+  if (target.dataset.action === "field-options") {
+    field.options = target.value
+      .split(",")
+      .map(function (option) {
+        return option.trim();
+      })
+      .filter(Boolean);
+    if (!field.options.length) {
+      field.options = DEFAULT_OPTION_LIST.slice();
     }
-
-    function setupPageInteractions(overlay, pageIndex) {
-        overlay.addEventListener('pointerdown', function (event) {
-            if (event.button !== 0) return;
-            const rect = overlay.getBoundingClientRect();
-            const pointX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
-            const pointY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
-
-            if (!state.selectedTool) {
-                if (event.target === overlay) {
-                    selectField(null, { focusNameInput: false, scrollIntoView: false });
-                }
-                return;
-            }
-
-            if (event.target !== overlay) return;
-
-            if (POINT_INSERT_TYPES.has(state.selectedTool)) {
-                createPointField(pageIndex, pointX, pointY);
-                return;
-            }
-
-            draftState = {
-                pageIndex: pageIndex,
-                startX: pointX,
-                startY: pointY,
-                currentX: pointX,
-                currentY: pointY
-            };
-            selectField(null, { focusNameInput: false, scrollIntoView: false });
-            renderDraftRect();
-        });
+    markDirtyAndRender();
+    return;
+  }
+  if (target.dataset.action === "field-font-size") {
+    const parsedValue = Number(target.value);
+    if (Number.isFinite(parsedValue)) {
+      field.fontSize = clamp(parsedValue, 4, 72);
+      markDirtyAndRender();
     }
+    return;
+  }
+  if (target.dataset.action === "field-checkbox-export-value") {
+    field.checkboxExportValue = String(target.value || "").trim() || "Yes";
+    markDirtyAndRender(true);
+  }
+});
 
-    function createPageShell(pageIndex) {
-        const shell = document.createElement('div');
-        shell.className = 'pdf-page-shell';
-        shell.dataset.pageIndex = String(pageIndex);
-
-        const label = document.createElement('div');
-        label.className = 'pdf-page-label';
-        label.textContent = 'Page ' + (pageIndex + 1);
-        shell.appendChild(label);
-
-        const page = document.createElement('div');
-        page.className = 'pdf-page';
-        page.dataset.pageIndex = String(pageIndex);
-        shell.appendChild(page);
-        return { shell: shell, page: page };
+fieldsList.addEventListener("change", function (event) {
+  const target = event.target;
+  if (!target || !target.dataset) return;
+  const fieldId = target.dataset.fieldId;
+  const field = state.fields.find(function (candidate) {
+    return candidate.id === fieldId;
+  });
+  if (!field) return;
+  if (target.dataset.action === "field-type") {
+    const newType = normalizeFieldType(target.value);
+    field.type = newType;
+    if (newType === "text" || newType === "multiline") {
+      field.font = field.font || getSessionDefault("font");
+      if (typeof field.autoSize !== "boolean") {
+        field.autoSize = true;
+      }
     }
-
-    async function renderPages(options) {
-        const settings = options || {};
-        pdfPages.innerHTML = '';
-
-        for (let pageIndex = 0; pageIndex < state.pageCount; pageIndex += 1) {
-            const pageProxy = await state.pdfDoc.getPage(pageIndex + 1);
-            const viewport = pageProxy.getViewport({ scale: getViewerRenderScale() });
-            const pageShell = createPageShell(pageIndex);
-            pageShell.page.style.width = viewport.width + 'px';
-            pageShell.page.style.height = viewport.height + 'px';
-
-            const canvas = document.createElement('canvas');
-            canvas.width = viewport.width;
-            canvas.height = viewport.height;
-            pageShell.page.appendChild(canvas);
-
-            const context = canvas.getContext('2d');
-            await pageProxy.render({
-                canvasContext: context,
-                viewport: viewport,
-                annotationMode: 0
-            }).promise;
-
-            const overlay = document.createElement('div');
-            overlay.className = 'page-overlay';
-            overlay.dataset.pageIndex = String(pageIndex);
-            pageShell.page.appendChild(overlay);
-            setupPageInteractions(overlay, pageIndex);
-
-            pdfPages.appendChild(pageShell.shell);
-        }
-
-        updateOverlayCursorState();
-        renderFieldsOnPages();
-        if (settings.anchor) {
-            restoreViewerAnchor(settings.anchor);
-        }
-        currentVisiblePageIndex = getCurrentVisiblePageIndex();
+    if (
+      OPTION_TYPES.has(newType) &&
+      (!Array.isArray(field.options) || !field.options.length)
+    ) {
+      field.options = DEFAULT_OPTION_LIST.slice();
     }
-
-    async function loadPdf(file) {
-        showLoading('Loading PDF...');
-        hideToasts();
-        clearInteractionState();
-        setSelectedTool(null);
-
-        try {
-            const arrayBuffer = await file.arrayBuffer();
-            syncPdfState(arrayBufferToUint8Array(arrayBuffer), file.name || 'edited-form.pdf', file);
-            updateDocumentName();
-            await refreshPdfDocumentFromState();
-            showLoading('Detecting fields with FormFyxer...');
-
-            const existingFields = await parseExistingFieldsLocally(state.pdfBytes, state.pageSizes);
-            const detectedFields = await detectExistingFieldsWithServer().catch(function (_error) {
-                return existingFields;
-            });
-            replaceFields(detectedFields);
-            await inspectAccessibilityData(true).catch(function () {
-                state.accessibility.inspected = false;
-            });
-            setDirty(false);
-            updateAiUiState();
-            floatingToolPicker.classList.remove('hidden');
-            showPdfWorkspace();
-            showSuccess(detectedFields.length ? ('Loaded ' + detectedFields.length + ' existing fields.') : 'PDF loaded.');
-        } catch (error) {
-            console.error('Error loading PDF:', error);
-            hideLoading();
-
-            if (error && error.name === 'PasswordException') {
-                tryAutoUnlock(file);
-                return;
-            }
-
-            showRepairPrompt(file, error);
-            return;
-        } finally {
-            hideLoading();
-        }
+    if (!OPTION_TYPES.has(newType)) {
+      delete field.options;
     }
-
-    /**
-     * Attempt to unlock the PDF without a password via the server-side
-     * repair API.  If the blank-password unlock succeeds the repaired
-     * file is reloaded immediately.  Otherwise the password dialog is shown.
-     */
-    async function tryAutoUnlock(file) {
-        showLoading('Trying to unlock PDF...');
-        try {
-            var formData = new FormData();
-            formData.append('file', file);
-            formData.append('action', 'unlock');
-
-            var response = await fetch(apiUrl('/pdf-labeler/api/repair'), {
-                method: 'POST',
-                headers: { 'Accept': 'application/json' },
-                body: formData
-            });
-            var result = await parseApiResponse(response);
-            if (result.success && result.data && result.data.pdf_base64) {
-                var binaryStr = atob(result.data.pdf_base64);
-                var bytes = new Uint8Array(binaryStr.length);
-                for (var i = 0; i < binaryStr.length; i++) {
-                    bytes[i] = binaryStr.charCodeAt(i);
-                }
-                var unlockedFile = new File([bytes], result.data.filename || state.fileName || 'unlocked.pdf', { type: 'application/pdf' });
-                hideLoading();
-                showSuccess('PDF unlocked successfully.');
-                await loadPdf(unlockedFile);
-                return;
-            }
-        } catch (_err) {
-            // blank-password unlock failed — fall through to password dialog
-        }
-        hideLoading();
-        showPasswordDialog(file);
+    if (newType === "checkbox") {
+      field.checkboxStyle =
+        field.checkboxStyle || getSessionDefault("checkboxStyle") || "cross";
+      field.checkboxExportValue = field.checkboxExportValue || "Yes";
+      field.checkboxBorder = !!field.checkboxBorder;
+      field.checkboxBorderWidth = field.checkboxBorderWidth || "thin";
     }
-
-    function showPasswordDialog(file) {
-        state._pendingPasswordFile = file;
-        passwordInput.value = '';
-        passwordError.classList.add('hidden');
-        passwordError.textContent = '';
-        passwordModal.classList.remove('hidden');
-        passwordInput.focus();
+    if (!(newType === "text" || newType === "multiline")) {
+      field.autoSize = true;
     }
-
-    async function submitPassword() {
-        var file = state._pendingPasswordFile;
-        if (!file) return;
-        var pw = passwordInput.value;
-        if (!pw) {
-            passwordError.textContent = 'Please enter a password.';
-            passwordError.classList.remove('hidden');
-            return;
-        }
-        passwordSubmitBtn.disabled = true;
-        passwordError.classList.add('hidden');
-        try {
-            var formData = new FormData();
-            formData.append('file', file);
-            formData.append('action', 'unlock');
-            formData.append('password', pw);
-
-            var response = await fetch(apiUrl('/pdf-labeler/api/repair'), {
-                method: 'POST',
-                headers: { 'Accept': 'application/json' },
-                body: formData
-            });
-            var result = await parseApiResponse(response);
-            if (!result.success) {
-                var errMsg = (result.error && result.error.message) || 'Incorrect password or unlock failed.';
-                throw new Error(errMsg);
-            }
-            var data = result.data || {};
-            if (!data.pdf_base64) throw new Error('No unlocked PDF was returned.');
-
-            var binaryStr = atob(data.pdf_base64);
-            var bytes = new Uint8Array(binaryStr.length);
-            for (var i = 0; i < binaryStr.length; i++) {
-                bytes[i] = binaryStr.charCodeAt(i);
-            }
-            var unlockedFile = new File([bytes], data.filename || state.fileName || 'unlocked.pdf', { type: 'application/pdf' });
-            passwordModal.classList.add('hidden');
-            state._pendingPasswordFile = null;
-            showSuccess('PDF unlocked successfully.');
-            await loadPdf(unlockedFile);
-        } catch (err) {
-            passwordError.textContent = err.message || 'Failed to unlock PDF.';
-            passwordError.classList.remove('hidden');
-        } finally {
-            passwordSubmitBtn.disabled = false;
-        }
+    markDirtyAndRender();
+    return;
+  }
+  if (target.dataset.action === "field-font") {
+    field.font = target.value || getSessionDefault("font");
+    markDirtyAndRender();
+    return;
+  }
+  if (target.dataset.action === "field-checkbox-style") {
+    field.checkboxStyle = target.value || "cross";
+    markDirtyAndRender();
+    return;
+  }
+  if (target.dataset.action === "move-field-page") {
+    const newPage = parseInt(target.value, 10);
+    if (!isNaN(newPage) && newPage >= 0 && newPage < state.pageCount) {
+      field.pageIndex = newPage;
+      markDirtyAndRender();
     }
+    return;
+  }
+  if (target.dataset.action === "field-checkbox-border") {
+    field.checkboxBorder = !!target.checked;
+    field.checkboxBorderWidth = field.checkboxBorderWidth || "thin";
+    markDirtyAndRender();
+    return;
+  }
+  if (target.dataset.action === "field-checkbox-border-width") {
+    field.checkboxBorderWidth = target.value || "thin";
+    markDirtyAndRender();
+    return;
+  }
+  if (target.dataset.action === "field-auto-size") {
+    field.autoSize = !!target.checked;
+    markDirtyAndRender();
+  }
+});
 
-    function showRepairPrompt(file, error) {
-        state._pendingRepairFile = file;
-        var msg = 'This PDF could not be rendered.';
-        if (error && error.message) {
-            msg += ' (' + error.message + ')';
-        }
-        msg += ' Would you like to try repairing it?';
-        repairPromptMessage.textContent = msg;
-        pdfEmpty.classList.add('hidden');
-        repairPromptModal.classList.remove('hidden');
+fieldsList.addEventListener("click", function (event) {
+  const actionTarget = event.target.closest("[data-action]");
+  if (!actionTarget) return;
+  const fieldId = actionTarget.dataset.fieldId;
+  if (!fieldId) return;
+  if (actionTarget.dataset.action === "normalize-name") {
+    event.preventDefault();
+    event.stopPropagation();
+    state.selectedFieldId = fieldId;
+    normalizeCurrentFieldName();
+    return;
+  }
+  if (actionTarget.dataset.action === "duplicate-field") {
+    event.preventDefault();
+    event.stopPropagation();
+    state.selectedFieldId = fieldId;
+    duplicateSelectedField();
+    return;
+  }
+  if (actionTarget.dataset.action === "delete-field") {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteField(fieldId);
+  }
+});
+
+autoDetectBtn.addEventListener("click", autoDetectFields);
+if (relabelBtn) {
+  relabelBtn.addEventListener("click", relabelFields);
+}
+if (sidebarRelabelBtn) {
+  sidebarRelabelBtn.addEventListener("click", relabelFields);
+}
+exportBtn.addEventListener("click", exportPdf);
+
+if (testFillingBtn) {
+  testFillingBtn.addEventListener("click", async function () {
+    if (!state.pdfBytes) return;
+    const originalText = testFillingBtn.textContent;
+    testFillingBtn.textContent = "Generating...";
+    testFillingBtn.disabled = true;
+    try {
+      const formData = new FormData();
+      formData.append("file", getPdfFileForRequests());
+
+      const saveNameMap = buildExportNameMap({
+        deduplicate: exportDeduplicateFieldNamesInput
+          ? exportDeduplicateFieldNamesInput.checked
+          : true,
+      });
+      formData.append(
+        "fields",
+        JSON.stringify(convertFieldsToAbsoluteCoordinates(saveNameMap)),
+      );
+      if (
+        exportDeduplicateFieldNamesInput &&
+        exportDeduplicateFieldNamesInput.checked
+      ) {
+        formData.append("deduplicate_field_names", "true");
+      }
+
+      const response = await fetch(apiUrl("/pdf-labeler/api/test-fill"), {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: formData,
+      });
+      const data = await parseApiResponse(response);
+      if (!data.success || !data.data || !data.data.pdf_base64) {
+        throw new Error(
+          (data.error && data.error.message) || "Test fill failed.",
+        );
+      }
+      const b64 = data.data.pdf_base64;
+      const binary = window.atob(b64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const blob = new Blob([bytes], { type: "application/pdf" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = data.data.filename || "test_fill.pdf";
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(function () {
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }, 100);
+    } catch (err) {
+      showError("Error testing PDF fill: " + err.message);
+    } finally {
+      testFillingBtn.textContent = originalText;
+      testFillingBtn.disabled = false;
     }
+  });
+}
 
-    function deleteField(fieldId) {
-        state.fields = state.fields.filter(function (field) { return field.id !== fieldId; });
-        reconcileAccessibilityFieldOrder();
-        bumpFieldNamesVersion();
-        if (state.selectedFieldId === fieldId) {
-            state.selectedFieldId = state.fields[0] ? state.fields[0].id : null;
-        }
-        if (state.quickEditFieldId === fieldId) {
-            hideQuickFieldEditor();
-        }
-        setDirty(true);
-        renderFieldsList();
-        renderFieldsOnPages();
-        updateFieldCount();
+// Playground event listeners
+openPlaygroundBtn.addEventListener("click", openPlaygroundModal);
+savePlaygroundBtn.addEventListener("click", openSavePlaygroundModal);
+document
+  .getElementById("close-open-playground")
+  .addEventListener("click", function () {
+    openPlaygroundModalEl.classList.add("hidden");
+  });
+document
+  .getElementById("open-pg-cancel")
+  .addEventListener("click", function () {
+    openPlaygroundModalEl.classList.add("hidden");
+  });
+document
+  .getElementById("open-pg-confirm")
+  .addEventListener("click", confirmOpenFromPlayground);
+document
+  .getElementById("open-pg-project")
+  .addEventListener("change", fetchOpenPlaygroundTemplates);
+document
+  .getElementById("close-save-playground")
+  .addEventListener("click", function () {
+    savePlaygroundModalEl.classList.add("hidden");
+  });
+document
+  .getElementById("save-pg-cancel")
+  .addEventListener("click", function () {
+    savePlaygroundModalEl.classList.add("hidden");
+  });
+document
+  .getElementById("save-pg-confirm")
+  .addEventListener("click", confirmSaveToPlayground);
+
+// Interview variable picker event listeners
+usePlaygroundVariablesInput.addEventListener("change", function () {
+  state.usePlaygroundVariables = usePlaygroundVariablesInput.checked;
+  renderPdfInterviewPicker();
+});
+pdfInterviewSourceModeInputs.forEach(function (inp) {
+  inp.addEventListener("change", function () {
+    state.interviewSourceMode = inp.value;
+    if (inp.value === "installed" && state.installed.packages.length === 0)
+      fetchPdfInstalledPackages();
+    renderPdfInterviewPicker();
+  });
+});
+pdfPlaygroundProjectSelect.addEventListener("change", function () {
+  state.playground.selectedProject = pdfPlaygroundProjectSelect.value;
+  fetchPdfPlaygroundFiles();
+});
+pdfPlaygroundYamlFileSelect.addEventListener("change", function () {
+  state.playground.selectedFile = pdfPlaygroundYamlFileSelect.value;
+  fetchPdfPlaygroundVariables();
+});
+pdfInstalledPackageSelect.addEventListener("change", function () {
+  state.installed.selectedPackage = pdfInstalledPackageSelect.value;
+  fetchPdfInstalledFiles();
+});
+pdfInstalledYamlFileSelect.addEventListener("change", function () {
+  state.installed.selectedFile = pdfInstalledYamlFileSelect.value;
+  fetchPdfInstalledVariables();
+});
+
+document.addEventListener("keydown", function (event) {
+  const targetTag =
+    document.activeElement && document.activeElement.tagName
+      ? document.activeElement.tagName.toUpperCase()
+      : "";
+  if (
+    (event.key === "Delete" || event.key === "Backspace") &&
+    state.selectedFieldId &&
+    targetTag !== "INPUT" &&
+    targetTag !== "TEXTAREA"
+  ) {
+    event.preventDefault();
+    deleteField(state.selectedFieldId);
+    return;
+  }
+  if (event.key === "Escape") {
+    clearInteractionState();
+    setSelectedTool(null);
+    selectField(null, { focusNameInput: false, scrollIntoView: false });
+    aiModelSuggestions.classList.add("hidden");
+    settingsModal.classList.add("hidden");
+    accessibilityModal.classList.add("hidden");
+    normalizationModal.classList.add("hidden");
+    if (!pageManagerModal.classList.contains("hidden")) {
+      closePageManager();
     }
-
-    function duplicateSelectedField() {
-        const field = getCurrentField();
-        if (!field) return;
-        const duplicate = {
-            id: generateId(),
-            name: ensureUniqueFieldName(field.name + '_copy', field.id),
-            type: field.type,
-            pageIndex: field.pageIndex,
-            x: clamp(field.x + 0.012, 0, 1 - field.width),
-            y: clamp(field.y + 0.012, 0, 1 - field.height),
-            width: field.width,
-            height: field.height,
-            font: field.font || getSessionDefault('font'),
-            fontSize: field.fontSize,
-            autoSize: field.autoSize !== false,
-            checkboxStyle: field.checkboxStyle,
-            checkboxExportValue: field.checkboxExportValue,
-            checkboxBorder: !!field.checkboxBorder,
-            checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
-            allowScroll: field.allowScroll !== false,
-            backgroundColor: field.backgroundColor,
-            options: Array.isArray(field.options) ? field.options.slice() : undefined,
-            tooltip: String(field.tooltip || '').trim() || defaultTooltipFromFieldName(field.name)
-        };
-        state.fields.push(duplicate);
-        reconcileAccessibilityFieldOrder();
-        bumpFieldNamesVersion();
-        selectField(duplicate.id, { focusNameInput: false, scrollIntoView: false });
-        setDirty(true);
-        updateFieldCount();
-    }
-
-    function updateSelectedField(updates) {
-        const field = getCurrentField();
-        if (!field) return;
-        Object.keys(updates).forEach(function (key) {
-            field[key] = updates[key];
-        });
-        markDirtyAndRender();
-    }
-
-    function normalizeCurrentFieldName() {
-        const field = getCurrentField();
-        if (!field) return;
-        const normalized = ensureUniqueFieldName(field.name, field.id);
-        if (field.name === normalized) return;
-        field.name = normalized;
-        bumpFieldNamesVersion();
-        setDirty(true);
-        updateRenderedFieldName(field.id);
-        syncQuickFieldEditor();
-    }
-
-    function buildExportNameMap(options) {
-        const deduplicate = !!(options && options.deduplicate);
-        const exportNameMap = new Map();
-        const originalNames = state.fields.map(function (field) {
-            return field.name === null || field.name === undefined || field.name === ''
-                ? 'field'
-                : String(field.name);
-        });
-        const reservedOriginalNames = new Set(originalNames);
-        const used = new Set();
-        const suffixByName = new Map();
-        state.fields.forEach(function (field, index) {
-            const base = originalNames[index];
-            let candidate = base;
-            if (deduplicate) {
-                let suffix = suffixByName.get(base) || 0;
-                while (used.has(candidate)) {
-                    suffix += 1;
-                    candidate = base + '__' + suffix;
-                    while (reservedOriginalNames.has(candidate) || used.has(candidate)) {
-                        suffix += 1;
-                        candidate = base + '__' + suffix;
-                    }
-                }
-                suffixByName.set(base, suffix);
-            }
-            used.add(candidate);
-            exportNameMap.set(field.id, candidate);
-        });
-        return exportNameMap;
-    }
-
-    function getRenamedFields(exportNameMap) {
-        const renames = [];
-        state.fields.forEach(function (field, index) {
-            const oldName = field.name === null || field.name === undefined || field.name === ''
-                ? 'field'
-                : String(field.name);
-            const newName = exportNameMap.get(field.id) || oldName;
-            if (newName !== oldName) {
-                renames.push({
-                    index: index,
-                    old_name: oldName,
-                    new_name: newName
-                });
-            }
-        });
-        return renames;
-    }
-
-    function showFieldRenameSummary(renames, contextText) {
-        if (!Array.isArray(renames) || renames.length === 0) return;
-        fieldRenameSummaryContext.textContent = contextText || 'The following exact duplicate field names were renamed.';
-        fieldRenameSummaryList.innerHTML = renames.map(function (rename) {
-            return '<div class="border rounded p-2">' +
-                '<div class="small text-muted">Field ' + String(Number(rename.index) + 1) + '</div>' +
-                '<div><code>' + escapeHtml(rename.old_name) + '</code> &rarr; <code>' + escapeHtml(rename.new_name) + '</code></div>' +
-                '</div>';
-        }).join('');
-        fieldRenameSummaryModal.classList.remove('hidden');
-    }
-
-    function buildUniqueExportNameMap() {
-        return buildExportNameMap({ deduplicate: true });
-    }
-
-    function convertFieldsToAbsoluteCoordinates(exportNameMap) {
-        const nameMap = exportNameMap || buildUniqueExportNameMap();
-        return state.fields.map(function (field) {
-            const pageSize = state.pageSizes[field.pageIndex];
-            const safeName = nameMap.get(field.id) || (
-                field.name === null || field.name === undefined || field.name === ''
-                    ? 'field'
-                    : String(field.name)
-            );
-            return {
-                name: safeName,
-                type: field.type,
-                pageIndex: field.pageIndex,
-                x: field.x * pageSize.width,
-                y: (1 - field.y - field.height) * pageSize.height,
-                width: field.width * pageSize.width,
-                height: field.height * pageSize.height,
-                font: field.font || getSessionDefault('font'),
-                fontSize: field.fontSize,
-                autoSize: field.autoSize !== false,
-                checkboxStyle: field.checkboxStyle,
-                checkboxExportValue: field.checkboxExportValue,
-                checkboxBorder: !!field.checkboxBorder,
-                checkboxBorderWidth: field.checkboxBorderWidth || 'thin',
-                allowScroll: field.allowScroll !== false,
-                backgroundColor: field.backgroundColor,
-                options: Array.isArray(field.options) ? field.options.slice() : undefined,
-                tooltip: String(field.tooltip || '').trim()
-            };
-        });
-    }
-
-    async function applyNormalizationPass() {
-        if (!state.pdfBytes || state.fields.length === 0) {
-            showError('Load a PDF with fields before running normalization.');
-            return;
-        }
-        const settings = readNormalizationSettings();
-        normalizationModal.classList.add('hidden');
-        showLoading('Applying normalization pass...');
-        try {
-            await sleep(50);
-            const normalizedFields = buildNormalizedFields(settings);
-            replaceFields(normalizedFields, { preserveSelection: true });
-            setDirty(true);
-
-            if (settings.removeEmbeddedFonts && state.pdfBytes) {
-                showLoading('Removing embedded fonts...');
-                var formData = new FormData();
-                formData.append('file', getPdfFileForRequests());
-                var resp = await fetch(apiUrl('/pdf-labeler/api/strip-fonts'), {
-                    method: 'POST',
-                    headers: { 'Accept': 'application/json' },
-                    body: formData
-                });
-                var data = await parseApiResponse(resp);
-                if (data.success && data.data && data.data.pdf_base64) {
-                    var strippedBytes = base64ToUint8Array(data.data.pdf_base64);
-                    syncPdfState(strippedBytes, state.fileName || 'edited-form.pdf');
-                    await refreshPdfDocumentFromState();
-                    replaceFields(state.fields, { preserveSelection: true });
-                }
-            }
-
-            showPdfWorkspace();
-            showSuccess('Normalization pass applied.');
-        } catch (error) {
-            console.error('Error applying normalization pass:', error);
-            showPdfWorkspace();
-            showError('Normalization failed: ' + (error && error.message ? error.message : 'Unknown error.'));
-        } finally {
-            hideLoading();
-        }
-    }
-
-    async function autoDetectFields() {
-        if (!state.pdfBytes) return;
-        if (!state.auth.aiEnabled) {
-            showError('AI auto-detect requires login.');
-            return;
-        }
-
-        showLoading('Auto-detecting fields with AI...');
-        try {
-            const formData = new FormData();
-            formData.append('file', getPdfFileForRequests());
-            formData.append('normalize_fields', 'true');
-            formData.append('model', state.model || state.defaultModel);
-
-            // Pass preferred variable names from Playground/installed interview
-            var effectiveVars = getEffectivePdfVariables();
-            if (state.usePlaygroundVariables && effectiveVars.length > 0) {
-                formData.append('use_playground_variables', 'true');
-                formData.append('preferred_variable_names', JSON.stringify(effectiveVars));
-                formData.append('interview_source_mode', state.interviewSourceMode);
-                if (state.interviewSourceMode === 'playground') {
-                    formData.append('playground_project', state.playground.selectedProject);
-                    formData.append('playground_yaml_file', state.playground.selectedFile);
-                } else {
-                    formData.append('installed_package', state.installed.selectedPackage);
-                    formData.append('installed_yaml_file', state.installed.selectedFile);
-                }
-            }
-
-            const data = await requestAsyncLabelerAction(
-                '/pdf-labeler/api/auto-detect',
-                formData,
-                'Auto-detect is running in the background...'
-            );
-
-            applyReturnedPdfPayload(data, state.fileName || 'edited-form.pdf');
-
-            const importedFields = Array.isArray(data && data.fields) ? data.fields : [];
-            let normalizedFields = [];
-            if (importedFields.length && typeof importedFields[0] === 'object' && importedFields[0] !== null && Object.prototype.hasOwnProperty.call(importedFields[0], 'x')) {
-                normalizedFields = importedFields.map(function (field) {
-                    const pageSize = state.pageSizes[field.pageIndex];
-                    const fieldType = normalizeFieldType(field.type);
-                    const width = pageSize ? clamp(field.width / pageSize.width, 0.01, 1) : 0.1;
-                    const height = pageSize ? clamp(field.height / pageSize.height, 0.01, 1) : 0.03;
-                    const x = pageSize ? clamp(field.x / pageSize.width, 0, 1 - width) : 0;
-                    const y = pageSize ? clamp(1 - ((field.y + field.height) / pageSize.height), 0, 1 - height) : 0;
-                    return {
-                        id: generateId(),
-                        name: ensureUniqueFieldName(field.name || getDefaultFieldName(fieldType), null),
-                        type: fieldType,
-                        pageIndex: field.pageIndex,
-                        x: x,
-                        y: y,
-                        width: width,
-                        height: height,
-                        font: field.font || getSessionDefault('font'),
-                        fontSize: field.fontSize || getSessionDefault('fontSize'),
-                        autoSize: field.autoSize !== false,
-                        options: Array.isArray(field.options) ? field.options.slice() : undefined
-                    };
-                });
-            } else {
-                normalizedFields = await detectExistingFieldsWithServer().catch(function () {
-                    return parseExistingFieldsLocally(state.pdfBytes, state.pageSizes);
-                });
-            }
-
-            replaceFields(normalizedFields);
-            setDirty(false);
-            showPdfWorkspace();
-            const detectedCount = normalizedFields.length;
-            showSuccess('Detected ' + detectedCount + ' field' + (detectedCount === 1 ? '' : 's') + '.');
-        } catch (error) {
-            console.error('Error auto-detecting:', error);
-            showPdfWorkspace();
-            showError('Auto-detection failed: ' + (error && error.message ? error.message : 'Unknown error.'));
-        } finally {
-            hideLoading();
-        }
-    }
-
-    async function relabelFields() {
-        if (!state.pdfBytes || state.fields.length === 0) return;
-        if (!state.auth.aiEnabled) {
-            showError('AI relabel requires login.');
-            return;
-        }
-        if (state.hasUnsavedChanges) {
-            const confirmed = window.confirm('AI relabel works on the PDF fields currently embedded in the document. Unsaved manual edits will be replaced. Continue?');
-            if (!confirmed) return;
-        }
-
-        showLoading('Relabeling fields with AI... this can take 2-3 minutes.');
-        try {
-            const formData = new FormData();
-            formData.append('file', getPdfFileForRequests());
-            formData.append('model', state.model || state.defaultModel);
-
-            const data = await requestAsyncLabelerAction(
-                '/pdf-labeler/api/relabel',
-                formData,
-                'AI relabel is running in the background (this can take 2-3 minutes)...'
-            );
-
-            const pdfWasUpdated = applyReturnedPdfPayload(data, state.fileName || 'edited-form.pdf');
-            const detectedRelabeledFields = await detectExistingFieldsWithServer().catch(function () {
-                return parseExistingFieldsLocally(state.pdfBytes, state.pageSizes);
-            });
-            const relabeledFields = reconcileRelabeledFields(detectedRelabeledFields, data);
-            logRelabelDebug(data, detectedRelabeledFields, relabeledFields);
-            replaceFields(relabeledFields);
-            setDirty(false);
-            showPdfWorkspace();
-            if (!pdfWasUpdated) {
-                throw new Error('AI relabel completed without returning an updated PDF.');
-            }
-            const renamedCount = getRelabelChangedCount(data);
-            if (renamedCount === 0) {
-                showError('AI relabel completed, but no field names changed. See the browser console for details.', 15000);
-                return;
-            }
-            showSuccess(
-                typeof renamedCount === 'number'
-                    ? ('Relabeled ' + renamedCount + ' field' + (renamedCount === 1 ? '' : 's') + '.')
-                    : 'Fields relabeled successfully.',
-                9000
-            );
-        } catch (error) {
-            console.error('Error relabeling:', error);
-            showPdfWorkspace();
-            showError('Relabeling failed: ' + (error && error.message ? error.message : 'Unknown error.'), 15000);
-        } finally {
-            hideLoading();
-        }
-    }
-
-    async function exportPdf() {
-        if (!state.pdfBytes || state.fields.length === 0) {
-            showError('There are no fields to export.');
-            return;
-        }
-
-        const deduplicateFieldNames = !exportDeduplicateFieldNamesInput || exportDeduplicateFieldNamesInput.checked;
-        const exportNameMap = buildExportNameMap({ deduplicate: deduplicateFieldNames });
-        const renamedFields = getRenamedFields(exportNameMap);
-
-        // A clean document already contains the exact PDF the user loaded. Sending
-        // it through FormFyxer would rebuild every widget, which can alter field
-        // appearance streams, checkbox geometry, and other PDF metadata even when
-        // the user made no edit. Keep a no-op export byte-for-byte non-destructive;
-        // duplicate names still go through the server so the export contract can
-        // enforce uniqueness when requested.
-        if (!state.hasUnsavedChanges && renamedFields.length === 0) {
-            const cleanFilename = stripPdfExtension(state.fileName || 'edited-form') + '-with-fields.pdf';
-            downloadBlob(new Blob([state.pdfBytes], { type: 'application/pdf' }), cleanFilename);
-            showSuccess('PDF exported successfully.');
-            return;
-        }
-
-        showLoading('Exporting PDF...');
-        try {
-            const formData = new FormData();
-            formData.append('file', getPdfFileForRequests());
-            formData.append('fields', JSON.stringify(convertFieldsToAbsoluteCoordinates(exportNameMap)));
-            formData.append('accessibility', JSON.stringify(buildAccessibilityPayload(exportNameMap)));
-            formData.append('deduplicate_field_names', deduplicateFieldNames ? 'true' : 'false');
-
-            const response = await fetch(apiUrl('/pdf-labeler/api/apply-fields'), {
-                method: 'POST',
-                headers: { 'Accept': 'application/json' },
-                body: formData
-            });
-            const data = await parseApiResponse(response);
-            if (!data.success) {
-                throw new Error((data.error && data.error.message) || 'Export failed.');
-            }
-
-            if (!data.data || !data.data.pdf_base64) {
-                throw new Error('The export endpoint did not return a PDF.');
-            }
-
-            const outputBytes = base64ToUint8Array(data.data.pdf_base64);
-            const filename = data.data.filename || ((state.fileName || 'edited-form').replace(/\.pdf$/i, '') + '-with-fields.pdf');
-
-            const blob = new Blob([outputBytes], { type: 'application/pdf' });
-            const url = URL.createObjectURL(blob);
-            const anchor = document.createElement('a');
-            anchor.href = url;
-            anchor.download = filename;
-            document.body.appendChild(anchor);
-            anchor.click();
-            document.body.removeChild(anchor);
-            URL.revokeObjectURL(url);
-
-            syncPdfState(outputBytes, filename);
-            updateDocumentName();
-            setDirty(false);
-            showPdfWorkspace();
-            showSuccess('PDF exported successfully.');
-            showFieldRenameSummary(
-                renamedFields,
-                'The exported PDF contains these renamed exact duplicate fields.'
-            );
-        } catch (error) {
-            console.error('Error exporting:', error);
-            showPdfWorkspace();
-            showError('Export failed: ' + (error && error.message ? error.message : 'Unknown error.'));
-        } finally {
-            hideLoading();
-        }
-    }
-
-    function createPageManagerDraftPage(sourceId, sourcePageIndex) {
-        return {
-            id: 'page-' + generateId(),
-            sourceId: sourceId,
-            sourcePageIndex: Number(sourcePageIndex) || 0,
-            splitBefore: false
-        };
-    }
-
-    function getPageManagerSource(sourceId) {
-        if (!pageManagerState || !pageManagerState.sources) return null;
-        return pageManagerState.sources[sourceId] || null;
-    }
-
-    function setPageManagerStatus(message, tone) {
-        if (!message) {
-            pageManagerStatus.className = 'hidden alert small mb-3';
-            pageManagerStatus.textContent = '';
-            return;
-        }
-        const level = tone || 'info';
-        pageManagerStatus.className = 'alert alert-' + level + ' small mb-3';
-        pageManagerStatus.textContent = message;
-        pageManagerStatus.classList.remove('hidden');
-    }
-
-    function hasPageManagerStructuralChanges() {
-        if (!pageManagerState) return false;
-        if (pageManagerState.draftPages.length !== state.pageCount) {
-            return true;
-        }
-        return pageManagerState.draftPages.some(function (page, index) {
-            return page.sourceId !== 'active' || page.sourcePageIndex !== index;
-        });
-    }
-
-    function getPageManagerSplitGroups() {
-        if (!pageManagerState || !pageManagerState.draftPages.length) return [];
-        const groups = [];
-        let currentGroup = [];
-        pageManagerState.draftPages.forEach(function (page, index) {
-            if (index > 0 && page.splitBefore && currentGroup.length) {
-                groups.push(currentGroup);
-                currentGroup = [];
-            }
-            currentGroup.push(page);
-        });
-        if (currentGroup.length) {
-            groups.push(currentGroup);
-        }
-        return groups;
-    }
-
-    function syncPageManagerInsertPositionOptions() {
-        if (!pageManagerState) return;
-        const previousValue = pageManagerInsertPosition.value;
-        pageManagerInsertPosition.innerHTML = '';
-        const totalPages = pageManagerState.draftPages.length;
-        if (!totalPages) {
-            const option = document.createElement('option');
-            option.value = '0';
-            option.textContent = 'At beginning';
-            pageManagerInsertPosition.appendChild(option);
-            return;
-        }
-        for (let index = 0; index <= totalPages; index += 1) {
-            const option = document.createElement('option');
-            option.value = String(index);
-            if (index === 0) {
-                option.textContent = 'Before page 1';
-            } else if (index === totalPages) {
-                option.textContent = 'After page ' + totalPages;
-            } else {
-                option.textContent = 'Between pages ' + index + ' and ' + (index + 1);
-            }
-            pageManagerInsertPosition.appendChild(option);
-        }
-        if (Array.from(pageManagerInsertPosition.options).some(function (option) { return option.value === previousValue; })) {
-            pageManagerInsertPosition.value = previousValue;
-        } else {
-            pageManagerInsertPosition.value = String(totalPages);
-        }
-    }
-
-    function renderPageManagerSummary() {
-        if (!pageManagerState) return;
-        const totalPages = pageManagerState.draftPages.length;
-        const insertedCount = pageManagerState.draftPages.filter(function (page) { return page.sourceId !== 'active'; }).length;
-        const splitCount = Math.max(getPageManagerSplitGroups().length - 1, 0);
-        const parts = [totalPages + ' page' + (totalPages === 1 ? '' : 's')];
-        if (insertedCount) {
-            parts.push(insertedCount + ' inserted');
-        }
-        if (splitCount) {
-            parts.push(splitCount + ' split point' + (splitCount === 1 ? '' : 's'));
-        }
-        pageManagerSummary.textContent = parts.join(' • ');
-    }
-
-    function updatePageManagerControls() {
-        if (!pageManagerState) return;
-        const insertSource = getPageManagerSource(pageManagerState.insertSourceId);
-        const selectedInsertCount = insertSource && pageManagerState.insertSelections
-            ? pageManagerState.insertSelections.size
-            : 0;
-        if (!insertSource) {
-            pageManagerInsertSelectionSummary.textContent = 'No insert PDF loaded.';
-        } else if (!selectedInsertCount) {
-            pageManagerInsertSelectionSummary.textContent = insertSource.name + ' loaded. Select page cards to insert.';
-        } else {
-            pageManagerInsertSelectionSummary.textContent = selectedInsertCount + ' page' + (selectedInsertCount === 1 ? '' : 's') + ' selected from ' + insertSource.name + '.';
-        }
-        pageManagerInsertRunBtn.disabled = !insertSource || selectedInsertCount === 0;
-        pageManagerApplyBtn.disabled = !pageManagerState.draftPages.length || !hasPageManagerStructuralChanges();
-        pageManagerDownloadSplitsBtn.disabled = getPageManagerSplitGroups().length < 2;
-        renderPageManagerSummary();
-        syncPageManagerInsertPositionOptions();
-    }
-
-    async function ensurePageManagerThumbnail(source, pageIndex) {
-        if (!source) return '';
-        if (!source.thumbCache) {
-            source.thumbCache = {};
-        }
-        if (source.thumbCache[pageIndex]) {
-            return source.thumbCache[pageIndex];
-        }
-        const page = await source.pdfDoc.getPage(pageIndex + 1);
-        const viewport = page.getViewport({ scale: 0.23 });
-        const canvas = document.createElement('canvas');
-        canvas.width = viewport.width;
-        canvas.height = viewport.height;
-        await page.render({
-            canvasContext: canvas.getContext('2d'),
-            viewport: viewport,
-            annotationMode: 0
-        }).promise;
-        source.thumbCache[pageIndex] = canvas.toDataURL('image/png');
-        return source.thumbCache[pageIndex];
-    }
-
-    async function hydratePageManagerThumb(thumbEl, sourceId, pageIndex) {
-        const source = getPageManagerSource(sourceId);
-        if (!thumbEl || !source || !source.pdfDoc) return;
-        thumbEl.innerHTML = '<div class="page-manager-thumb-placeholder">Rendering preview…</div>';
-        try {
-            const imageUrl = await ensurePageManagerThumbnail(source, pageIndex);
-            if (!thumbEl.isConnected) return;
-            const image = document.createElement('img');
-            image.src = imageUrl;
-            image.alt = 'Page preview';
-            thumbEl.innerHTML = '';
-            thumbEl.appendChild(image);
-        } catch (_error) {
-            if (!thumbEl.isConnected) return;
-            thumbEl.innerHTML = '<div class="page-manager-thumb-placeholder">Preview unavailable</div>';
-        }
-    }
-
-    function clearPageManagerDropTargets() {
-        pageManagerPages.querySelectorAll('.page-manager-page.drop-target').forEach(function (card) {
-            card.classList.remove('drop-target');
-        });
-        pageManagerDropzone.classList.remove('drop-target');
-    }
-
-    function movePageManagerDraftPage(pageId, nextIndex) {
-        if (!pageManagerState) return;
-        const currentIndex = pageManagerState.draftPages.findIndex(function (page) {
-            return page.id === pageId;
-        });
-        if (currentIndex < 0) return;
-        const boundedIndex = clamp(nextIndex, 0, pageManagerState.draftPages.length);
-        if (currentIndex === boundedIndex) return;
-        const movedPage = pageManagerState.draftPages.splice(currentIndex, 1)[0];
-        const adjustedIndex = boundedIndex > currentIndex ? boundedIndex - 1 : boundedIndex;
-        pageManagerState.draftPages.splice(adjustedIndex, 0, movedPage);
-        renderPageManagerPages();
-    }
-
-    function renderPageManagerPages() {
-        if (!pageManagerState) return;
-        pageManagerPages.innerHTML = '';
-        pageManagerState.draftPages.forEach(function (page, index) {
-            const source = getPageManagerSource(page.sourceId);
-            const card = document.createElement('div');
-            card.className = 'page-manager-page';
-            card.draggable = true;
-            card.dataset.pageId = page.id;
-
-            const header = document.createElement('div');
-            header.className = 'page-manager-page-header';
-            header.innerHTML =
-                '<div>' +
-                    '<div class="page-manager-page-title">Page ' + (index + 1) + '</div>' +
-                    '<div class="page-manager-page-subtitle">Source page ' + (page.sourcePageIndex + 1) + '</div>' +
-                '</div>' +
-                '<span class="page-manager-source-badge">' + escapeHtml(source && source.kind === 'active' ? 'Active PDF' : 'Inserted PDF') + '</span>';
-            card.appendChild(header);
-
-            const thumb = document.createElement('div');
-            thumb.className = 'page-manager-thumb';
-            thumb.innerHTML = '<div class="page-manager-thumb-placeholder">Rendering preview…</div>';
-            card.appendChild(thumb);
-            void hydratePageManagerThumb(thumb, page.sourceId, page.sourcePageIndex);
-
-            const actions = document.createElement('div');
-            actions.className = 'page-manager-page-actions';
-            actions.innerHTML =
-                '<div class="form-check mb-0">' +
-                    '<input class="form-check-input page-manager-split-toggle"' +
-                        (index === 0 ? ' disabled' : '') +
-                        ' type="checkbox" data-page-id="' + escapeHtml(page.id) + '"' +
-                        (page.splitBefore ? ' checked' : '') +
-                        ' id="page-manager-split-' + escapeHtml(page.id) + '">' +
-                    '<label class="form-check-label small" for="page-manager-split-' + escapeHtml(page.id) + '">Start new document here</label>' +
-                '</div>' +
-                '<button type="button" class="btn btn-outline-danger btn-sm" data-page-manager-action="remove" data-page-id="' + escapeHtml(page.id) + '">Remove</button>';
-            card.appendChild(actions);
-
-            pageManagerPages.appendChild(card);
-        });
-        updatePageManagerControls();
-    }
-
-    function renderPageManagerInsertPages() {
-        pageManagerInsertPages.innerHTML = '';
-        if (!pageManagerState) return;
-        const insertSource = getPageManagerSource(pageManagerState.insertSourceId);
-        if (!insertSource) {
-            updatePageManagerControls();
-            return;
-        }
-        for (let pageIndex = 0; pageIndex < insertSource.pdfDoc.numPages; pageIndex += 1) {
-            const selected = pageManagerState.insertSelections.has(pageIndex);
-            const card = document.createElement('button');
-            card.type = 'button';
-            card.className = 'insert-page-card text-start' + (selected ? ' selected' : '');
-            card.dataset.insertPageIndex = String(pageIndex);
-            card.innerHTML =
-                '<div class="d-flex justify-content-between align-items-center gap-2 mb-2">' +
-                    '<div class="small fw-semibold">Page ' + (pageIndex + 1) + '</div>' +
-                    '<input type="checkbox" class="form-check-input m-0" tabindex="-1"' + (selected ? ' checked' : '') + '>' +
-                '</div>';
-            const thumb = document.createElement('div');
-            thumb.className = 'page-manager-thumb mb-0';
-            thumb.innerHTML = '<div class="page-manager-thumb-placeholder">Rendering preview…</div>';
-            card.appendChild(thumb);
-            void hydratePageManagerThumb(thumb, insertSource.id, pageIndex);
-            pageManagerInsertPages.appendChild(card);
-        }
-        updatePageManagerControls();
-    }
-
-    function renderPageManager() {
-        renderPageManagerPages();
-        renderPageManagerInsertPages();
-        updatePageManagerControls();
-    }
-
-    function buildFreshPageManagerState() {
-        return {
-            sources: {
-                active: {
-                    id: 'active',
-                    kind: 'active',
-                    name: state.fileName || 'active.pdf',
-                    bytes: clonePdfBytes(state.pdfBytes),
-                    pdfDoc: state.pdfDoc,
-                    thumbCache: {}
-                }
-            },
-            draftPages: Array.from({ length: state.pageCount }, function (_unused, index) {
-                return createPageManagerDraftPage('active', index);
-            }),
-            insertSourceId: null,
-            insertSelections: new Set()
-        };
-    }
-
-    function openPageManager() {
-        if (!state.pdfBytes || !state.pdfDoc) return;
-        pageManagerState = buildFreshPageManagerState();
-        pageManagerInsertFileInput.value = '';
-        pageManagerInsertFileName.textContent = '';
-        pageManagerDragPageId = null;
-        setPageManagerStatus('', 'info');
-        renderPageManager();
-        pageManagerModal.classList.remove('hidden');
-    }
-
-    function closePageManager() {
-        pageManagerModal.classList.add('hidden');
-        pageManagerState = null;
-        pageManagerDragPageId = null;
-        setPageManagerStatus('', 'info');
-    }
-
-    async function loadPageManagerInsertSource(file) {
-        if (!pageManagerState || !file) return;
-        setPageManagerStatus('Loading insert PDF...', 'info');
-        try {
-            const bytes = clonePdfBytes(arrayBufferToUint8Array(await file.arrayBuffer()));
-            const pdfDoc = await pdfjsLib.getDocument({ data: clonePdfBytes(bytes) }).promise;
-            const sourceId = 'insert-' + Date.now();
-            pageManagerState.sources[sourceId] = {
-                id: sourceId,
-                kind: 'insert',
-                name: file.name || 'insert.pdf',
-                bytes: bytes,
-                pdfDoc: pdfDoc,
-                thumbCache: {}
-            };
-            pageManagerState.insertSourceId = sourceId;
-            pageManagerState.insertSelections = new Set();
-            pageManagerInsertFileName.textContent = file.name || 'insert.pdf';
-            renderPageManagerInsertPages();
-            setPageManagerStatus('Insert PDF loaded.', 'success');
-        } catch (error) {
-            console.error('Error loading insert PDF:', error);
-            setPageManagerStatus('Could not load insert PDF: ' + (error && error.message ? error.message : 'Unknown error.'), 'danger');
-        }
-    }
-
-    function togglePageManagerInsertSelection(pageIndex) {
-        if (!pageManagerState) return;
-        if (pageManagerState.insertSelections.has(pageIndex)) {
-            pageManagerState.insertSelections.delete(pageIndex);
-        } else {
-            pageManagerState.insertSelections.add(pageIndex);
-        }
-        renderPageManagerInsertPages();
-    }
-
-    function insertSelectedPagesIntoManager() {
-        if (!pageManagerState) return;
-        const source = getPageManagerSource(pageManagerState.insertSourceId);
-        const selectedPages = Array.from(pageManagerState.insertSelections).sort(function (left, right) {
-            return left - right;
-        });
-        if (!source || !selectedPages.length) return;
-        const insertAt = clamp(Number(pageManagerInsertPosition.value || pageManagerState.draftPages.length), 0, pageManagerState.draftPages.length);
-        const draftPages = selectedPages.map(function (pageIndex) {
-            return createPageManagerDraftPage(source.id, pageIndex);
-        });
-        pageManagerState.draftPages.splice.apply(pageManagerState.draftPages, [insertAt, 0].concat(draftPages));
-        pageManagerState.insertSelections = new Set();
-        renderPageManager();
-        setPageManagerStatus('Inserted ' + selectedPages.length + ' page' + (selectedPages.length === 1 ? '' : 's') + '.', 'success');
-    }
-
-    async function buildPdfBytesFromPageDescriptors(pages) {
-        if (!PDFLibGlobal.PDFDocument) {
-            throw new Error('Page management requires pdf-lib in the browser.');
-        }
-        const outputDoc = await PDFLibGlobal.PDFDocument.create();
-        const sourceDocs = {};
-        for (const page of pages) {
-            const source = getPageManagerSource(page.sourceId);
-            if (!source || !source.bytes) {
-                throw new Error('A source PDF is missing for one or more pages.');
-            }
-            if (!sourceDocs[source.id]) {
-                sourceDocs[source.id] = await PDFLibGlobal.PDFDocument.load(clonePdfBytes(source.bytes));
-            }
-            const copiedPages = await outputDoc.copyPages(sourceDocs[source.id], [page.sourcePageIndex]);
-            outputDoc.addPage(copiedPages[0]);
-        }
-        return new Uint8Array(await outputDoc.save());
-    }
-
-    function remapFieldsForPageManagerDraft() {
-        const fieldsByPageIndex = new Map();
-        state.fields.forEach(function (field) {
-            if (!fieldsByPageIndex.has(field.pageIndex)) {
-                fieldsByPageIndex.set(field.pageIndex, []);
-            }
-            fieldsByPageIndex.get(field.pageIndex).push(field);
-        });
-
-        const nextFields = [];
-        pageManagerState.draftPages.forEach(function (page, newPageIndex) {
-            if (page.sourceId !== 'active') return;
-            const sourceFields = fieldsByPageIndex.get(page.sourcePageIndex) || [];
-            sourceFields.forEach(function (field) {
-                nextFields.push(Object.assign({}, field, { pageIndex: newPageIndex }));
-            });
-        });
-        return nextFields;
-    }
-
-    async function applyPageManagerChanges() {
-        if (!pageManagerState || !pageManagerState.draftPages.length) {
-            setPageManagerStatus('Keep at least one page in the document.', 'danger');
-            return;
-        }
-        showLoading('Applying page changes...');
-        try {
-            const nextPdfBytes = await buildPdfBytesFromPageDescriptors(pageManagerState.draftPages);
-            const nextFields = remapFieldsForPageManagerDraft();
-            syncPdfState(nextPdfBytes, state.fileName || 'edited-form.pdf');
-            updateDocumentName();
-            await refreshPdfDocumentFromState();
-            replaceFields(nextFields, { preserveSelection: true });
-            setDirty(true);
-            closePageManager();
-            showPdfWorkspace();
-            showSuccess('Page changes applied to the workspace.');
-        } catch (error) {
-            console.error('Error applying page changes:', error);
-            setPageManagerStatus('Could not apply page changes: ' + (error && error.message ? error.message : 'Unknown error.'), 'danger');
-        } finally {
-            hideLoading();
-        }
-    }
-
-    async function downloadSplitDocumentsFromManager() {
-        if (!pageManagerState) return;
-        const groups = getPageManagerSplitGroups();
-        if (groups.length < 2) {
-            setPageManagerStatus('Add at least one split point before downloading multiple documents.', 'warning');
-            return;
-        }
-        if (state.fields.length > 0 && state.hasUnsavedChanges) {
-            const confirmed = window.confirm('Split downloads use the current PDF pages only. Unsaved field overlay edits will not be embedded. Continue?');
-            if (!confirmed) return;
-        }
-        showLoading('Preparing split PDFs...');
-        try {
-            const baseName = sanitizeFilenameSegment(stripPdfExtension(state.fileName || 'document'), 'document');
-            const outputs = [];
-            for (let index = 0; index < groups.length; index += 1) {
-                const bytes = await buildPdfBytesFromPageDescriptors(groups[index]);
-                outputs.push({
-                    name: baseName + '-part-' + String(index + 1).padStart(2, '0') + '.pdf',
-                    bytes: bytes
-                });
-            }
-            if (JSZipGlobal) {
-                const zip = new JSZipGlobal();
-                outputs.forEach(function (output) {
-                    zip.file(output.name, output.bytes);
-                });
-                const zipBlob = await zip.generateAsync({ type: 'blob' });
-                downloadBlob(zipBlob, baseName + '-split-pdfs.zip');
-            } else {
-                outputs.forEach(function (output) {
-                    downloadBlob(new Blob([output.bytes], { type: 'application/pdf' }), output.name);
-                });
-            }
-            setPageManagerStatus('Downloaded ' + outputs.length + ' split PDF' + (outputs.length === 1 ? '' : 's') + '.', 'success');
-            showSuccess('Split PDFs downloaded.');
-        } catch (error) {
-            console.error('Error downloading split PDFs:', error);
-            setPageManagerStatus('Could not split the PDF: ' + (error && error.message ? error.message : 'Unknown error.'), 'danger');
-        } finally {
-            hideLoading();
-        }
-    }
-
-    document.addEventListener('pointermove', function (event) {
-        if (draftState) {
-            const overlay = getOverlayForPage(draftState.pageIndex);
-            if (!overlay) return;
-            const rect = overlay.getBoundingClientRect();
-            draftState.currentX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
-            draftState.currentY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
-            renderDraftRect();
-            return;
-        }
-        if (dragState) {
-            handleDragMove(event);
-            return;
-        }
-        if (resizeState) {
-            handleResizeMove(event);
-        }
-    });
-
-    document.addEventListener('pointerup', function () {
-        if (draftState && state.selectedTool) {
-            const width = Math.abs(draftState.currentX - draftState.startX);
-            const height = Math.abs(draftState.currentY - draftState.startY);
-            if (width >= 0.01 && height >= 0.01) {
-                createFieldFromTool(
-                    draftState.pageIndex,
-                    Math.min(draftState.startX, draftState.currentX),
-                    Math.min(draftState.startY, draftState.currentY),
-                    width,
-                    height
-                );
-            }
-        }
-        clearInteractionState();
-    });
-
-    fileInput.addEventListener('change', function (event) {
-        const file = event.target.files && event.target.files[0];
-        if (file) {
-            loadPdf(file);
-        }
-        fileInput.value = '';
-    });
-
-    pdfZoomOutBtn.addEventListener('click', function () {
-        void updateViewerZoom(state.viewerZoom - 0.15);
-    });
-    pdfZoomInBtn.addEventListener('click', function () {
-        void updateViewerZoom(state.viewerZoom + 0.15);
-    });
-    pdfZoomResetBtn.addEventListener('click', function () {
-        void updateViewerZoom(1);
-    });
-
-    pdfContainer.addEventListener('dragover', function (event) {
-        event.preventDefault();
-        pdfContainer.classList.add('drag-over');
-    });
-
-    pdfContainer.addEventListener('dragleave', function () {
-        pdfContainer.classList.remove('drag-over');
-    });
-
-    pdfContainer.addEventListener('drop', function (event) {
-        event.preventDefault();
-        pdfContainer.classList.remove('drag-over');
-        const file = event.dataTransfer.files && event.dataTransfer.files[0];
-        if (file && file.type === 'application/pdf') {
-            loadPdf(file);
-        }
-    });
-    pdfContainer.addEventListener('scroll', function () {
-        currentVisiblePageIndex = getCurrentVisiblePageIndex();
-        positionQuickFieldEditor();
-    });
-    pdfContainer.addEventListener('wheel', function (event) {
-        if (!state.pdfBytes || !(event.ctrlKey || event.metaKey)) return;
-        if (event.cancelable) {
-            event.preventDefault();
-        }
-        void updateViewerZoom(state.viewerZoom + (event.deltaY < 0 ? 0.1 : -0.1));
-    }, { passive: false });
-    fieldsList.addEventListener('scroll', function () {
-        if (fieldsListProgrammaticScroll) return;
-        fieldsListManualScrollUntil = Date.now() + 1600;
-    });
-    fieldSearchInput.addEventListener('input', function () {
-        state.fieldSearch = fieldSearchInput.value || '';
-        refreshFieldsListFromControls();
-    });
-    fieldTypeFilterInput.addEventListener('change', function () {
-        state.fieldTypeFilter = fieldTypeFilterInput.value || '';
-        refreshFieldsListFromControls();
-    });
-    fieldSortInput.addEventListener('change', function () {
-        state.fieldSort = fieldSortInput.value || 'position';
-        refreshFieldsListFromControls();
-    });
-    fieldsModeInputs.forEach(function (input) {
-        input.addEventListener('change', function () {
-            setFieldsPanelMode(input.value);
-        });
-    });
-    bulkRenameTypeInput.addEventListener('change', function () {
-        state.bulkRenameType = bulkRenameTypeInput.value === 'regex' ? 'regex' : 'pattern';
-        invalidateBulkRenamePreview();
-        refreshFieldsListFromControls();
-    });
-    bulkRenamePatternInput.addEventListener('input', function () {
-        state.bulkRenamePattern = bulkRenamePatternInput.value || '';
-        invalidateBulkRenamePreview();
-        refreshFieldsListFromControls();
-    });
-    bulkRenameReplacementInput.addEventListener('input', function () {
-        state.bulkRenameReplacement = bulkRenameReplacementInput.value || '';
-        invalidateBulkRenamePreview();
-        refreshFieldsListFromControls();
-    });
-    bulkRenameApplyBtn.addEventListener('click', applyBulkRename);
-    window.addEventListener('resize', function () {
-        currentVisiblePageIndex = getCurrentVisiblePageIndex();
-        positionQuickFieldEditor();
-    });
-
-    Object.keys(toolButtons).forEach(function (tool) {
-        toolButtons[tool].addEventListener('click', function () {
-            setSelectedTool(state.selectedTool === tool ? null : tool);
-            if (state.selectedTool) {
-                selectField(null, { focusNameInput: false, scrollIntoView: false });
-            }
-        });
-    });
-
-    normalizePassBtn.addEventListener('click', function () {
-        if (!state.pdfBytes || state.fields.length === 0) return;
-        // Pre-populate normalization modal with session defaults
-        var sessionDefs = _loadSessionDefaults();
-        document.getElementById('norm-font-name').value = sessionDefs.font || 'Helvetica';
-        document.getElementById('norm-font-size').value = String(sessionDefs.fontSize || 10);
-        document.getElementById('norm-checkbox-style').value = sessionDefs.checkboxStyle || 'cross';
-        normalizationModal.classList.remove('hidden');
-    });
-    repairBtn.addEventListener('click', function () {
-        if (!state.pdfBytes) return;
-        repairStatus.classList.add('hidden');
-        repairModal.querySelectorAll('.repair-run-btn').forEach(function (btn) { btn.disabled = false; });
-        repairModal.classList.remove('hidden');
-    });
-    managePagesBtn.addEventListener('click', function () {
-        openPageManager();
-    });
-    closePageManagerBtn.addEventListener('click', function () {
-        closePageManager();
-    });
-    pageManagerResetBtn.addEventListener('click', function () {
-        if (!state.pdfBytes) return;
-        pageManagerState = buildFreshPageManagerState();
-        pageManagerInsertFileInput.value = '';
-        pageManagerInsertFileName.textContent = '';
-        setPageManagerStatus('Page arrangement reset to the active PDF.', 'info');
-        renderPageManager();
-    });
-    pageManagerInsertFileInput.addEventListener('change', function (event) {
-        const file = event.target.files && event.target.files[0];
-        if (file) {
-            void loadPageManagerInsertSource(file);
-        }
-        pageManagerInsertFileInput.value = '';
-    });
-    pageManagerInsertRunBtn.addEventListener('click', function () {
-        insertSelectedPagesIntoManager();
-    });
-    pageManagerApplyBtn.addEventListener('click', function () {
-        void applyPageManagerChanges();
-    });
-    pageManagerDownloadSplitsBtn.addEventListener('click', function () {
-        void downloadSplitDocumentsFromManager();
-    });
-    pageManagerInsertPages.addEventListener('click', function (event) {
-        const card = event.target.closest('[data-insert-page-index]');
-        if (!card || !pageManagerState) return;
-        togglePageManagerInsertSelection(Number(card.dataset.insertPageIndex || 0));
-    });
-    pageManagerPages.addEventListener('click', function (event) {
-        const removeBtn = event.target.closest('[data-page-manager-action="remove"][data-page-id]');
-        if (!removeBtn || !pageManagerState) return;
-        if (pageManagerState.draftPages.length <= 1) {
-            setPageManagerStatus('The document must keep at least one page.', 'warning');
-            return;
-        }
-        const pageId = removeBtn.dataset.pageId;
-        pageManagerState.draftPages = pageManagerState.draftPages.filter(function (page) {
-            return page.id !== pageId;
-        });
-        renderPageManagerPages();
-    });
-    pageManagerPages.addEventListener('change', function (event) {
-        const toggle = event.target.closest('.page-manager-split-toggle[data-page-id]');
-        if (!toggle || !pageManagerState) return;
-        const page = pageManagerState.draftPages.find(function (candidate) {
-            return candidate.id === toggle.dataset.pageId;
-        });
-        if (!page) return;
-        page.splitBefore = !!toggle.checked;
-        updatePageManagerControls();
-    });
-    pageManagerPages.addEventListener('dragstart', function (event) {
-        const card = event.target.closest('.page-manager-page[data-page-id]');
-        if (!card || !pageManagerState) return;
-        pageManagerDragPageId = card.dataset.pageId;
-        card.classList.add('dragging');
-        if (event.dataTransfer) {
-            event.dataTransfer.effectAllowed = 'move';
-        }
-    });
-    pageManagerPages.addEventListener('dragend', function () {
-        pageManagerDragPageId = null;
-        pageManagerPages.querySelectorAll('.page-manager-page.dragging').forEach(function (card) {
-            card.classList.remove('dragging');
-        });
-        clearPageManagerDropTargets();
-    });
-    pageManagerPages.addEventListener('dragover', function (event) {
-        const card = event.target.closest('.page-manager-page[data-page-id]');
-        if (!card || !pageManagerState || !pageManagerDragPageId || card.dataset.pageId === pageManagerDragPageId) return;
-        event.preventDefault();
-        clearPageManagerDropTargets();
-        card.classList.add('drop-target');
-    });
-    pageManagerPages.addEventListener('drop', function (event) {
-        const card = event.target.closest('.page-manager-page[data-page-id]');
-        if (!card || !pageManagerState || !pageManagerDragPageId || card.dataset.pageId === pageManagerDragPageId) return;
-        event.preventDefault();
-        const nextIndex = pageManagerState.draftPages.findIndex(function (page) {
-            return page.id === card.dataset.pageId;
-        });
-        movePageManagerDraftPage(pageManagerDragPageId, nextIndex);
-        clearPageManagerDropTargets();
-    });
-    pageManagerDropzone.addEventListener('dragover', function (event) {
-        if (!pageManagerState || !pageManagerDragPageId) return;
-        event.preventDefault();
-        clearPageManagerDropTargets();
-        pageManagerDropzone.classList.add('drop-target');
-    });
-    pageManagerDropzone.addEventListener('drop', function (event) {
-        if (!pageManagerState || !pageManagerDragPageId) return;
-        event.preventDefault();
-        movePageManagerDraftPage(pageManagerDragPageId, pageManagerState.draftPages.length);
-        clearPageManagerDropTargets();
-    });
-    closeRepairBtn.addEventListener('click', function () {
-        repairModal.classList.add('hidden');
-    });
-
-    /* --------------- Utilities modal --------------- */
-    var utilCopySourceBytes = null;
-    var utilCopySourceName = '';
-    var utilCopyDestBytes = null;
-    var utilCopyDestName = '';
-
-    function updateUtilCopyRunState() {
-        document.getElementById('util-copy-run').disabled = !(utilCopySourceBytes && utilCopyDestBytes);
-    }
-    function updateUtilActiveButtons() {
-        var hasPdf = !!state.pdfBytes;
-        document.getElementById('util-copy-source-active').disabled = !hasPdf;
-        document.getElementById('util-copy-dest-active').disabled = !hasPdf;
-    }
-
-    previewBtn.addEventListener('click', function () {
-        state.previewMode = !state.previewMode;
-        previewBtn.classList.toggle('active', state.previewMode);
-        document.getElementById('preview-icon-open').classList.toggle('hidden', state.previewMode);
-        document.getElementById('preview-icon-closed').classList.toggle('hidden', !state.previewMode);
-        renderFieldsOnPages();
-    });
-
-    utilitiesBtn.addEventListener('click', function () {
-        utilCopySourceBytes = null;
-        utilCopySourceName = '';
-        utilCopyDestBytes = null;
-        utilCopyDestName = '';
-        document.getElementById('util-copy-source-name').textContent = '';
-        document.getElementById('util-copy-dest-name').textContent = '';
-        document.getElementById('util-copy-source-file').value = '';
-        document.getElementById('util-copy-dest-file').value = '';
-        document.getElementById('util-copy-status').classList.add('hidden');
-        document.getElementById('util-bulk-status').classList.add('hidden');
-        document.getElementById('util-bulk-size-warning').classList.add('hidden');
-        document.getElementById('util-bulk-files').value = '';
-        document.getElementById('util-attachment-status').classList.add('hidden');
-        document.getElementById('util-attachment-output').value = '';
-        document.getElementById('util-attachment-generate').disabled = state.fields.length === 0;
-        document.getElementById('util-attachment-copy').disabled = true;
-        bulkFiles = [];
-        updateBulkState();
-        updateUtilActiveButtons();
-        updateUtilCopyRunState();
-        utilitiesModal.classList.remove('hidden');
-    });
-    utilitiesCloseBtn.addEventListener('click', function () {
-        utilitiesModal.classList.add('hidden');
-    });
-    [
-        document.getElementById('field-rename-summary-close'),
-        document.getElementById('field-rename-summary-done')
-    ].forEach(function (button) {
-        button.addEventListener('click', function () {
-            fieldRenameSummaryModal.classList.add('hidden');
-        });
-    });
-
-    document.getElementById('util-attachment-generate').addEventListener('click', function () {
-        var statusEl = document.getElementById('util-attachment-status');
-        var outputEl = document.getElementById('util-attachment-output');
-        var copyBtn = document.getElementById('util-attachment-copy');
-        statusEl.className = 'alert alert-info small mb-2';
-        statusEl.textContent = 'Generating attachment block...';
-        statusEl.classList.remove('hidden');
-        fetch(apiUrl('/pdf-labeler/api/attachment-block'), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-            body: JSON.stringify({
-                field_names: state.fields.map(function (field) { return field.name; }),
-                filename: state.fileName || 'template.pdf'
-            })
-        })
-        .then(function (response) { return parseApiResponse(response); })
-        .then(function (data) {
-            if (!data.success || !data.data) {
-                throw new Error((data.error && data.error.message) || 'Generation failed.');
-            }
-            outputEl.value = data.data.attachment_block || 'fields:';
-            copyBtn.disabled = false;
-            statusEl.className = 'alert alert-success small mb-2';
-            statusEl.textContent = 'Attachment block generated.';
-        })
-        .catch(function (error) {
-            statusEl.className = 'alert alert-danger small mb-2';
-            statusEl.textContent = 'Error: ' + (error && error.message ? error.message : 'Unknown error.');
-        });
-    });
-    document.getElementById('util-attachment-copy').addEventListener('click', function () {
-        var outputEl = document.getElementById('util-attachment-output');
-        var copyPromise = navigator.clipboard && navigator.clipboard.writeText
-            ? navigator.clipboard.writeText(outputEl.value)
-            : Promise.reject(new Error('Clipboard API unavailable'));
-        copyPromise.then(function () {
-            showSuccess('Attachment fields block copied.');
-        }).catch(function () {
-            outputEl.focus();
-            outputEl.select();
-            document.execCommand('copy');
-            showSuccess('Attachment fields block copied.');
-        });
-    });
-
-    document.getElementById('util-copy-source-file').addEventListener('change', function (e) {
-        var file = e.target.files && e.target.files[0];
-        if (!file) return;
-        file.arrayBuffer().then(function (buf) {
-            utilCopySourceBytes = new Uint8Array(buf);
-            utilCopySourceName = file.name || 'source.pdf';
-            document.getElementById('util-copy-source-name').textContent = utilCopySourceName;
-            updateUtilCopyRunState();
-        });
-    });
-    document.getElementById('util-copy-dest-file').addEventListener('change', function (e) {
-        var file = e.target.files && e.target.files[0];
-        if (!file) return;
-        file.arrayBuffer().then(function (buf) {
-            utilCopyDestBytes = new Uint8Array(buf);
-            utilCopyDestName = file.name || 'destination.pdf';
-            document.getElementById('util-copy-dest-name').textContent = utilCopyDestName;
-            updateUtilCopyRunState();
-        });
-    });
-    document.getElementById('util-copy-source-active').addEventListener('click', function () {
-        if (!state.pdfBytes) return;
-        utilCopySourceBytes = state.pdfBytes;
-        utilCopySourceName = state.fileName || 'active.pdf';
-        document.getElementById('util-copy-source-name').textContent = utilCopySourceName + ' (active)';
-        updateUtilCopyRunState();
-    });
-    document.getElementById('util-copy-dest-active').addEventListener('click', function () {
-        if (!state.pdfBytes) return;
-        utilCopyDestBytes = state.pdfBytes;
-        utilCopyDestName = state.fileName || 'active.pdf';
-        document.getElementById('util-copy-dest-name').textContent = utilCopyDestName + ' (active)';
-        updateUtilCopyRunState();
-    });
-
-    document.getElementById('util-copy-run').addEventListener('click', function () {
-        if (!utilCopySourceBytes || !utilCopyDestBytes) return;
-        var statusEl = document.getElementById('util-copy-status');
-        statusEl.className = 'alert alert-info small mb-3';
-        statusEl.textContent = 'Copying fields...';
-        statusEl.classList.remove('hidden');
-        document.getElementById('util-copy-run').disabled = true;
-
-        var formData = new FormData();
-        formData.append('source', new Blob([utilCopySourceBytes], { type: 'application/pdf' }), utilCopySourceName);
-        formData.append('destination', new Blob([utilCopyDestBytes], { type: 'application/pdf' }), utilCopyDestName);
-
-        fetch(apiUrl('/pdf-labeler/api/copy-fields'), {
-            method: 'POST',
-            headers: { 'Accept': 'application/json' },
-            body: formData
-        })
-        .then(function (resp) { return parseApiResponse(resp); })
-        .then(function (data) {
-            if (!data.success) {
-                throw new Error((data.error && data.error.message) || 'Copy failed.');
-            }
-            if (!data.data || !data.data.pdf_base64) {
-                throw new Error('Server did not return a PDF.');
-            }
-            var outputBytes = base64ToUint8Array(data.data.pdf_base64);
-            var outputName = data.data.filename || 'result-with-fields.pdf';
-
-            statusEl.className = 'alert alert-success small mb-3';
-            statusEl.textContent = 'Fields copied successfully.';
-
-            var shouldLoad = document.getElementById('util-copy-load-result').checked;
-            if (shouldLoad) {
-                utilitiesModal.classList.add('hidden');
-                var blob = new Blob([outputBytes], { type: 'application/pdf' });
-                var file = new File([blob], outputName, { type: 'application/pdf' });
-                loadPdf(file);
-            } else {
-                var blob = new Blob([outputBytes], { type: 'application/pdf' });
-                var url = URL.createObjectURL(blob);
-                var anchor = document.createElement('a');
-                anchor.href = url;
-                anchor.download = outputName;
-                document.body.appendChild(anchor);
-                anchor.click();
-                document.body.removeChild(anchor);
-                URL.revokeObjectURL(url);
-            }
-        })
-        .catch(function (err) {
-            statusEl.className = 'alert alert-danger small mb-3';
-            statusEl.textContent = 'Error: ' + (err && err.message ? err.message : 'Unknown error.');
-        })
-        .finally(function () {
-            updateUtilCopyRunState();
-        });
-    });
-
-    /* --------------- Bulk normalize --------------- */
-    var bulkFiles = [];
-    var BULK_WARN_BYTES = 16 * 1024 * 1024;
-
-    function formatBytes(bytes) {
-        if (bytes < 1024) return bytes + ' B';
-        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-        return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-    }
-
-    function updateBulkState() {
-        document.getElementById('util-bulk-run').disabled = bulkFiles.length === 0;
-        document.getElementById('util-bulk-file-count').textContent =
-            bulkFiles.length ? bulkFiles.length + ' file' + (bulkFiles.length === 1 ? '' : 's') + ' selected' : '';
-        var totalSize = bulkFiles.reduce(function (sum, f) { return sum + f.size; }, 0);
-        var sizeWarning = document.getElementById('util-bulk-size-warning');
-        if (totalSize > BULK_WARN_BYTES) {
-            document.getElementById('util-bulk-size-display').textContent = formatBytes(totalSize);
-            sizeWarning.classList.remove('hidden');
-        } else {
-            sizeWarning.classList.add('hidden');
-        }
-    }
-
-    document.getElementById('util-bulk-files').addEventListener('change', function (e) {
-        bulkFiles = e.target.files ? Array.from(e.target.files) : [];
-        updateBulkState();
-    });
-
-    document.getElementById('util-bulk-run').addEventListener('click', function () {
-        if (!bulkFiles.length) return;
-        var statusEl = document.getElementById('util-bulk-status');
-        statusEl.className = 'alert alert-info small mb-3';
-        statusEl.textContent = 'Normalizing ' + bulkFiles.length + ' PDF' + (bulkFiles.length === 1 ? '' : 's') + '...';
-        statusEl.classList.remove('hidden');
-        document.getElementById('util-bulk-run').disabled = true;
-
-        var options = {
-            normalizeFont: document.getElementById('util-bulk-norm-font').checked,
-            fontName: document.getElementById('util-bulk-norm-font-name').value,
-            normalizeFontSize: document.getElementById('util-bulk-norm-fontsize').checked,
-            fontSizePt: Number(document.getElementById('util-bulk-norm-fontsize-val').value || 10),
-            normalizeCheckboxStyle: document.getElementById('util-bulk-norm-checkbox-style').checked,
-            checkboxStyle: document.getElementById('util-bulk-norm-checkbox-style-val').value,
-            checkboxExportValue: 'Yes',
-            uniformCheckboxSize: document.getElementById('util-bulk-norm-checkbox-size').checked,
-            checkboxSizePt: Number(document.getElementById('util-bulk-norm-checkbox-size-val').value || 12),
-            removeEmbeddedFonts: document.getElementById('util-bulk-norm-strip-fonts').checked
-        };
-
-        var formData = new FormData();
-        formData.append('options', JSON.stringify(options));
-        bulkFiles.forEach(function (file) {
-            formData.append('files', file, file.name);
-        });
-
-        fetch(apiUrl('/pdf-labeler/api/bulk-normalize'), {
-            method: 'POST',
-            headers: { 'Accept': 'application/json' },
-            body: formData
-        })
-        .then(function (resp) { return parseApiResponse(resp); })
-        .then(function (data) {
-            if (!data.success) {
-                throw new Error((data.error && data.error.message) || 'Bulk normalize failed.');
-            }
-            if (!data.data || !data.data.zip_base64) {
-                throw new Error('Server did not return a .zip file.');
-            }
-            var zipBytes = base64ToUint8Array(data.data.zip_base64);
-            var zipName = data.data.filename || 'normalized-pdfs.zip';
-
-            var summary = 'Normalized ' + data.data.processed + '/' + data.data.total + ' PDF' + (data.data.total === 1 ? '' : 's') + '.';
-            if (data.data.errors && data.data.errors.length) {
-                summary += ' Errors: ' + data.data.errors.join('; ');
-                statusEl.className = 'alert alert-warning small mb-3';
-            } else {
-                statusEl.className = 'alert alert-success small mb-3';
-            }
-            statusEl.textContent = summary;
-
-            var blob = new Blob([zipBytes], { type: 'application/zip' });
-            var url = URL.createObjectURL(blob);
-            var anchor = document.createElement('a');
-            anchor.href = url;
-            anchor.download = zipName;
-            document.body.appendChild(anchor);
-            anchor.click();
-            document.body.removeChild(anchor);
-            URL.revokeObjectURL(url);
-        })
-        .catch(function (err) {
-            statusEl.className = 'alert alert-danger small mb-3';
-            statusEl.textContent = 'Error: ' + (err && err.message ? err.message : 'Unknown error.');
-        })
-        .finally(function () {
-            updateBulkState();
-        });
-    });
-
-    repairModal.querySelectorAll('.repair-run-btn').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-            var action = btn.dataset.repairAction;
-            if (!action || !state.pdfBytes) return;
-            runRepairAction(action);
-        });
-    });
-    passwordSubmitBtn.addEventListener('click', submitPassword);
-    passwordInput.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter') submitPassword();
-    });
-    passwordCancelBtn.addEventListener('click', function () {
-        passwordModal.classList.add('hidden');
-        state._pendingPasswordFile = null;
-        pdfEmpty.classList.remove('hidden');
-    });
-    repairPromptFixBtn.addEventListener('click', function () {
-        repairPromptModal.classList.add('hidden');
-        if (state._pendingRepairFile || state.pdfBytes) {
-            runRepairAction('auto');
-        } else {
-            repairStatus.classList.add('hidden');
-            repairModal.querySelectorAll('.repair-run-btn').forEach(function (btn) { btn.disabled = false; });
-            repairBtn.disabled = false;
-            repairModal.classList.remove('hidden');
-        }
-    });
-    repairPromptCancelBtn.addEventListener('click', function () {
-        repairPromptModal.classList.add('hidden');
-        state._pendingRepairFile = null;
-        pdfEmpty.classList.remove('hidden');
-    });
-    accessibilityBtn.addEventListener('click', async function () {
-        if (!state.pdfBytes) return;
-        await inspectAccessibilityData(false).catch(function () {
-            showError('Could not inspect accessibility metadata for this PDF.');
-        });
-        renderAccessibilityModal();
-        accessibilityModal.classList.remove('hidden');
-    });
-    closeAccessibilityBtn.addEventListener('click', function () {
-        updateAccessibilityMetadataFromInputs();
-        accessibilityModal.classList.add('hidden');
-    });
-    a11yEnableInput.addEventListener('change', function () {
-        state.accessibility.enabled = !!a11yEnableInput.checked;
-    });
-    a11yImageModeInput.addEventListener('change', function () {
-        state.accessibility.imageMode = !!a11yImageModeInput.checked;
-        renderAccessibilityImages();
-    });
-    a11yAutofillTooltipsBtn.addEventListener('click', function () {
-        state.fields.forEach(function (field) {
-            if (!String(field.tooltip || '').trim()) {
-                field.tooltip = defaultTooltipFromFieldName(field.name);
-            }
-        });
-        renderAccessibilityFieldList();
-        setDirty(true);
-    });
-    [a11yMetaLanguage, a11yMetaTitle, a11yMetaAuthor, a11yMetaSubject].forEach(function (input) {
-        input.addEventListener('input', function () {
-            updateAccessibilityMetadataFromInputs();
-            setDirty(true);
-        });
-    });
-    a11yFieldList.addEventListener('input', function (event) {
-        var target = event.target;
-        if (!target || !target.dataset) return;
-        if (target.dataset.a11yAction !== 'tooltip') return;
-        var fieldId = target.dataset.fieldId;
-        var field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        field.tooltip = String(target.value || '');
-        setDirty(true);
-    });
-    a11yFieldList.addEventListener('click', function (event) {
-        var actionTarget = event.target.closest('[data-a11y-action]');
-        if (!actionTarget) return;
-        var action = actionTarget.dataset.a11yAction;
-        var fieldId = actionTarget.dataset.fieldId;
-        if (!fieldId || (action !== 'move-up' && action !== 'move-down')) return;
-        var order = state.accessibility.fieldOrder.slice();
-        var index = order.indexOf(fieldId);
-        if (index < 0) return;
-        var swapWith = action === 'move-up' ? index - 1 : index + 1;
-        if (swapWith < 0 || swapWith >= order.length) return;
-        var temp = order[swapWith];
-        order[swapWith] = order[index];
-        order[index] = temp;
-        state.accessibility.fieldOrder = order;
-        renderAccessibilityFieldList();
-        setDirty(true);
-    });
-    a11yFieldList.addEventListener('dragstart', function (event) {
-        if (!event.target.closest('.a11y-drag-handle')) return;
-        var row = event.target.closest('[data-field-id]');
-        if (!row) return;
-        a11yDragFieldId = row.dataset.fieldId;
-        row.classList.add('a11y-dragging');
-        if (event.dataTransfer) {
-            event.dataTransfer.effectAllowed = 'move';
-        }
-    });
-    a11yFieldList.addEventListener('dragend', function () {
-        a11yDragFieldId = null;
-        a11yFieldList.querySelectorAll('.a11y-dragging, .a11y-drag-over').forEach(function (el) {
-            el.classList.remove('a11y-dragging', 'a11y-drag-over');
-        });
-    });
-    a11yFieldList.addEventListener('dragover', function (event) {
-        if (!a11yDragFieldId) return;
-        event.preventDefault();
-        var row = event.target.closest('[data-field-id]');
-        a11yFieldList.querySelectorAll('.a11y-drag-over').forEach(function (el) {
-            el.classList.remove('a11y-drag-over');
-        });
-        if (row && row.dataset.fieldId !== a11yDragFieldId) {
-            row.classList.add('a11y-drag-over');
-        }
-    });
-    a11yFieldList.addEventListener('drop', function (event) {
-        if (!a11yDragFieldId) return;
-        event.preventDefault();
-        var targetRow = event.target.closest('[data-field-id]');
-        var order = state.accessibility.fieldOrder.slice();
-        var fromIndex = order.indexOf(a11yDragFieldId);
-        if (fromIndex < 0) return;
-        var toIndex;
-        if (targetRow && targetRow.dataset.fieldId !== a11yDragFieldId) {
-            toIndex = order.indexOf(targetRow.dataset.fieldId);
-            if (toIndex < 0) return;
-        } else if (!targetRow) {
-            toIndex = order.length;
-        } else {
-            return;
-        }
-        order.splice(fromIndex, 1);
-        var adjustedIndex = toIndex > fromIndex ? toIndex - 1 : toIndex;
-        order.splice(adjustedIndex, 0, a11yDragFieldId);
-        state.accessibility.fieldOrder = order;
-        a11yDragFieldId = null;
-        renderAccessibilityFieldList();
-        setDirty(true);
-    });
-    a11yImageList.addEventListener('input', function (event) {
-        var target = event.target;
-        if (!target || !target.dataset) return;
-        if (target.dataset.a11yAction !== 'image-alt') return;
-        var assetId = String(target.dataset.assetId || '');
-        if (!assetId) return;
-        var imageAsset = state.accessibility.images.find(function (item) {
-            return String(item.assetId || '') === assetId;
-        });
-        if (!imageAsset) return;
-        imageAsset.altText = String(target.value || '');
-        setDirty(true);
-    });
-    settingsBtn.addEventListener('click', function () {
-        aiModelInput.value = state.model || state.defaultModel;
-        renderModelSuggestions('');
-        // Load session defaults into settings UI
-        var sessionDefs = _loadSessionDefaults();
-        document.getElementById('settings-default-font').value = sessionDefs.font || 'Helvetica';
-        document.getElementById('settings-default-font-size').value = String(sessionDefs.fontSize || 10);
-        document.getElementById('settings-default-checkbox-style').value = sessionDefs.checkboxStyle || 'cross';
-        settingsModal.classList.remove('hidden');
-    });
-    closeSettingsBtn.addEventListener('click', function () {
-        settingsModal.classList.add('hidden');
-        aiModelSuggestions.classList.add('hidden');
-    });
-    closeNormalizationBtn.addEventListener('click', function () {
-        normalizationModal.classList.add('hidden');
-    });
-    applyNormalizationBtn.addEventListener('click', applyNormalizationPass);
-    saveSettingsBtn.addEventListener('click', function () {
-        state.model = aiModelInput.value.trim() || state.defaultModel;
-        // Save session defaults
-        setSessionDefault('font', document.getElementById('settings-default-font').value || 'Helvetica');
-        setSessionDefault('fontSize', Number(document.getElementById('settings-default-font-size').value) || 10);
-        setSessionDefault('checkboxStyle', document.getElementById('settings-default-checkbox-style').value || 'cross');
-        settingsModal.classList.add('hidden');
-        aiModelSuggestions.classList.add('hidden');
-    });
-    resetSettingsBtn.addEventListener('click', function () {
-        state.model = state.defaultModel;
-        aiModelInput.value = state.defaultModel;
-        // Reset session defaults to hard defaults
-        _saveSessionDefaults(Object.assign({}, HARD_DEFAULTS));
-        document.getElementById('settings-default-font').value = HARD_DEFAULTS.font;
-        document.getElementById('settings-default-font-size').value = String(HARD_DEFAULTS.fontSize);
-        document.getElementById('settings-default-checkbox-style').value = HARD_DEFAULTS.checkboxStyle;
-        renderModelSuggestions('');
-    });
-    aiModelInput.addEventListener('input', function () {
-        state.model = aiModelInput.value.trim() || state.defaultModel;
-        renderModelSuggestions(aiModelInput.value);
-    });
-    aiModelInput.addEventListener('focus', function () {
-        renderModelSuggestions(aiModelInput.value);
-    });
-    quickFieldCloseBtn.addEventListener('click', function () {
-        hideQuickFieldEditor();
-    });
-
-    // Close quick editor when clicking outside it, but keep the field selected
-    document.addEventListener('mousedown', function (event) {
-        if (state.quickEditFieldId &&
-            !quickFieldEditor.contains(event.target) &&
-            !event.target.closest('.field-box[data-field-id="' + state.quickEditFieldId + '"]')) {
-            hideQuickFieldEditor();
-        }
-    }, true);
-    quickFieldDeleteBtn.addEventListener('click', function () {
-        const field = getQuickEditField();
-        if (!field) return;
-        deleteField(field.id);
-    });
-    quickFieldNameInput.addEventListener('input', function () {
-        const field = getQuickEditField();
-        if (!field) return;
-        commitFieldNameChange(field.id, quickFieldNameInput.value, 'quick');
-    });
-    quickFieldNameInput.addEventListener('keydown', function (event) {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            hideQuickFieldEditor();
-            return;
-        }
-        if (event.key === 'Enter') {
-            event.preventDefault();
-            hideQuickFieldEditor();
-        }
-    });
-    quickFieldSuggestions.addEventListener('click', function (event) {
-        const button = event.target.closest('[data-suggested-name]');
-        const field = getQuickEditField();
-        if (!button || !field) return;
-        const nextName = button.dataset.suggestedName || '';
-        if (!nextName) return;
-        event.preventDefault();
-        commitFieldNameChange(field.id, nextName, 'quick');
-        quickFieldNameInput.value = nextName;
-        renderQuickFieldSuggestions(field);
-        quickFieldNameInput.focus();
-        quickFieldNameInput.select();
-    });
-
-    document.addEventListener('mousedown', function (event) {
-        if (!aiModelSuggestions.contains(event.target) &&
-            event.target !== aiModelInput &&
-            !settingsModal.contains(event.target)) {
-            aiModelSuggestions.classList.add('hidden');
-        }
-        const authMenu = document.getElementById('auth-menu');
-        if (authMenu && !authControls.contains(event.target)) {
-            authMenu.classList.remove('show');
-        }
-        if (!settingsModal.classList.contains('hidden') && event.target === settingsModal) {
-            settingsModal.classList.add('hidden');
-            aiModelSuggestions.classList.add('hidden');
-        }
-        if (!accessibilityModal.classList.contains('hidden') && event.target === accessibilityModal) {
-            updateAccessibilityMetadataFromInputs();
-            accessibilityModal.classList.add('hidden');
-        }
-        if (!normalizationModal.classList.contains('hidden') && event.target === normalizationModal) {
-            normalizationModal.classList.add('hidden');
-        }
-        if (!repairModal.classList.contains('hidden') && event.target === repairModal) {
-            repairModal.classList.add('hidden');
-        }
-        if (!pageManagerModal.classList.contains('hidden') && event.target === pageManagerModal) {
-            closePageManager();
-        }
-    });
-
-    fieldsList.addEventListener('input', function (event) {
-        const target = event.target;
-        if (!target || !target.dataset) return;
-        const fieldId = target.dataset.fieldId;
-        const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        if (target.dataset.action === 'field-name') {
-            commitFieldNameChange(fieldId, target.value, 'sidebar');
-            return;
-        }
-        if (target.dataset.action === 'field-options') {
-            field.options = target.value.split(',').map(function (option) {
-                return option.trim();
-            }).filter(Boolean);
-            if (!field.options.length) {
-                field.options = DEFAULT_OPTION_LIST.slice();
-            }
-            markDirtyAndRender();
-            return;
-        }
-        if (target.dataset.action === 'field-font-size') {
-            const parsedValue = Number(target.value);
-            if (Number.isFinite(parsedValue)) {
-                field.fontSize = clamp(parsedValue, 4, 72);
-                markDirtyAndRender();
-            }
-            return;
-        }
-        if (target.dataset.action === 'field-checkbox-export-value') {
-            field.checkboxExportValue = String(target.value || '').trim() || 'Yes';
-            markDirtyAndRender(true);
-        }
-    });
-
-    fieldsList.addEventListener('change', function (event) {
-        const target = event.target;
-        if (!target || !target.dataset) return;
-        const fieldId = target.dataset.fieldId;
-        const field = state.fields.find(function (candidate) { return candidate.id === fieldId; });
-        if (!field) return;
-        if (target.dataset.action === 'field-type') {
-            const newType = normalizeFieldType(target.value);
-            field.type = newType;
-            if (newType === 'text' || newType === 'multiline') {
-                field.font = field.font || getSessionDefault('font');
-                if (typeof field.autoSize !== 'boolean') {
-                    field.autoSize = true;
-                }
-            }
-            if (OPTION_TYPES.has(newType) && (!Array.isArray(field.options) || !field.options.length)) {
-                field.options = DEFAULT_OPTION_LIST.slice();
-            }
-            if (!OPTION_TYPES.has(newType)) {
-                delete field.options;
-            }
-            if (newType === 'checkbox') {
-                field.checkboxStyle = field.checkboxStyle || (getSessionDefault('checkboxStyle') || 'cross');
-                field.checkboxExportValue = field.checkboxExportValue || 'Yes';
-                field.checkboxBorder = !!field.checkboxBorder;
-                field.checkboxBorderWidth = field.checkboxBorderWidth || 'thin';
-            }
-            if (!(newType === 'text' || newType === 'multiline')) {
-                field.autoSize = true;
-            }
-            markDirtyAndRender();
-            return;
-        }
-        if (target.dataset.action === 'field-font') {
-            field.font = target.value || getSessionDefault('font');
-            markDirtyAndRender();
-            return;
-        }
-        if (target.dataset.action === 'field-checkbox-style') {
-            field.checkboxStyle = target.value || 'cross';
-            markDirtyAndRender();
-            return;
-        }
-        if (target.dataset.action === 'move-field-page') {
-            const newPage = parseInt(target.value, 10);
-            if (!isNaN(newPage) && newPage >= 0 && newPage < state.pageCount) {
-                field.pageIndex = newPage;
-                markDirtyAndRender();
-            }
-            return;
-        }
-        if (target.dataset.action === 'field-checkbox-border') {
-            field.checkboxBorder = !!target.checked;
-            field.checkboxBorderWidth = field.checkboxBorderWidth || 'thin';
-            markDirtyAndRender();
-            return;
-        }
-        if (target.dataset.action === 'field-checkbox-border-width') {
-            field.checkboxBorderWidth = target.value || 'thin';
-            markDirtyAndRender();
-            return;
-        }
-        if (target.dataset.action === 'field-auto-size') {
-            field.autoSize = !!target.checked;
-            markDirtyAndRender();
-        }
-    });
-
-    fieldsList.addEventListener('click', function (event) {
-        const actionTarget = event.target.closest('[data-action]');
-        if (!actionTarget) return;
-        const fieldId = actionTarget.dataset.fieldId;
-        if (!fieldId) return;
-        if (actionTarget.dataset.action === 'normalize-name') {
-            event.preventDefault();
-            event.stopPropagation();
-            state.selectedFieldId = fieldId;
-            normalizeCurrentFieldName();
-            return;
-        }
-        if (actionTarget.dataset.action === 'duplicate-field') {
-            event.preventDefault();
-            event.stopPropagation();
-            state.selectedFieldId = fieldId;
-            duplicateSelectedField();
-            return;
-        }
-        if (actionTarget.dataset.action === 'delete-field') {
-            event.preventDefault();
-            event.stopPropagation();
-            deleteField(fieldId);
-        }
-    });
-
-    autoDetectBtn.addEventListener('click', autoDetectFields);
-    if (relabelBtn) {
-        relabelBtn.addEventListener('click', relabelFields);
-    }
-    if (sidebarRelabelBtn) {
-        sidebarRelabelBtn.addEventListener('click', relabelFields);
-    }
-    exportBtn.addEventListener('click', exportPdf);
-
-    if (testFillingBtn) {
-        testFillingBtn.addEventListener('click', async function () {
-            if (!state.pdfBytes) return;
-            const originalText = testFillingBtn.textContent;
-            testFillingBtn.textContent = 'Generating...';
-            testFillingBtn.disabled = true;
-            try {
-                const formData = new FormData();
-                formData.append('file', getPdfFileForRequests());
-                
-                const saveNameMap = buildExportNameMap({
-                    deduplicate: exportDeduplicateFieldNamesInput ? exportDeduplicateFieldNamesInput.checked : true
-                });
-                formData.append('fields', JSON.stringify(convertFieldsToAbsoluteCoordinates(saveNameMap)));
-                if (exportDeduplicateFieldNamesInput && exportDeduplicateFieldNamesInput.checked) {
-                    formData.append('deduplicate_field_names', 'true');
-                }
-
-                const response = await fetch(apiUrl('/pdf-labeler/api/test-fill'), {
-                    method: 'POST',
-                    headers: { 'Accept': 'application/json' },
-                    body: formData
-                });
-                const data = await parseApiResponse(response);
-                if (!data.success || !data.data || !data.data.pdf_base64) {
-                    throw new Error((data.error && data.error.message) || 'Test fill failed.');
-                }
-                const b64 = data.data.pdf_base64;
-                const binary = window.atob(b64);
-                const bytes = new Uint8Array(binary.length);
-                for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-                const blob = new Blob([bytes], { type: 'application/pdf' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = data.data.filename || 'test_fill.pdf';
-                document.body.appendChild(a);
-                a.click();
-                setTimeout(function () {
-                    document.body.removeChild(a);
-                    URL.revokeObjectURL(url);
-                }, 100);
-            } catch (err) {
-                showError('Error testing PDF fill: ' + err.message);
-            } finally {
-                testFillingBtn.textContent = originalText;
-                testFillingBtn.disabled = false;
-            }
-        });
-    }
-
-    // Playground event listeners
-    openPlaygroundBtn.addEventListener('click', openPlaygroundModal);
-    savePlaygroundBtn.addEventListener('click', openSavePlaygroundModal);
-    document.getElementById('close-open-playground').addEventListener('click', function() { openPlaygroundModalEl.classList.add('hidden'); });
-    document.getElementById('open-pg-cancel').addEventListener('click', function() { openPlaygroundModalEl.classList.add('hidden'); });
-    document.getElementById('open-pg-confirm').addEventListener('click', confirmOpenFromPlayground);
-    document.getElementById('open-pg-project').addEventListener('change', fetchOpenPlaygroundTemplates);
-    document.getElementById('close-save-playground').addEventListener('click', function() { savePlaygroundModalEl.classList.add('hidden'); });
-    document.getElementById('save-pg-cancel').addEventListener('click', function() { savePlaygroundModalEl.classList.add('hidden'); });
-    document.getElementById('save-pg-confirm').addEventListener('click', confirmSaveToPlayground);
-
-    // Interview variable picker event listeners
-    usePlaygroundVariablesInput.addEventListener('change', function() {
-        state.usePlaygroundVariables = usePlaygroundVariablesInput.checked;
-        renderPdfInterviewPicker();
-    });
-    pdfInterviewSourceModeInputs.forEach(function(inp) {
-        inp.addEventListener('change', function() {
-            state.interviewSourceMode = inp.value;
-            if (inp.value === 'installed' && state.installed.packages.length === 0) fetchPdfInstalledPackages();
-            renderPdfInterviewPicker();
-        });
-    });
-    pdfPlaygroundProjectSelect.addEventListener('change', function() {
-        state.playground.selectedProject = pdfPlaygroundProjectSelect.value;
-        fetchPdfPlaygroundFiles();
-    });
-    pdfPlaygroundYamlFileSelect.addEventListener('change', function() {
-        state.playground.selectedFile = pdfPlaygroundYamlFileSelect.value;
-        fetchPdfPlaygroundVariables();
-    });
-    pdfInstalledPackageSelect.addEventListener('change', function() {
-        state.installed.selectedPackage = pdfInstalledPackageSelect.value;
-        fetchPdfInstalledFiles();
-    });
-    pdfInstalledYamlFileSelect.addEventListener('change', function() {
-        state.installed.selectedFile = pdfInstalledYamlFileSelect.value;
-        fetchPdfInstalledVariables();
-    });
-
-    document.addEventListener('keydown', function (event) {
-        const targetTag = document.activeElement && document.activeElement.tagName ? document.activeElement.tagName.toUpperCase() : '';
-        if ((event.key === 'Delete' || event.key === 'Backspace') && state.selectedFieldId && targetTag !== 'INPUT' && targetTag !== 'TEXTAREA') {
-            event.preventDefault();
-            deleteField(state.selectedFieldId);
-            return;
-        }
-        if (event.key === 'Escape') {
-            clearInteractionState();
-            setSelectedTool(null);
-            selectField(null, { focusNameInput: false, scrollIntoView: false });
-            aiModelSuggestions.classList.add('hidden');
-            settingsModal.classList.add('hidden');
-            accessibilityModal.classList.add('hidden');
-            normalizationModal.classList.add('hidden');
-            if (!pageManagerModal.classList.contains('hidden')) {
-                closePageManager();
-            }
-            return;
-        }
-        if (!state.selectedFieldId || targetTag === 'INPUT' || targetTag === 'TEXTAREA') {
-            return;
-        }
-        const field = getCurrentField();
-        if (!field) return;
-        const step = event.shiftKey ? 0.01 : 0.003;
-        let moved = false;
-        if (event.key === 'ArrowLeft') {
-            field.x = clamp(field.x - step, 0, 1 - field.width);
-            moved = true;
-        } else if (event.key === 'ArrowRight') {
-            field.x = clamp(field.x + step, 0, 1 - field.width);
-            moved = true;
-        } else if (event.key === 'ArrowUp') {
-            field.y = clamp(field.y - step, 0, 1 - field.height);
-            moved = true;
-        } else if (event.key === 'ArrowDown') {
-            field.y = clamp(field.y + step, 0, 1 - field.height);
-            moved = true;
-        }
-        if (moved) {
-            event.preventDefault();
-            markDirtyAndRender();
-        }
-    });
-
-    applyBranding();
-    bulkRenameTypeInput.value = state.bulkRenameType;
-    bulkRenamePatternInput.value = state.bulkRenamePattern;
-    bulkRenameReplacementInput.value = state.bulkRenameReplacement;
-    setFieldsPanelMode(state.fieldsPanelMode);
-    updateDocumentName();
-    updateToolHint();
-    fetchModelCatalog();
-    fetchAuthStatus();
-    updateFieldCount();
-    updateZoomControls();
+    return;
+  }
+  if (
+    !state.selectedFieldId ||
+    targetTag === "INPUT" ||
+    targetTag === "TEXTAREA"
+  ) {
+    return;
+  }
+  const field = getCurrentField();
+  if (!field) return;
+  const step = event.shiftKey ? 0.01 : 0.003;
+  let moved = false;
+  if (event.key === "ArrowLeft") {
+    field.x = clamp(field.x - step, 0, 1 - field.width);
+    moved = true;
+  } else if (event.key === "ArrowRight") {
+    field.x = clamp(field.x + step, 0, 1 - field.width);
+    moved = true;
+  } else if (event.key === "ArrowUp") {
+    field.y = clamp(field.y - step, 0, 1 - field.height);
+    moved = true;
+  } else if (event.key === "ArrowDown") {
+    field.y = clamp(field.y + step, 0, 1 - field.height);
+    moved = true;
+  }
+  if (moved) {
+    event.preventDefault();
+    markDirtyAndRender();
+  }
+});
+
+applyBranding();
+bulkRenameTypeInput.value = state.bulkRenameType;
+bulkRenamePatternInput.value = state.bulkRenamePattern;
+bulkRenameReplacementInput.value = state.bulkRenameReplacement;
+setFieldsPanelMode(state.fieldsPanelMode);
+updateDocumentName();
+updateToolHint();
+fetchModelCatalog();
+fetchAuthStatus();
+updateFieldCount();
+updateZoomControls();

--- a/docassemble/ALDashboard/data/templates/docx_labeler.html
+++ b/docassemble/ALDashboard/data/templates/docx_labeler.html
@@ -118,20 +118,20 @@
                 <!-- Main Panel (tabs for existing labels vs suggestions) -->
                 <div id="main-panel" class="hidden flex-fill d-flex flex-column overflow-hidden">
                     <!-- Tabs -->
-                    <div class="dl-tabs">
-                        <button id="tab-existing" class="dl-tab tab-active">
+                    <div class="dl-tabs" role="tablist" aria-label="Label views">
+                        <button id="tab-existing" class="dl-tab tab-active" type="button" role="tab" aria-controls="existing-panel" aria-selected="true">
                             Existing Labels <span id="existing-count" class="dl-count-badge dl-count-badge-primary">0</span>
                         </button>
-                        <button id="tab-manual" class="dl-tab hidden">
+                        <button id="tab-manual" class="dl-tab hidden" type="button" role="tab" aria-controls="manual-panel" aria-selected="false" tabindex="-1">
                             Manual Labels <span id="manual-count" class="dl-count-badge dl-count-badge-warning">0</span>
                         </button>
-                        <button id="tab-suggestions" class="dl-tab">
+                        <button id="tab-suggestions" class="dl-tab" type="button" role="tab" aria-controls="suggestions-panel" aria-selected="false" tabindex="-1">
                             AI Suggestions <span id="suggestions-count" class="dl-count-badge dl-count-badge-warning">0</span>
                         </button>
                     </div>
 
                     <!-- Existing Labels Panel -->
-                    <div id="existing-panel" class="flex-fill d-flex flex-column overflow-hidden">
+                    <div id="existing-panel" class="flex-fill d-flex flex-column overflow-hidden" role="tabpanel" aria-labelledby="tab-existing" tabindex="0">
                         <div class="dl-panel-toolbar d-flex align-items-center gap-2">
                             <button id="bulk-replace-btn" class="btn btn-sm btn-outline-primary">Bulk Replace</button>
                             <button id="ai-relabel-btn" class="btn btn-sm btn-primary">AI Relabel All</button>
@@ -140,7 +140,7 @@
                     </div>
 
                     <!-- Manual Labels Panel -->
-                    <div id="manual-panel" class="hidden flex-fill d-flex flex-column overflow-hidden">
+                    <div id="manual-panel" class="hidden flex-fill d-flex flex-column overflow-hidden" role="tabpanel" aria-labelledby="tab-manual" tabindex="0">
                         <div class="dl-panel-toolbar d-flex align-items-center justify-content-between gap-2">
                             <div class="small text-muted">Labels added from preview selections</div>
                         </div>
@@ -148,7 +148,7 @@
                     </div>
 
                     <!-- Suggestions Panel -->
-                    <div id="suggestions-panel" class="hidden flex-fill d-flex flex-column overflow-hidden">
+                    <div id="suggestions-panel" class="hidden flex-fill d-flex flex-column overflow-hidden" role="tabpanel" aria-labelledby="tab-suggestions" tabindex="0">
                         <div class="dl-panel-toolbar d-flex align-items-center justify-content-between">
                             <div class="d-flex gap-2">
                                 <button id="accept-all-btn" class="btn btn-sm btn-success">Accept All</button>
@@ -198,11 +198,11 @@
         </main>
 
         <!-- Settings Modal -->
-        <div id="settings-modal" class="hidden dl-modal-overlay">
+        <div id="settings-modal" role="dialog" aria-modal="true" aria-labelledby="settings-modal-title" class="hidden dl-modal-overlay">
             <div class="dl-modal dl-modal-md">
                 <div class="dl-modal-header">
-                    <h2 class="h5 fw-semibold mb-0">AI Prompt Settings</h2>
-                    <button id="close-settings" class="btn btn-sm btn-light rounded">
+                    <h2 id="settings-modal-title" class="h5 fw-semibold mb-0">AI Prompt Settings</h2>
+                    <button id="close-settings" class="btn btn-sm btn-light rounded" aria-label="Close AI prompt settings">
                         <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
@@ -281,18 +281,18 @@
                     </div>
                 </div>
                 <div class="dl-modal-footer d-flex justify-content-end gap-2">
-                    <button id="reset-settings" class="btn btn-outline-secondary">Reset to Default</button>
+                    <button id="reset-settings" class="btn btn-outline-dark">Reset to Default</button>
                     <button id="save-settings" class="btn btn-primary">Save Settings</button>
                 </div>
             </div>
         </div>
 
         <!-- Bulk Replace Modal -->
-        <div id="bulk-replace-modal" class="hidden dl-modal-overlay">
+        <div id="bulk-replace-modal" role="dialog" aria-modal="true" aria-labelledby="bulk-replace-modal-title" class="hidden dl-modal-overlay">
             <div class="dl-modal dl-modal-sm">
                 <div class="dl-modal-header">
                     <div>
-                        <h2 class="h5 fw-semibold mb-1">Bulk Find &amp; Replace</h2>
+                        <h2 id="bulk-replace-modal-title" class="h5 fw-semibold mb-1">Bulk Find &amp; Replace</h2>
                         <p class="text-muted small mb-0">Replace variable names across all labels</p>
                     </div>
                 </div>
@@ -321,11 +321,11 @@
         </div>
 
         <!-- Create/Edit Label Modal -->
-        <div id="edit-label-modal" class="hidden dl-modal-overlay">
+        <div id="edit-label-modal" role="dialog" aria-modal="true" aria-labelledby="edit-label-title" class="hidden dl-modal-overlay">
             <div class="dl-modal dl-modal-lg">
                 <div class="dl-modal-header">
                     <h2 id="edit-label-title" class="h5 fw-semibold mb-0">Edit Label</h2>
-                    <button id="edit-close" class="btn btn-sm btn-light rounded">
+                    <button id="edit-close" class="btn btn-sm btn-light rounded" aria-label="Close label editor">
                         <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
@@ -360,10 +360,10 @@
         </div>
 
         <!-- Open from Playground modal -->
-        <div id="open-playground-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="open-playground-modal" role="dialog" aria-modal="true" aria-labelledby="open-playground-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 30rem;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
-                    <h2 class="h5 fw-semibold mb-0">Open from Playground</h2>
+                    <h2 id="open-playground-modal-title" class="h5 fw-semibold mb-0">Open from Playground</h2>
                     <button id="close-open-playground" class="btn btn-sm btn-light">Close</button>
                 </div>
                 <div class="mb-2">
@@ -382,10 +382,10 @@
         </div>
 
         <!-- Save to Playground modal -->
-        <div id="save-playground-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="save-playground-modal" role="dialog" aria-modal="true" aria-labelledby="save-playground-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 30rem;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
-                    <h2 class="h5 fw-semibold mb-0">Save to Playground</h2>
+                    <h2 id="save-playground-modal-title" class="h5 fw-semibold mb-0">Save to Playground</h2>
                     <button id="close-save-playground" class="btn btn-sm btn-light">Close</button>
                 </div>
                 <div class="mb-2">
@@ -405,11 +405,11 @@
         </div>
 
         <!-- Utilities Modal -->
-        <div id="utilities-modal" class="hidden dl-modal-overlay">
+        <div id="utilities-modal" role="dialog" aria-modal="true" aria-labelledby="utilities-modal-title" class="hidden dl-modal-overlay">
             <div class="dl-modal dl-modal-lg">
                 <div class="dl-modal-header">
                     <div>
-                        <h2 class="h5 fw-semibold mb-1">Utilities</h2>
+                        <h2 id="utilities-modal-title" class="h5 fw-semibold mb-1">Utilities</h2>
                         <p class="text-muted small mb-0">Run DOCX utilities on the active file or a separate upload.</p>
                     </div>
                     <button id="utilities-close" class="btn btn-sm btn-light rounded">Close</button>
@@ -440,11 +440,11 @@
         </div>
 
         <!-- Repair Modal -->
-        <div id="repair-modal" class="hidden dl-modal-overlay">
+        <div id="repair-modal" role="dialog" aria-modal="true" aria-labelledby="repair-modal-title" class="hidden dl-modal-overlay">
             <div class="dl-modal dl-modal-lg">
                 <div class="dl-modal-header">
                     <div>
-                        <h2 class="h5 fw-semibold mb-1">Repair</h2>
+                        <h2 id="repair-modal-title" class="h5 fw-semibold mb-1">Repair</h2>
                         <p class="text-muted small mb-0">Try increasingly aggressive rescue steps for broken DOCX files.</p>
                     </div>
                     <button id="repair-close" class="btn btn-sm btn-light rounded">Close</button>
@@ -496,6 +496,7 @@
     </div>
 
     <script id="labeler-bootstrap" type="application/json">__LABELER_BOOTSTRAP_JSON__</script>
+    <script src="/packagestatic/docassemble.ALDashboard/labeler_dialogs.js"></script>
     <script src="/packagestatic/docassemble.ALDashboard/docx_labeler_preview_utils.js"></script>
     <script src="/packagestatic/docassemble.ALDashboard/docx_labeler.js"></script>
 </body>

--- a/docassemble/ALDashboard/data/templates/pdf_labeler.html
+++ b/docassemble/ALDashboard/data/templates/pdf_labeler.html
@@ -72,8 +72,8 @@
                         <span class="form-check-label">Deduplicate repeated names</span>
                     </label>
                     <button id="export-btn" class="btn btn-primary btn-sm" disabled>Export PDF</button>
-                    <button id="test-filling-btn" class="btn btn-outline-info btn-sm" disabled title="Generate a filled PDF preview">Test filling</button>
-                    <button id="save-playground-btn" class="btn btn-outline-success btn-sm hidden" disabled title="Save this PDF back to the Playground templates folder">
+                    <button id="test-filling-btn" class="btn btn-outline-light btn-sm" disabled title="Generate a filled PDF preview">Test filling</button>
+                    <button id="save-playground-btn" class="btn btn-outline-light btn-sm hidden" disabled title="Save this PDF back to the Playground templates folder">
                         <svg class="icon-16 me-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"></path></svg>
                         Save to Playground
                     </button>
@@ -114,7 +114,7 @@
                         <p class="mt-2 text-muted">Drag and drop a PDF here or use the upload button above.</p>
                     </div>
                 </div>
-                <div id="pdf-loading" class="loading-modal hidden" role="status" aria-live="polite" aria-modal="true">
+                <div id="pdf-loading" class="loading-modal hidden" role="status" aria-live="polite">
                     <div class="loading-modal-card">
                         <svg class="loading-spinner icon-48 mx-auto text-primary" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -248,10 +248,10 @@
             <p id="success-toast-message" class="mb-0"></p>
         </div>
 
-        <div id="settings-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="settings-modal" role="dialog" aria-modal="true" aria-labelledby="settings-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 32rem;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
-                    <h2 class="h5 fw-semibold mb-0">AI Settings</h2>
+                    <h2 id="settings-modal-title" class="h5 fw-semibold mb-0">AI Settings</h2>
                     <button id="close-settings" class="btn btn-sm btn-light">Close</button>
                 </div>
                 <div class="mb-3">
@@ -338,10 +338,10 @@
         </div>
 
         <!-- Open from Playground modal -->
-        <div id="open-playground-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="open-playground-modal" role="dialog" aria-modal="true" aria-labelledby="open-playground-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 30rem;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
-                    <h2 class="h5 fw-semibold mb-0">Open from Playground</h2>
+                    <h2 id="open-playground-modal-title" class="h5 fw-semibold mb-0">Open from Playground</h2>
                     <button id="close-open-playground" class="btn btn-sm btn-light">Close</button>
                 </div>
                 <div class="mb-2">
@@ -360,10 +360,10 @@
         </div>
 
         <!-- Save to Playground modal -->
-        <div id="save-playground-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="save-playground-modal" role="dialog" aria-modal="true" aria-labelledby="save-playground-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 30rem;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
-                    <h2 class="h5 fw-semibold mb-0">Save to Playground</h2>
+                    <h2 id="save-playground-modal-title" class="h5 fw-semibold mb-0">Save to Playground</h2>
                     <button id="close-save-playground" class="btn btn-sm btn-light">Close</button>
                 </div>
                 <div class="mb-2">
@@ -389,11 +389,11 @@
             </div>
         </div>
 
-        <div id="field-rename-summary-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1090;">
+        <div id="field-rename-summary-modal" role="dialog" aria-modal="true" aria-labelledby="field-rename-summary-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1090;">
             <div class="bg-white border shadow rounded p-4" style="width: 100%; max-width: 42rem; max-height: 85vh; overflow-y: auto;">
                 <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
                     <div>
-                        <h2 class="h5 fw-semibold mb-1">Field Names Changed</h2>
+                        <h2 id="field-rename-summary-modal-title" class="h5 fw-semibold mb-1">Field Names Changed</h2>
                         <p id="field-rename-summary-context" class="small text-muted mb-0"></p>
                     </div>
                     <button id="field-rename-summary-close" class="btn-close" aria-label="Close"></button>
@@ -405,11 +405,11 @@
             </div>
         </div>
 
-        <div id="accessibility-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="accessibility-modal" role="dialog" aria-modal="true" aria-labelledby="accessibility-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 62rem; max-height: 92vh; overflow: auto;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
                     <div>
-                        <h2 class="h5 fw-semibold mb-0">PDF Accessibility</h2>
+                        <h2 id="accessibility-modal-title" class="h5 fw-semibold mb-0">PDF Accessibility</h2>
                         <p class="small text-muted mb-0 mt-1">Tooltips, field order, image alt text, metadata, and tag structure.</p>
                     </div>
                     <button id="close-accessibility" class="btn btn-sm btn-light">Close</button>
@@ -469,11 +469,11 @@
             </div>
         </div>
 
-        <div id="normalization-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="normalization-modal" role="dialog" aria-modal="true" aria-labelledby="normalization-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 58rem; max-height: 90vh; overflow: auto;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
                     <div>
-                        <h2 class="h5 fw-semibold mb-0">Normalize PDF Fields</h2>
+                        <h2 id="normalization-modal-title" class="h5 fw-semibold mb-0">Normalize PDF Fields</h2>
                         <p class="small text-muted mb-0 mt-1">Apply court-PDF cleanup heuristics to the current fields.</p>
                     </div>
                     <button id="close-normalization" class="btn btn-sm btn-light">Close</button>
@@ -611,11 +611,11 @@
             </div>
         </div>
 
-        <div id="repair-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="repair-modal" role="dialog" aria-modal="true" aria-labelledby="repair-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow p-3" style="width: 100%; max-width: 40rem; max-height: 90vh; overflow: auto;">
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
                     <div>
-                        <h2 class="h5 fw-semibold mb-0">PDF Repair Tools</h2>
+                        <h2 id="repair-modal-title" class="h5 fw-semibold mb-0">PDF Repair Tools</h2>
                         <p class="small text-muted mb-0 mt-1">Run one repair action at a time on the current PDF.</p>
                     </div>
                     <button id="close-repair" class="btn btn-sm btn-light">Close</button>
@@ -719,9 +719,9 @@
             </div>
         </div>
 
-        <div id="password-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1080;">
+        <div id="password-modal" role="dialog" aria-modal="true" aria-labelledby="password-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1080;">
             <div class="bg-white border shadow rounded p-4" style="width: 100%; max-width: 28rem;">
-                <h2 class="h5 fw-semibold mb-2">Password Required</h2>
+                <h2 id="password-modal-title" class="h5 fw-semibold mb-2">Password Required</h2>
                 <p class="small text-muted mb-3">This PDF is password-protected. Enter the password to unlock it.</p>
                 <div id="password-error" class="hidden alert alert-danger small mb-3"></div>
                 <div class="mb-3">
@@ -735,12 +735,12 @@
             </div>
         </div>
 
-        <div id="repair-prompt-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1080;">
+        <div id="repair-prompt-modal" role="dialog" aria-modal="true" aria-labelledby="repair-prompt-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1080;">
             <div class="bg-white border shadow rounded p-4" style="width: 100%; max-width: 32rem;">
                 <div class="d-flex align-items-start gap-3 mb-3">
                     <svg class="flex-shrink-0 mt-1" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#dc3545" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
                     <div>
-                        <h2 class="h5 fw-semibold mb-1">PDF Cannot Be Opened</h2>
+                        <h2 id="repair-prompt-modal-title" class="h5 fw-semibold mb-1">PDF Cannot Be Opened</h2>
                         <p id="repair-prompt-message" class="small text-muted mb-0">This PDF could not be rendered. Would you like to try repairing it?</p>
                     </div>
                 </div>
@@ -751,10 +751,10 @@
             </div>
         </div>
 
-        <div id="utilities-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
+        <div id="utilities-modal" role="dialog" aria-modal="true" aria-labelledby="utilities-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.5); z-index: 1070;">
             <div class="bg-white border shadow rounded p-4" style="width: 100%; max-width: 36rem; max-height: 85vh; overflow-y: auto;">
                 <div class="d-flex justify-content-between align-items-center mb-3">
-                    <h2 class="h5 fw-semibold mb-0">Utilities</h2>
+                    <h2 id="utilities-modal-title" class="h5 fw-semibold mb-0">Utilities</h2>
                     <button id="utilities-close" class="btn-close" aria-label="Close"></button>
                 </div>
                 <section class="border rounded p-3 mb-3">
@@ -866,11 +866,11 @@
             </div>
         </div>
 
-        <div id="page-manager-modal" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.52); z-index: 1070;">
+        <div id="page-manager-modal" role="dialog" aria-modal="true" aria-labelledby="page-manager-modal-title" class="hidden position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center" style="background: rgba(0,0,0,0.52); z-index: 1070;">
             <div class="bg-white border shadow rounded p-4" style="width: min(94vw, 82rem); max-height: 92vh; overflow-y: auto;">
                 <div class="d-flex align-items-start justify-content-between gap-3 border-bottom pb-3 mb-3">
                     <div>
-                        <h2 class="h5 fw-semibold mb-1">Manage Pages</h2>
+                        <h2 id="page-manager-modal-title" class="h5 fw-semibold mb-1">Manage Pages</h2>
                         <p class="small text-muted mb-0">Reorder pages by dragging cards, remove pages, insert pages from another PDF, or add split points for multi-document export.</p>
                     </div>
                     <button id="close-page-manager" class="btn btn-sm btn-light">Close</button>
@@ -924,6 +924,7 @@
     </div>
 
     <script id="labeler-bootstrap" type="application/json">__LABELER_BOOTSTRAP_JSON__</script>
+    <script src="/packagestatic/docassemble.ALDashboard/labeler_dialogs.js"></script>
     <script type="module" src="/packagestatic/docassemble.ALDashboard/pdf_labeler.js"></script>
 </body>
 </html>

--- a/docassemble/ALDashboard/test/test_labeler_dialogs.node.test.js
+++ b/docassemble/ALDashboard/test/test_labeler_dialogs.node.test.js
@@ -1,0 +1,109 @@
+/*  Keyboard behaviour for the shared labeler dialog helper.
+
+    labeler_dialogs.js implements the ARIA dialog pattern (focus in on open,
+    focus restored on close, Tab trapped inside, Escape to dismiss) for the
+    custom modals in both labelers. That logic is easy to break silently, so
+    it is exercised here against a real browser rather than a DOM stub.
+
+    Needs Chromium, so this runs in the browser accessibility workflow:
+        npm run test:dialogs
+*/
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { chromium } = require("playwright");
+
+const helperSource = fs.readFileSync(
+  path.join(__dirname, "../data/static/labeler_dialogs.js"),
+  "utf8",
+);
+
+// A minimal stand-in for the labelers' markup: an opener on the page, and a
+// hidden overlay carrying role="dialog" that is shown by toggling `hidden`.
+const PAGE = `<!doctype html><html><body>
+<style>.hidden{display:none}</style>
+<button id="opener">Open</button>
+<button id="other">Other</button>
+<div id="settings-modal" class="hidden" role="dialog" aria-modal="true" aria-labelledby="settings-modal-title">
+  <h2 id="settings-modal-title">Settings</h2>
+  <input id="first">
+  <input id="mid">
+  <button id="close-settings">Close</button>
+</div>
+<script>
+  document.getElementById("opener").addEventListener("click", function () {
+    document.getElementById("settings-modal").classList.remove("hidden");
+  });
+  document.getElementById("close-settings").addEventListener("click", function () {
+    document.getElementById("settings-modal").classList.add("hidden");
+  });
+<\/script>
+</body></html>`;
+
+async function withPage(run) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent(PAGE);
+    await page.addScriptTag({ content: helperSource });
+    page.activeId = () => page.evaluate(() => document.activeElement.id);
+    await run(page);
+  } finally {
+    await browser.close();
+  }
+}
+
+test("opening a dialog moves focus to its first control", async () => {
+  await withPage(async (page) => {
+    await page.click("#opener");
+    assert.equal(await page.activeId(), "first");
+  });
+});
+
+test("Tab and Shift+Tab stay inside the open dialog", async () => {
+  await withPage(async (page) => {
+    await page.click("#opener");
+
+    await page.focus("#close-settings");
+    await page.keyboard.press("Tab");
+    assert.equal(await page.activeId(), "first", "Tab wraps last to first");
+
+    await page.keyboard.press("Shift+Tab");
+    assert.equal(
+      await page.activeId(),
+      "close-settings",
+      "Shift+Tab wraps first to last",
+    );
+
+    await page.focus("#mid");
+    await page.keyboard.press("Tab");
+    assert.equal(
+      await page.activeId(),
+      "close-settings",
+      "focus never reaches the page behind the dialog",
+    );
+  });
+});
+
+test("Escape dismisses the dialog and restores focus to its opener", async () => {
+  await withPage(async (page) => {
+    await page.click("#opener");
+    await page.keyboard.press("Escape");
+
+    const hidden = await page.evaluate(() =>
+      document.getElementById("settings-modal").classList.contains("hidden"),
+    );
+    assert.equal(hidden, true, "Escape uses the dialog's own close button");
+    assert.equal(await page.activeId(), "opener");
+  });
+});
+
+test("Escape does nothing while no dialog is open", async () => {
+  await withPage(async (page) => {
+    await page.focus("#other");
+    await page.keyboard.press("Escape");
+    assert.equal(await page.activeId(), "other");
+  });
+});

--- a/docassemble/ALDashboard/test/test_labeler_js_extraction.py
+++ b/docassemble/ALDashboard/test/test_labeler_js_extraction.py
@@ -70,7 +70,7 @@ class TestDocxLabelerJsExtraction(unittest.TestCase):
         self.assertGreater(len(self.js.strip()), 1000)
 
     def test_js_contains_iife_wrapper(self):
-        self.assertIn("(function()", self.js)
+        self.assertRegex(self.js, r"\(function\s*\(\)")
         self.assertTrue(self.js.strip().endswith("})();"))
 
     def test_js_contains_variable_tree(self):
@@ -186,7 +186,7 @@ class TestPdfLabelerJsExtraction(unittest.TestCase):
     def test_js_contains_field_types(self):
         self.assertIn("FIELD_TYPES", self.js)
         for ft in ["text", "multiline", "checkbox", "signature", "radio"]:
-            self.assertIn(f"'{ft}'", self.js)
+            self.assertRegex(self.js, rf"[\"']{re.escape(ft)}[\"']")
 
     def test_js_contains_core_functions(self):
         expected = [
@@ -237,9 +237,10 @@ class TestPdfLabelerJsExtraction(unittest.TestCase):
 
     def test_new_text_fields_only_auto_size_name_and_address_like_names(self):
         self.assertIn("function looksLikeSingleLineAutoSizeField", self.js)
-        self.assertIn(
-            "autoSize: type === 'text' && looksLikeSingleLineAutoSizeField(",
+        self.assertRegex(
             self.js,
+            r"autoSize:\s*type === [\"']text[\"']\s*&&\s*"
+            r"looksLikeSingleLineAutoSizeField\(",
         )
 
     def test_auto_size_preview_starts_from_field_height(self):
@@ -247,9 +248,10 @@ class TestPdfLabelerJsExtraction(unittest.TestCase):
         self.assertNotIn("pxSize = Math.min(pxSize, maxPxSize);", self.js)
 
     def test_pdf_field_default_is_ten_point_helvetica(self):
-        self.assertIn(
-            "HARD_DEFAULTS = { font: 'Helvetica', fontSize: 10",
+        self.assertRegex(
             self.js,
+            r"HARD_DEFAULTS\s*=\s*\{\s*font:\s*[\"']Helvetica[\"'],"
+            r"\s*fontSize:\s*10",
         )
 
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,56 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import sonarjs from 'eslint-plugin-sonarjs';
+
+const labelerFiles = [
+  'docassemble/ALDashboard/data/static/labeler_dialogs.js',
+  'docassemble/ALDashboard/data/static/docx_labeler.js',
+  'docassemble/ALDashboard/data/static/docx_labeler_preview_utils.js',
+  'docassemble/ALDashboard/data/static/pdf_labeler.js',
+  'docassemble/ALDashboard/data/static/interview_linter.js',
+  '.github/scripts/labeler_a11y.js',
+];
+
+export default [
+  {
+    ignores: ['node_modules/**'],
+  },
+  {
+    files: labelerFiles,
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        mammoth: 'readonly',
+      },
+    },
+    plugins: {
+      sonarjs,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...sonarjs.configs.recommended.rules,
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-unused-vars': [
+        'error',
+        { args: 'none', caughtErrors: 'none' },
+      ],
+      // These browser scripts intentionally use nested closures for stateful
+      // controllers and promise callbacks.
+      'sonarjs/no-nested-functions': 'off',
+      'sonarjs/cognitive-complexity': 'off',
+      // These scripts use browser-safe fallback IDs and deliberately complex
+      // expressions/regular expressions for document-template parsing.
+      'sonarjs/no-ignored-exceptions': 'off',
+      'sonarjs/no-nested-conditional': 'off',
+      'sonarjs/no-useless-escape': 'off',
+      'sonarjs/pseudo-random': 'off',
+      'sonarjs/regex-complexity': 'off',
+      'sonarjs/super-linear-regex': 'off',
+      'sonarjs/no-dead-store': 'off',
+      'sonarjs/no-unused-vars': 'off',
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1202 @@
+{
+  "name": "docassemble-aldashboard-static-checks",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docassemble-aldashboard-static-checks",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
+        "@eslint/js": "^9.35.0",
+        "@types/node": "^24.3.0",
+        "eslint": "^10.9.1",
+        "eslint-plugin-sonarjs": "^4.2.0",
+        "globals": "^16.3.0",
+        "playwright": "^1.62.1",
+        "prettier": "^3.6.2",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.7.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.8.5",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "docassemble-aldashboard-static-checks",
+  "private": true,
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "format": "prettier --write $npm_package_config_jsFiles",
+    "format:check": "prettier --check $npm_package_config_jsFiles",
+    "lint": "eslint $npm_package_config_jsFiles",
+    "typecheck": "tsc --project tsconfig.json",
+    "syntaxcheck": "for file in $npm_package_config_jsFiles; do node --check \"$file\"; done",
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm run syntaxcheck",
+    "test:dialogs": "node --test docassemble/ALDashboard/test/test_labeler_dialogs.node.test.js"
+  },
+  "config": {
+    "jsFiles": "docassemble/ALDashboard/data/static/labeler_dialogs.js docassemble/ALDashboard/data/static/docx_labeler.js docassemble/ALDashboard/data/static/docx_labeler_preview_utils.js docassemble/ALDashboard/data/static/pdf_labeler.js docassemble/ALDashboard/data/static/interview_linter.js .github/scripts/labeler_a11y.js"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.35.0",
+    "@types/node": "^24.3.0",
+    "eslint": "^10.9.1",
+    "eslint-plugin-sonarjs": "^4.2.0",
+    "globals": "^16.3.0",
+    "@axe-core/playwright": "^4.13.0",
+    "playwright": "^1.62.1",
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": ">=22.13.0"
-  }
+  },
   "scripts": {
     "format": "prettier --write $npm_package_config_jsFiles",
     "format:check": "prettier --check $npm_package_config_jsFiles",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "docassemble-aldashboard-static-checks",
   "private": true,
   "engines": {
-    "node": ">=22"
-  },
+    "node": ">=22.13.0"
+  }
   "scripts": {
     "format": "prettier --write $npm_package_config_jsFiles",
     "format:check": "prettier --check $npm_package_config_jsFiles",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "types/static-globals.d.ts",
+    "docassemble/ALDashboard/data/static/labeler_dialogs.js",
+    "docassemble/ALDashboard/data/static/docx_labeler.js",
+    "docassemble/ALDashboard/data/static/docx_labeler_preview_utils.js",
+    "docassemble/ALDashboard/data/static/pdf_labeler.js",
+    "docassemble/ALDashboard/data/static/interview_linter.js",
+    ".github/scripts/labeler_a11y.js"
+  ]
+}

--- a/types/static-globals.d.ts
+++ b/types/static-globals.d.ts
@@ -1,0 +1,23 @@
+interface DocxLabelerPreviewUtils {
+  [key: string]: (...args: any[]) => any;
+}
+
+interface Window {
+  DOCX_LABELER_CONFIG?: Record<string, any>;
+  DocxLabelerPreviewUtils?: any;
+  PDFLib?: any;
+  JSZip?: any;
+}
+
+declare const mammoth: Record<string, any>;
+
+// These labelers are plain browser scripts that look elements up by id and
+// immediately use element-specific properties (.value, .checked, .files).
+// Widening only the three lookup APIs keeps the rest of the DOM surface
+// type-checked -- document.createElement, .body, .addEventListener and
+// friends still catch typos and bad arguments.
+interface Document {
+  getElementById(elementId: string): any;
+  querySelector(selectors: string): any;
+  querySelectorAll(selectors: string): any;
+}


### PR DESCRIPTION
Closes #274.

## Summary

Adds a static check pipeline for the labelers' Flask-only browser code, which had no coverage before, and fixes the accessibility problems that surfaced along the way.

**New tooling** (`.github/workflows/javascript_checks.yml`, PR-gated against `main`):
- Prettier, ESLint (with `eslint-plugin-sonarjs`), TypeScript (`checkJs` mode), and a Node syntax check over `docx_labeler.js`, `docx_labeler_preview_utils.js`, `pdf_labeler.js`, `interview_linter.js`, and the new `labeler_dialogs.js`
- TypeScript integration is scoped narrowly: `types/static-globals.d.ts` types three DOM lookup APIs (`getElementById`/`querySelector`/`querySelectorAll`) as `any`, but `document.createElement`, `.body`, `.addEventListener`, and everything else stay fully checked
- `npm run check` runs all of the above; `npm run test:dialogs` runs the new Playwright-driven dialog test

**New tooling** (`.github/workflows/browser_accessibility.yml`, PR-gated against `main`):
- `.github/scripts/labeler_a11y.js` drives both labelers with Playwright + axe-core against a real docassemble server (via `suffolkLITLab/ALKiln/action_for_github_server`), auditing every modal, both empty and loaded states, and the DOCX tab views
- Failures produce an `axe-results.json` artifact and a job-summary table (impact, rule, location), sorted most-severe first

## Accessibility fixes

- All 18 custom modals across both labelers now carry `role="dialog"`, `aria-modal`, and `aria-labelledby`
- New shared `docassemble/ALDashboard/data/static/labeler_dialogs.js`: a `MutationObserver` on `[role="dialog"]` that provides focus-in on open, focus-restore on close, a Tab/Shift+Tab focus trap, and Escape-to-close (via the dialog's own close/cancel button, so existing cleanup still runs) — any modal added later gets this for free just by carrying the role
- DOCX label-view tabs get full ARIA tab semantics: `role="tablist"/tab/tabpanel"`, `aria-selected`, roving `tabindex`, and arrow-key/Home/End navigation
- `#edit-close` and other icon-only buttons get accessible names
- Darkened several colors that fell short of WCAG AA contrast, including a systemic gap in `.btn-outline-secondary` against the modals' light background (4.45:1 → 6.26:1) — found via a live axe run against the running app, not the original code review
- Fixed `#pdf-loading`'s invalid `role="status"` + `aria-modal="true"` combination
- Fixed a broken HTML attribute: unescaped quotes in the catch-all filter placeholder were terminating the attribute early

## Validation

- `npm run check` passes (format, lint, typecheck, syntax)
- New `docassemble/ALDashboard/test/test_labeler_dialogs.node.test.js` drives real Chromium against the dialog helper: focus-in on open, Tab/Shift+Tab trapped inside, Escape closes and restores focus, Escape is inert with nothing open
- **Installed to a local docassemble server via `dainstall`** and exercised both labelers end-to-end in headless Chromium against the live app: modal dialog semantics, focus management, ARIA tabs and keyboard nav, every contrast fix, both file-upload flows — 44/44 checks passed, zero browser console or page errors
- **Ran the actual `labeler_a11y.js` CI script against that live server** with a real admin login. First run caught a genuine, previously-unknown contrast bug (`.btn-outline-secondary` at 4.45:1) — fixed and reinstalled. Second pass surfaced a flaky false positive in the *script itself* (axe occasionally sampled a button mid-transition, right after a click, during Bootstrap's 150ms color transition — a different element and color each time, which is the signature of a timing race, not a real bug); added a settle delay before each scan and confirmed 5 consecutive clean runs afterward
- Confirmed via `git stash` that the 39 pre-existing Python test failures in this sandbox (missing docassemble config) are identical before and after this branch — none introduced by these changes

## Test plan

- [x] `npm run check`
- [x] `npm run test:dialogs`
- [x] `python3 -m unittest docassemble.ALDashboard.test.test_labeler_js_extraction`
- [x] Live end-to-end run against a local docassemble install (both labelers, all modals, both file types)
- [x] Live run of `.github/scripts/labeler_a11y.js` against that install, 5x for flake-checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gzwo371YibY4VTkMEuQ3qL