### PR TITLE
Add court form template shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,47 @@ name.
 Run the focused Python tests for export and attachment mapping, then the static
 labeler extraction tests. When changing browser behavior, also run a JavaScript
 syntax check.
+
+## Court form shapes
+
+The Interview Intake Document Generator can draft a court filing instead of an
+intake summary. Implementation:
+
+- `docassemble/ALDashboard/court_form_profiles.py`: loading, `extends:`
+  merging, Word style application, `.docx` fragment resolution and splicing.
+- `docassemble/ALDashboard/court_form_generator.py`: the four shapes
+  (`court_form`, `motion`, `affidavit`, `letter`) and the block renderer.
+- `docassemble/ALDashboard/data/sources/court_form_profiles/*.yml`: one file
+  per court.
+- `docassemble/ALDashboard/data/templates/court_forms/<profile>/<section>.docx`:
+  optional Word-authored override for a single section.
+
+`shape="intake"` is the default of `generate_variable_report()` and must stay
+that way: the ALWeaver's `variable_report.py` calls it without a shape.
+
+### Where a court's layout belongs
+
+No caption, footer, font or party label goes in Python. A new court is a new
+YAML file and nothing else; if drafting a court needs a code change, the block
+vocabulary is missing something and that is what should grow.
+
+### The two kinds of placeholder
+
+Profile text mixes two kinds of `{{ ... }}` and they are not interchangeable:
+
+- Draft-time keys (`document_title`, `docket_label`, `form_code`,
+  `form_revision`, `court_rule_citation`, `labels.*`) are substituted while
+  drafting and must not survive into the output.
+- Everything else — `{{ trial_court }}`, `{{ docket_number }}`,
+  `{{ users[0].signature }}` — passes through untouched as the profile's
+  contract with the interview.
+
+Fields discovered in the interview are separate again and are always wrapped in
+`showifdef()`. Do not "unify" these three; the tests assert each one.
+
+### Verification
+
+Run `test/test_court_form_generator.py`. It generates every shape against every
+shipped profile, asserts each caption carries that jurisdiction's boilerplate
+and docket label, and checks that a `.docx` fragment replaces only its own
+section while the profile's Word styles survive.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ When installed on a docassemble server, ALDashboard exposes a Flask API at:
 - `POST /al/api/v1/dashboard/bootstrap/compile`
 - `POST /al/api/v1/dashboard/translation/validate`
 - `POST /al/api/v1/dashboard/review-screen/draft`
+- `POST /al/api/v1/dashboard/variable-report`
+- `POST /al/api/v1/dashboard/court-form/profiles`
 - `POST /al/api/v1/dashboard/docx/validate`
 - `POST /al/api/v1/dashboard/yaml/check`
 - `POST /al/api/v1/dashboard/yaml/reformat`
@@ -72,6 +74,15 @@ celery modules:
 ```
 
 ### Endpoint Notes
+
+- `POST /al/api/v1/dashboard/variable-report`
+  - Input: interview YAML via `yaml_text`, upload, or `playground_project` + `playground_yaml_file`; optional `report_title`, `infer_assemblyline`.
+  - Optional `shape`: `intake` (default), `court_form`, `motion`, `affidavit`, `letter`. See [Court form shapes](#court-form-shapes).
+  - Court shapes also take `court_profile` and `include_certificate_of_service`, and return `docx_base64` by default.
+  - Output: `mako_markdown`, variable metrics, and for court shapes `profile_id`, `profile_name`, `styles`, and a `sections` map naming the template each fixed section came from.
+- `POST /al/api/v1/dashboard/court-form/profiles`
+  - Input: none.
+  - Output: the `shapes` this server can draft, the jurisdiction `profiles` installed on it, and the `sections` a profile may define.
 
 - `POST /al/api/v1/dashboard/translation`
   - Input: `interview_path`, one or more target languages (`tr_langs`), optional GPT settings.
@@ -106,6 +117,8 @@ celery modules:
   - Input: translation XLSX.
   - Output: structured errors/warnings/empty rows.
 - `POST /al/api/v1/dashboard/review-screen/draft`
+- `POST /al/api/v1/dashboard/variable-report`
+- `POST /al/api/v1/dashboard/court-form/profiles`
   - Input: one or more YAML files.
   - Output: generated review-screen YAML draft.
 - `POST /al/api/v1/dashboard/docx/validate`
@@ -149,6 +162,74 @@ Live docs:
 
 - `GET /al/api/v1/dashboard/openapi.json`
 - `GET /al/api/v1/dashboard/docs`
+
+## Court form shapes
+
+The Interview Intake Document Generator can arrange an interview's variables
+into a draft court filing rather than a list of fields. The interview's screens
+become the middle of the document; a **jurisdiction profile** supplies the parts
+the court fixes.
+
+Shapes:
+
+| Shape | What it drafts |
+| --- | --- |
+| `intake` | The original field-and-value summary. Still the default. |
+| `court_form` | Caption, title, the interview's screens as numbered sections, signature block. |
+| `motion` | The same, wrapped in a "NOW COMES" introduction and a prayer for relief, with a certificate of service. |
+| `affidavit` | The same, introduced as sworn statements and closed with the jurisdiction's perjury language and a jurat. |
+| `letter` | No caption: sender, date, recipient, `RE:` line, body, closing. |
+
+Profiles shipped with the package, each modeled on that court's real forms:
+`ma_trial_court`, `il_circuit`, `vt_superior`, `mi_scao`, `mn_district`,
+`dmass_federal`, and a neutral `generic`.
+
+### Editing the templates
+
+Nothing about a court's layout is compiled into Python.
+
+- **Profiles** are YAML in `docassemble/ALDashboard/data/sources/court_form_profiles/`.
+  Each defines the caption, running header and footer, signature block,
+  certificate of service and jurat as ordered blocks, plus the Word styles the
+  document should use. Adding `nh_circuit.yml` adds an `nh_circuit` profile to
+  the dropdown with no code change. A profile can `extends:` another so a new
+  court only states what differs.
+- **Word-authored overrides** go in
+  `docassemble/ALDashboard/data/templates/court_forms/<profile id>/<section>.docx`.
+  A fragment replaces just that section and is copied in verbatim; the rest of
+  the form still comes from the profile. Use this when a caption is easier to
+  draw in Word than to describe.
+- **Fonts and spacing are Word styles.** Everything the generator writes is
+  tagged `CourtBodyText`, `CourtCaptionHeading`, `CourtDocumentTitle` and so on,
+  so a court that wants Arial instead of Times is a one-line edit to the
+  profile rather than a sweep through the layout.
+
+Servers that would rather not fork the package can point the
+`court form profiles` configuration key at their own directory of profiles.
+
+Both README files under those directories document the block and placeholder
+syntax in full.
+
+### From Python
+
+```python
+from docassemble.ALDashboard.variable_report_generator import generate_variable_report
+
+result = generate_variable_report(
+    [yaml_text],
+    report_title="Motion to Vacate Default Judgment",
+    shape="motion",
+    court_profile="ma_trial_court",
+    output_docx_path="/tmp/motion.docx",
+)
+result["sections"]   # {'caption': 'yaml', 'signature': 'yaml', ...}
+```
+
+This is the entry point the ALWeaver's `variable_report.py` already calls, so
+the Weaver reaches the court shapes by passing `shape` and `court_profile`
+through. `docassemble.ALDashboard.court_form_generator.generate_court_form_docx`
+is available directly when a caller has already extracted the interview's
+groups and variables.
 
 ## MCP Bridge API
 

--- a/docassemble/ALDashboard/api_dashboard.py
+++ b/docassemble/ALDashboard/api_dashboard.py
@@ -78,6 +78,7 @@ from .api_dashboard_utils import (
     translation_payload_from_request,
     validate_docx_payload_from_request,
     validate_translation_payload_from_request,
+    court_form_profiles_payload_from_request,
     variable_report_payload_from_request,
     yaml_check_payload_from_request,
     yaml_reformat_payload_from_request,
@@ -109,6 +110,7 @@ if not in_celery:
         dashboard_yaml_check_task,
         dashboard_yaml_reformat_task,
         dashboard_pdf_repair_task,
+        dashboard_court_form_profiles_task,
         dashboard_variable_report_task,
     )
 
@@ -559,7 +561,18 @@ def dashboard_kiln_story():
 @cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
 def dashboard_variable_report():
     return _run_endpoint(
-        variable_report_payload_from_request, dashboard_variable_report_task
+        court_form_profiles_payload_from_request,
+        variable_report_payload_from_request,
+        dashboard_variable_report_task,
+    )
+
+
+@app.route(f"{DASHBOARD_API_BASE_PATH}/court-form/profiles", methods=["POST"])
+@csrf.exempt
+@cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
+def dashboard_court_form_profiles():
+    return _run_endpoint(
+        court_form_profiles_payload_from_request, dashboard_court_form_profiles_task
     )
 
 

--- a/docassemble/ALDashboard/api_dashboard.py
+++ b/docassemble/ALDashboard/api_dashboard.py
@@ -561,9 +561,7 @@ def dashboard_kiln_story():
 @cross_origin(origins="*", methods=["POST", "HEAD"], automatic_options=True)
 def dashboard_variable_report():
     return _run_endpoint(
-        court_form_profiles_payload_from_request,
-        variable_report_payload_from_request,
-        dashboard_variable_report_task,
+        variable_report_payload_from_request, dashboard_variable_report_task
     )
 
 

--- a/docassemble/ALDashboard/api_dashboard_utils.py
+++ b/docassemble/ALDashboard/api_dashboard_utils.py
@@ -1996,16 +1996,78 @@ def variable_report_payload_from_options(
     report_title = str(raw.get("report_title") or "Interview Variable Report").strip()
     infer_assemblyline = parse_bool(raw.get("infer_assemblyline"), default=True)
 
+    from .court_form_generator import COURT_FORM_SHAPES
+
+    shape = str(raw.get("shape") or "intake").strip().lower()
+    if shape not in ("intake",) + tuple(COURT_FORM_SHAPES):
+        raise DashboardAPIValidationError(
+            "`shape` must be one of: intake, " + ", ".join(COURT_FORM_SHAPES) + "."
+        )
+    court_profile = str(raw.get("court_profile") or "").strip() or None
+    include_certificate_of_service = (
+        parse_bool(raw.get("include_certificate_of_service"))
+        if raw.get("include_certificate_of_service") is not None
+        else None
+    )
+    # The DOCX is the deliverable for a court shape, so return it by default
+    # there and keep the intake response as small as it has always been.
+    include_docx_base64 = parse_bool(
+        raw.get("include_docx_base64"), default=shape != "intake"
+    )
+
     res = generate_variable_report(
         [yaml_text],
         report_title=report_title,
         infer_assemblyline=infer_assemblyline,
+        shape=shape,
+        court_profile=court_profile,
+        include_certificate_of_service=include_certificate_of_service,
     )
-    return {
+    payload: Dict[str, Any] = {
         "mako_markdown": res["mako_markdown"],
         "variables_count": res["variables_count"],
         "list_count": res["list_count"],
         "scalar_count": res["scalar_count"],
+        "shape": res.get("shape", shape),
+    }
+    for key in ("profile_id", "profile_name", "sections", "styles"):
+        if key in res:
+            payload[key] = res[key]
+    if include_docx_base64:
+        docx_path = res.get("docx_path")
+        if docx_path and os.path.isfile(docx_path):
+            with open(docx_path, "rb") as handle:
+                payload["docx_base64"] = base64.b64encode(handle.read()).decode("ascii")
+    return payload
+
+
+def court_form_profiles_payload_from_request() -> Dict[str, Any]:
+    """List the court form shapes and jurisdiction profiles this server has."""
+    return court_form_profiles_payload_from_options(merge_raw_options(_request_dict()))
+
+
+def court_form_profiles_payload_from_options(
+    raw_options: Mapping[str, Any],
+) -> Dict[str, Any]:
+    from .court_form_generator import COURT_FORM_SHAPES, SHAPE_LABELS
+    from .court_form_profiles import SECTION_NAMES, list_court_form_profiles
+
+    profiles = [
+        {
+            "id": profile["id"],
+            "name": profile["name"],
+            "jurisdiction": profile.get("jurisdiction", ""),
+            "description": profile.get("description", ""),
+        }
+        for profile in list_court_form_profiles()
+    ]
+    return {
+        "shapes": [
+            {"value": shape, "label": SHAPE_LABELS.get(shape, shape)}
+            for shape in ("intake",) + tuple(COURT_FORM_SHAPES)
+        ],
+        "profiles": profiles,
+        "sections": list(SECTION_NAMES),
     }
 
 
@@ -2476,11 +2538,76 @@ def build_openapi_spec() -> Dict[str, Any]:
             },
             f"{DASHBOARD_API_BASE_PATH}/variable-report": {
                 "post": {
-                    "summary": "Generate interview variable report (Mako+Markdown and Jinja2 DOCX)",
+                    "summary": (
+                        "Draft a document from an interview's variables "
+                        "(Mako+Markdown and Jinja2 DOCX)"
+                    ),
                     "description": (
                         "Accepts interview YAML via `yaml_text`, upload, or playground selection, "
                         "extracts all variables, infers AssemblyLine built-ins, and returns "
-                        "Mako+Markdown plain text and variable metrics."
+                        "Mako+Markdown plain text and variable metrics. Set `shape` to draft a "
+                        "court document instead of the intake summary: `court_form`, `motion`, "
+                        "`affidavit` or `letter`. Court shapes take the caption, running footer, "
+                        "signature block and certificate of service from the jurisdiction profile "
+                        "named by `court_profile`, and return the DOCX as `docx_base64` along with "
+                        "a `sections` map saying whether each fixed section came from the profile "
+                        "YAML (`yaml`) or from a Word-authored override (`docx`)."
+                    ),
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "yaml_text": {"type": "string"},
+                                        "file_content_base64": {"type": "string"},
+                                        "playground_project": {"type": "string"},
+                                        "playground_yaml_file": {"type": "string"},
+                                        "report_title": {"type": "string"},
+                                        "infer_assemblyline": {"type": "boolean"},
+                                        "shape": {
+                                            "type": "string",
+                                            "enum": [
+                                                "intake",
+                                                "court_form",
+                                                "motion",
+                                                "affidavit",
+                                                "letter",
+                                            ],
+                                            "default": "intake",
+                                        },
+                                        "court_profile": {
+                                            "type": "string",
+                                            "description": (
+                                                "Jurisdiction profile id, as listed by "
+                                                "/court-form/profiles."
+                                            ),
+                                        },
+                                        "include_certificate_of_service": {
+                                            "type": "boolean"
+                                        },
+                                        "include_docx_base64": {
+                                            "type": "boolean",
+                                            "description": (
+                                                "Defaults to true for court shapes and false "
+                                                "for the intake shape."
+                                            ),
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+            f"{DASHBOARD_API_BASE_PATH}/court-form/profiles": {
+                "post": {
+                    "summary": "List court form shapes and jurisdiction profiles",
+                    "description": (
+                        "Returns the template `shapes` this server can draft, the jurisdiction "
+                        "`profiles` installed on it, and the `sections` a profile may define. "
+                        "Profiles are editable YAML; any section can be replaced by a "
+                        "Word-authored .docx fragment."
                     ),
                 }
             },

--- a/docassemble/ALDashboard/api_dashboard_worker.py
+++ b/docassemble/ALDashboard/api_dashboard_worker.py
@@ -25,6 +25,7 @@ from .api_dashboard_utils import (
     pdf_fields_detect_payload_from_options,
     pdf_fields_relabel_payload_from_options,
     pdf_label_fields_payload_from_options,
+    court_form_profiles_payload_from_options,
     pdf_repair_payload_from_options,
     relabel_payload_from_options,
     review_screen_payload_from_options,
@@ -151,3 +152,9 @@ def dashboard_pdf_repair_task(payload: Dict[str, Any]) -> Dict[str, Any]:
 def dashboard_variable_report_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     with bg_context():
         return variable_report_payload_from_options(payload)
+
+
+@workerapp.task
+def dashboard_court_form_profiles_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    with bg_context():
+        return court_form_profiles_payload_from_options(payload)

--- a/docassemble/ALDashboard/court_form_generator.py
+++ b/docassemble/ALDashboard/court_form_generator.py
@@ -1,0 +1,824 @@
+"""Draft a court document from the variables an interview already gathers.
+
+The variable report answers "what does this interview collect?". A court form
+answers "what does the court want to see?", and the two are close enough that
+the report's own extraction can drive both: the interview's screens become the
+numbered middle of the document, and the jurisdiction profile supplies the
+caption, running footer, signature block and certificate of service that the
+court fixes (SuffolkLITLab/docassemble-ALDashboard#272).
+
+Four shapes are drafted here. They share the caption and signature machinery and
+differ in what surrounds the body:
+
+``court_form``
+    Caption, title, the interview's screens as numbered sections, signature.
+``motion``
+    The same, wrapped in a "NOW COMES" introduction and a prayer for relief,
+    and followed by a certificate of service.
+``affidavit``
+    The same, introduced as sworn statements and closed with a jurat.
+``letter``
+    No caption at all: sender block, date, recipient, RE: line, body, closing.
+
+The output is a docassemble DOCX **template**, not a filled document. Two
+conventions apply to the Jinja it contains, and they differ on purpose:
+
+* Boilerplate named by the profile -- ``{{ trial_court }}``,
+  ``{{ users[0].signature }}`` -- is written through as-is. These names are the
+  profile's contract with the interview, they read the way a human would write
+  them, and they match what hand-authored AssemblyLine court templates use.
+* Fields discovered in the interview are wrapped in ``showifdef()``, because
+  whether any given one is defined at assembly time is exactly what we do not
+  know. This matches the intake report's existing behavior.
+"""
+
+import re
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .court_form_profiles import (
+    CourtFormProfile,
+    apply_profile_styles,
+    find_docx_fragment,
+    load_court_form_profile,
+    splice_docx_fragment,
+)
+
+try:
+    import docx
+    from docx.enum.table import WD_TABLE_ALIGNMENT
+    from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_BREAK
+    from docx.document import Document as _DocxDocument
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+    from docx.shared import Inches, Pt
+except ImportError:  # pragma: no cover - python-docx is a hard dependency at runtime
+    docx = None  # type: ignore[assignment]
+
+__all__ = [
+    "COURT_FORM_SHAPES",
+    "SHAPE_LABELS",
+    "build_court_form_context",
+    "generate_court_form_docx",
+    "generate_court_form_markdown",
+    "render_blocks",
+]
+
+# Shapes this module can draft. "intake" stays with the variable report.
+COURT_FORM_SHAPES: Sequence[str] = ("court_form", "motion", "affidavit", "letter")
+
+SHAPE_LABELS: Dict[str, str] = {
+    "intake": "Intake summary (field and value tables)",
+    "court_form": "Court form (caption, numbered body, signature)",
+    "motion": "Motion (caption, grounds, prayer for relief, certificate of service)",
+    "affidavit": "Affidavit (caption, sworn statements, jurat)",
+    "letter": "Letter (no caption; sender, recipient, body, closing)",
+}
+
+# Placeholders resolved while drafting rather than left for docassemble. These
+# name things the drafter knows now -- the title of this document, what this
+# court calls its docket number -- so baking them in produces a template an
+# author can read instead of a chain of indirections.
+_DRAFT_TIME_KEYS: Sequence[str] = (
+    "document_title",
+    "docket_label",
+    "court_name",
+    "jurisdiction",
+    "form_code",
+    "form_revision",
+    "court_rule_citation",
+)
+
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_\.]*)\s*\}\}")
+
+# Attributes that are noise in a court document body.
+_SKIP_BODY_ATTRS = {"instanceName", "elements", "parent", "attr_name"}
+
+
+def _require_docx() -> None:
+    if docx is None:
+        raise RuntimeError("python-docx is not installed in the python environment.")
+
+
+def build_court_form_context(
+    profile: CourtFormProfile,
+    document_title: str,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, str]:
+    """The draft-time substitutions for one document.
+
+    ``labels.plaintiff`` and friends resolve from the profile so a caption can
+    say "Defendant(s)/Respondent(s)" in Michigan and "Defendant" in Vermont
+    without either profile restating the other's wording.
+    """
+    context: Dict[str, str] = {
+        "document_title": str(document_title or "").strip(),
+        "docket_label": profile.label("docket", "Case No."),
+        "court_name": profile.name,
+        "jurisdiction": profile.jurisdiction,
+        # Form metadata nobody has supplied yet. A visible bracket tells the
+        # author what to fill in; an empty string would just leave a gap in the
+        # footer that reads like a bug.
+        "form_code": "[form number]",
+        "form_revision": "[revision date]",
+        "court_rule_citation": "[court rule citation]",
+    }
+    for key, value in profile.labels.items():
+        context[f"labels.{key}"] = str(value)
+    for key in _DRAFT_TIME_KEYS:
+        if key in profile.labels:
+            context[key] = str(profile.labels[key])
+    if extra:
+        for key, value in extra.items():
+            if value is not None and str(value) != "":
+                context[str(key)] = str(value)
+    return context
+
+
+def _substitute(text: str, context: Mapping[str, str]) -> str:
+    """Fill draft-time placeholders and leave interview variables alone."""
+
+    def replace(match: "re.Match[str]") -> str:
+        name = match.group(1)
+        if name in context:
+            return str(context[name])
+        return match.group(0)
+
+    return _PLACEHOLDER_RE.sub(replace, str(text or ""))
+
+
+def _set_table_borders(table, kind: str) -> None:
+    """Apply one of the border treatments a caption needs.
+
+    python-docx has no border API, so this writes ``w:tblBorders`` directly.
+    """
+    kind = str(kind or "none").strip().lower()
+    tbl_pr = table._tbl.tblPr
+    for existing in tbl_pr.findall(qn("w:tblBorders")):
+        tbl_pr.remove(existing)
+    borders = OxmlElement("w:tblBorders")
+
+    if kind in ("box", "grid"):
+        edges = ["top", "left", "bottom", "right"]
+        if kind == "grid":
+            edges += ["insideH", "insideV"]
+        for edge in edges:
+            element = OxmlElement(f"w:{edge}")
+            element.set(qn("w:val"), "single")
+            element.set(qn("w:sz"), "6")
+            element.set(qn("w:color"), "000000")
+            borders.append(element)
+        if kind == "box":
+            for edge in ("insideH", "insideV"):
+                element = OxmlElement(f"w:{edge}")
+                element.set(qn("w:val"), "none")
+                borders.append(element)
+    elif kind == "bottom":
+        for edge in ("top", "left", "right", "insideH", "insideV"):
+            element = OxmlElement(f"w:{edge}")
+            element.set(qn("w:val"), "none")
+            borders.append(element)
+        element = OxmlElement("w:bottom")
+        element.set(qn("w:val"), "single")
+        element.set(qn("w:sz"), "6")
+        element.set(qn("w:color"), "000000")
+        borders.append(element)
+    else:
+        for edge in ("top", "left", "bottom", "right", "insideH", "insideV"):
+            element = OxmlElement(f"w:{edge}")
+            element.set(qn("w:val"), "none")
+            borders.append(element)
+
+    tbl_pr.append(borders)
+
+
+def _add_page_number_field(paragraph, align: Optional[str] = None) -> None:
+    """Append a live "Page X of Y" field so pagination follows the document."""
+    if align:
+        alignment = {
+            "left": WD_ALIGN_PARAGRAPH.LEFT,
+            "center": WD_ALIGN_PARAGRAPH.CENTER,
+            "right": WD_ALIGN_PARAGRAPH.RIGHT,
+        }.get(str(align).lower())
+        if alignment is not None:
+            paragraph.alignment = alignment
+
+    if paragraph.text:
+        paragraph.add_run("    ")
+    paragraph.add_run("Page ")
+    for instruction in ("PAGE", "NUMPAGES"):
+        run = paragraph.add_run()
+        begin = OxmlElement("w:fldChar")
+        begin.set(qn("w:fldCharType"), "begin")
+        instr = OxmlElement("w:instrText")
+        instr.set(qn("xml:space"), "preserve")
+        instr.text = f" {instruction} "
+        end = OxmlElement("w:fldChar")
+        end.set(qn("w:fldCharType"), "end")
+        run._r.append(begin)
+        run._r.append(instr)
+        run._r.append(end)
+        if instruction == "PAGE":
+            paragraph.add_run(" of ")
+
+
+def _add_horizontal_rule(paragraph) -> None:
+    """A bottom border on an empty paragraph: the line under a caption."""
+    p_pr = paragraph._p.get_or_add_pPr()
+    borders = OxmlElement("w:pBdr")
+    bottom = OxmlElement("w:bottom")
+    bottom.set(qn("w:val"), "single")
+    bottom.set(qn("w:sz"), "6")
+    bottom.set(qn("w:space"), "1")
+    bottom.set(qn("w:color"), "000000")
+    borders.append(bottom)
+    p_pr.append(borders)
+
+
+def _style_or_none(document, name: Optional[str]) -> Optional[str]:
+    """A style name the document actually has, so a typo cannot raise."""
+    if not name:
+        return None
+    try:
+        document.styles[str(name)]
+        return str(name)
+    except KeyError:
+        return None
+
+
+def _add_paragraph(container, document, text: str, style: Optional[str]):
+    resolved = _style_or_none(document, style)
+    paragraph = container.add_paragraph(text)
+    if resolved:
+        paragraph.style = document.styles[resolved]
+    return paragraph
+
+
+def render_blocks(
+    document,
+    container,
+    blocks: Sequence[Mapping[str, Any]],
+    profile: CourtFormProfile,
+    context: Mapping[str, str],
+) -> int:
+    """Draw a profile's declarative blocks into ``container``.
+
+    ``container`` is the document body, a header or a footer -- all of them take
+    ``add_paragraph`` and ``add_table``. Returns the number of blocks drawn.
+    """
+    _require_docx()
+    drawn = 0
+
+    for block in blocks:
+        if not isinstance(block, Mapping):
+            continue
+        block_type = str(block.get("type") or "paragraph").strip().lower()
+
+        if block_type == "spacer":
+            _add_paragraph(container, document, "", block.get("style"))
+            drawn += 1
+
+        elif block_type == "rule":
+            paragraph = _add_paragraph(container, document, "", block.get("style"))
+            _add_horizontal_rule(paragraph)
+            drawn += 1
+
+        elif block_type == "page_break":
+            paragraph = container.add_paragraph()
+            paragraph.add_run().add_break(WD_BREAK.PAGE)
+            drawn += 1
+
+        elif block_type == "paragraph":
+            text = _substitute(block.get("text", ""), context)
+            paragraph = _add_paragraph(container, document, text, block.get("style"))
+            align = block.get("align")
+            if align:
+                alignment = {
+                    "left": WD_ALIGN_PARAGRAPH.LEFT,
+                    "center": WD_ALIGN_PARAGRAPH.CENTER,
+                    "right": WD_ALIGN_PARAGRAPH.RIGHT,
+                    "justify": WD_ALIGN_PARAGRAPH.JUSTIFY,
+                }.get(str(align).lower())
+                if alignment is not None:
+                    paragraph.alignment = alignment
+            if block.get("page_numbers"):
+                _add_page_number_field(
+                    paragraph, block.get("page_numbers_align") or "right"
+                )
+            drawn += 1
+
+        elif block_type == "table":
+            rows = block.get("rows")
+            if not isinstance(rows, list) or not rows:
+                continue
+            widths = block.get("widths")
+            column_count = max(
+                len(row.get("cells", []) if isinstance(row, Mapping) else row)
+                for row in rows
+            )
+            if isinstance(widths, list) and widths:
+                column_count = max(column_count, len(widths))
+
+            # Document.add_table sizes itself from the section; a header or
+            # footer is a bare block container and insists on an explicit width.
+            if isinstance(container, _DocxDocument):
+                table = container.add_table(rows=0, cols=column_count)
+            else:
+                total_width = 6.5
+                if isinstance(widths, list) and widths:
+                    try:
+                        total_width = sum(float(w) for w in widths)
+                    except (TypeError, ValueError):
+                        pass
+                table = container.add_table(
+                    rows=0, cols=column_count, width=Inches(total_width)
+                )
+            try:
+                table.alignment = WD_TABLE_ALIGNMENT.LEFT
+                table.autofit = False
+            except Exception:
+                pass
+            _set_table_borders(table, block.get("borders", "none"))
+
+            default_style = block.get("style") or "CourtCaptionText"
+            for row_spec in rows:
+                if isinstance(row_spec, Mapping):
+                    cells = row_spec.get("cells") or []
+                    row_style = row_spec.get("style") or default_style
+                else:
+                    cells = row_spec
+                    row_style = default_style
+                row = table.add_row()
+                for index in range(column_count):
+                    raw = cells[index] if index < len(cells) else ""
+                    text = _substitute(raw, context)
+                    cell = row.cells[index]
+                    # A cell starts with one empty paragraph; write the first
+                    # line into it so no blank line precedes the content.
+                    lines = str(text).split("\n")
+                    resolved = _style_or_none(document, row_style)
+                    first = cell.paragraphs[0]
+                    first.text = lines[0]
+                    if resolved:
+                        first.style = document.styles[resolved]
+                    for line in lines[1:]:
+                        extra = cell.add_paragraph(line)
+                        if resolved:
+                            extra.style = document.styles[resolved]
+
+            if isinstance(widths, list):
+                for index, width in enumerate(widths):
+                    if index >= column_count:
+                        break
+                    try:
+                        inches = Inches(float(width))
+                    except (TypeError, ValueError):
+                        continue
+                    for row in table.rows:
+                        row.cells[index].width = inches
+            drawn += 1
+
+    return drawn
+
+
+def _render_section(
+    document,
+    section: str,
+    profile: CourtFormProfile,
+    context: Mapping[str, str],
+    container=None,
+) -> str:
+    """Draw one fixed section, preferring a Word-authored override.
+
+    Returns "docx", "yaml" or "" so callers can report which template was used.
+    """
+    fragment = find_docx_fragment(profile.id, section, profile.fragment_dirs)
+    if fragment:
+        # A header or footer is its own block container; the body splice has to
+        # respect the trailing sectPr, which is why it is handled separately.
+        target_element = getattr(container, "_element", None) if container else None
+        splice_docx_fragment(document, fragment, container=target_element)
+        return "docx"
+    blocks = profile.section_blocks(section)
+    if not blocks:
+        return ""
+    target = container if container is not None else document
+    render_blocks(document, target, blocks, profile, context)
+    return "yaml"
+
+
+def _field_expression(field_spec) -> str:
+    """The Jinja for one discovered field, guarded against being undefined."""
+    if getattr(field_spec, "datatype", "") in ("yesno", "boolean"):
+        return (
+            "{% if showifdef('"
+            + field_spec.var_name
+            + "') %}Yes{% else %}No{% endif %}"
+        )
+    return "{{ showifdef('" + field_spec.var_name + "') }}"
+
+
+def _add_list_table(document, container, list_spec, profile: CourtFormProfile) -> None:
+    """A repeating table for one of the interview's lists."""
+    attributes = [
+        attribute
+        for attribute in list_spec.attributes
+        if attribute.name not in _SKIP_BODY_ATTRS
+    ]
+    if not attributes:
+        return
+
+    table = container.add_table(rows=0, cols=len(attributes) + 1)
+    _set_table_borders(table, "grid")
+    label_style = _style_or_none(document, profile.style_name("label_style", "Normal"))
+    text_style = _style_or_none(document, profile.style_name("text_style", "Normal"))
+
+    header = table.add_row()
+    header.cells[0].text = "#"
+    for index, attribute in enumerate(attributes, start=1):
+        header.cells[index].text = attribute.description or attribute.name
+    if label_style:
+        for cell in header.cells:
+            for paragraph in cell.paragraphs:
+                paragraph.style = document.styles[label_style]
+
+    # Standalone loop rows keep docxtpl's row repetition working.
+    loop_start = table.add_row()
+    loop_start.cells[0].text = "{%tr for item in showifdef('" + list_spec.name + "') %}"
+
+    data = table.add_row()
+    data.cells[0].text = "{{ loop.index }}"
+    for index, attribute in enumerate(attributes, start=1):
+        if attribute.name == "item":
+            data.cells[index].text = "{{ item }}"
+        else:
+            data.cells[index].text = (
+                "{{ showifdef(item.attr_name('" + attribute.name + "')) }}"
+            )
+    if text_style:
+        for cell in data.cells:
+            for paragraph in cell.paragraphs:
+                paragraph.style = document.styles[text_style]
+
+    loop_end = table.add_row()
+    loop_end.cells[0].text = "{%tr endfor %}"
+
+
+def _add_numbered_body(
+    document,
+    groups: Sequence[Any],
+    profile: CourtFormProfile,
+    *,
+    numbered: bool = True,
+    show_headings: bool = True,
+) -> int:
+    """The middle of the document: the interview's screens, in order.
+
+    Returns the number of numbered paragraphs written, so a caller can tell
+    whether the draft has any substance to it.
+    """
+    heading_style = profile.style_name("heading_style", "Heading 2")
+    text_style = profile.style_name("text_style", "Normal")
+    counter = 0
+
+    for group in groups:
+        fields = list(getattr(group, "fields", []) or [])
+        lists = list(getattr(group, "lists", []) or [])
+        if not fields and not lists:
+            continue
+
+        if show_headings:
+            _add_paragraph(document, document, group.title, heading_style)
+
+        for field_spec in fields:
+            counter += 1
+            prefix = f"{counter}. " if numbered else ""
+            text = f"{prefix}{field_spec.label}: {_field_expression(field_spec)}"
+            _add_paragraph(document, document, text, text_style)
+
+        for list_spec in lists:
+            _add_paragraph(
+                document,
+                document,
+                list_spec.label or list_spec.name,
+                heading_style,
+            )
+            _add_list_table(document, document, list_spec, profile)
+            _add_paragraph(document, document, "", text_style)
+
+    return counter
+
+
+def generate_court_form_docx(
+    groups: Sequence[Any],
+    variables: Mapping[str, Any],
+    *,
+    shape: str = "court_form",
+    profile: Optional[CourtFormProfile] = None,
+    profile_id: Optional[str] = None,
+    document_title: Optional[str] = None,
+    output_path: Optional[str] = None,
+    include_certificate_of_service: Optional[bool] = None,
+    numbered_paragraphs: Optional[bool] = None,
+    fragment_dirs: Optional[Sequence[str]] = None,
+    context_extra: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Draft one court document and return it with a description of what it is.
+
+    The result's ``sections`` map says, for each fixed section, whether it came
+    from the profile YAML or from a Word-authored ``.docx`` override -- which is
+    the question people ask first when a caption does not look the way they
+    expected.
+    """
+    _require_docx()
+
+    shape_name = str(shape or "court_form").strip().lower()
+    if shape_name not in COURT_FORM_SHAPES:
+        raise ValueError(
+            f"Unknown court form shape '{shape}'. "
+            f"Choose one of: {', '.join(COURT_FORM_SHAPES)}."
+        )
+
+    if profile is None:
+        profile = load_court_form_profile(profile_id, fragment_dirs=fragment_dirs)
+    elif fragment_dirs:
+        profile.fragment_dirs = [str(d) for d in fragment_dirs]
+
+    title = str(document_title or "").strip() or "Court Document Draft"
+    context = build_court_form_context(profile, title, context_extra)
+
+    document = docx.Document()
+    apply_profile_styles(document, profile)
+
+    section = document.sections[0]
+    section.top_margin = Inches(profile.page.top_margin)
+    section.bottom_margin = Inches(profile.page.bottom_margin)
+    section.left_margin = Inches(profile.page.left_margin)
+    section.right_margin = Inches(profile.page.right_margin)
+
+    used: Dict[str, str] = {}
+
+    if numbered_paragraphs is None:
+        numbered_paragraphs = bool(profile.body.get("numbered_paragraphs", True))
+
+    if shape_name == "letter":
+        used["letterhead"] = _render_section(document, "letterhead", profile, context)
+        _build_letter_body(document, groups, profile, context, title)
+    else:
+        used["caption"] = _render_section(document, "caption", profile, context)
+        _add_paragraph(
+            document, document, title, profile.style_name("title_style", "Heading 1")
+        )
+
+        text_style = profile.style_name("text_style", "Normal")
+        if shape_name == "motion" and profile.body.get("motion_intro"):
+            _add_paragraph(
+                document,
+                document,
+                _substitute(profile.body["motion_intro"], context),
+                text_style,
+            )
+        elif shape_name == "affidavit" and profile.body.get("affidavit_intro"):
+            _add_paragraph(
+                document,
+                document,
+                _substitute(profile.body["affidavit_intro"], context),
+                text_style,
+            )
+
+        _add_numbered_body(
+            document, groups, profile, numbered=bool(numbered_paragraphs)
+        )
+
+        if shape_name == "motion" and profile.body.get("motion_prayer"):
+            _add_paragraph(
+                document,
+                document,
+                _substitute(profile.body["motion_prayer"], context),
+                text_style,
+            )
+
+        if shape_name == "affidavit":
+            closing = profile.body.get("affidavit_closing")
+            if closing:
+                _add_paragraph(
+                    document, document, _substitute(closing, context), text_style
+                )
+            used["jurat"] = _render_section(document, "jurat", profile, context)
+        else:
+            used["signature"] = _render_section(document, "signature", profile, context)
+
+        if include_certificate_of_service is None:
+            include_certificate_of_service = shape_name == "motion"
+        if include_certificate_of_service:
+            used["certificate_of_service"] = _render_section(
+                document, "certificate_of_service", profile, context
+            )
+
+    # Running header and footer belong to the section, not the body flow. A
+    # letter is correspondence rather than a filing, so the court's form number
+    # and "Page 1 of 2" footer would be wrong on it.
+    if shape_name != "letter":
+        for name, container in (("header", section.header), ("footer", section.footer)):
+            origin = _render_section(
+                document, name, profile, context, container=container
+            )
+            if origin:
+                used[name] = origin
+
+    path = output_path
+    if not path:
+        import os
+        import tempfile
+
+        path = os.path.join(tempfile.mkdtemp(prefix="court_form_"), "court_form.docx")
+    document.save(path)
+
+    return {
+        "docx_path": path,
+        "shape": shape_name,
+        "profile_id": profile.id,
+        "profile_name": profile.name,
+        "document_title": title,
+        "sections": {key: value for key, value in used.items() if value},
+        "styles": sorted(profile.styles.keys()),
+    }
+
+
+def _build_letter_body(
+    document,
+    groups: Sequence[Any],
+    profile: CourtFormProfile,
+    context: Mapping[str, str],
+    title: str,
+) -> None:
+    """A letter has no caption; it has correspondents."""
+    text_style = profile.style_name("text_style", "Normal")
+    signature_style = profile.style_name("signature_style", text_style)
+
+    for line in (
+        "{{ users[0] }}",
+        "{{ users[0].address.block() }}",
+        "",
+        "{{ letter_date }}",
+        "",
+        "{{ recipient }}",
+        "{{ recipient.address.block() }}",
+        "",
+    ):
+        _add_paragraph(document, document, line, text_style)
+
+    _add_paragraph(
+        document,
+        document,
+        f"RE: {title}",
+        profile.style_name("label_style", text_style),
+    )
+    _add_paragraph(document, document, "", text_style)
+    _add_paragraph(document, document, "Dear {{ recipient }}:", text_style)
+
+    _add_numbered_body(document, groups, profile, numbered=False, show_headings=True)
+
+    for line in ("", "Sincerely,", "", "{{ users[0].signature }}", "{{ users[0] }}"):
+        _add_paragraph(document, document, line, signature_style)
+
+
+def generate_court_form_markdown(
+    groups: Sequence[Any],
+    variables: Mapping[str, Any],
+    *,
+    shape: str = "court_form",
+    profile: Optional[CourtFormProfile] = None,
+    profile_id: Optional[str] = None,
+    document_title: Optional[str] = None,
+    context_extra: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """A Mako + Markdown rendering of the same draft, for preview and for
+    authors who assemble to Markdown rather than to DOCX."""
+    if profile is None:
+        profile = load_court_form_profile(profile_id)
+    shape_name = str(shape or "court_form").strip().lower()
+    title = str(document_title or "").strip() or "Court Document Draft"
+    context = build_court_form_context(profile, title, context_extra)
+
+    lines: List[str] = []
+
+    def block_lines(section: str) -> None:
+        for block in profile.section_blocks(section):
+            block_type = str(block.get("type") or "paragraph").strip().lower()
+            if block_type == "paragraph":
+                text = _substitute(block.get("text", ""), context).strip()
+                if text:
+                    lines.append(text)
+                    lines.append("")
+            elif block_type == "table":
+                for row_spec in block.get("rows") or []:
+                    cells = (
+                        row_spec.get("cells")
+                        if isinstance(row_spec, Mapping)
+                        else row_spec
+                    ) or []
+                    rendered = [
+                        _substitute(cell, context).replace("\n", " ").strip()
+                        for cell in cells
+                    ]
+                    if any(rendered):
+                        lines.append(" | ".join(rendered))
+                lines.append("")
+            elif block_type == "rule":
+                lines.append("---")
+                lines.append("")
+
+    if shape_name == "letter":
+        lines.append("{{ users[0] }}")
+        lines.append("")
+        lines.append("{{ letter_date }}")
+        lines.append("")
+        lines.append("{{ recipient }}")
+        lines.append("")
+        lines.append(f"**RE: {title}**")
+        lines.append("")
+        lines.append("Dear {{ recipient }}:")
+        lines.append("")
+    else:
+        block_lines("caption")
+        lines.append(f"# {title}")
+        lines.append("")
+        if shape_name == "motion" and profile.body.get("motion_intro"):
+            lines.append(_substitute(profile.body["motion_intro"], context))
+            lines.append("")
+        elif shape_name == "affidavit" and profile.body.get("affidavit_intro"):
+            lines.append(_substitute(profile.body["affidavit_intro"], context))
+            lines.append("")
+
+    counter = 0
+    for group in groups:
+        fields = list(getattr(group, "fields", []) or [])
+        lists = list(getattr(group, "lists", []) or [])
+        if not fields and not lists:
+            continue
+        lines.append(f"## {group.title}")
+        lines.append("")
+        for field_spec in fields:
+            counter += 1
+            if getattr(field_spec, "datatype", "") in ("yesno", "boolean"):
+                value = (
+                    "% if showifdef('"
+                    + field_spec.var_name
+                    + "'): Yes % else: No % endif"
+                )
+            else:
+                value = "${ showifdef('" + field_spec.var_name + "') }"
+            prefix = f"{counter}. " if shape_name != "letter" else ""
+            lines.append(f"{prefix}**{field_spec.label}:** {value}")
+            lines.append("")
+        for list_spec in lists:
+            lines.append(f"### {list_spec.label or list_spec.name}")
+            lines.append("")
+            attributes = [
+                attribute
+                for attribute in list_spec.attributes
+                if attribute.name not in _SKIP_BODY_ATTRS
+            ]
+            if not attributes:
+                continue
+            lines.append(
+                "| # | "
+                + " | ".join(a.description or a.name for a in attributes)
+                + " |"
+            )
+            lines.append("| --- | " + " | ".join(["---"] * len(attributes)) + " |")
+            lines.append(
+                "% for i, item in enumerate(showifdef('" + list_spec.name + "') or []):"
+            )
+            cells = []
+            for attribute in attributes:
+                if attribute.name == "item":
+                    cells.append("${ item }")
+                else:
+                    cells.append(
+                        "${ showifdef(item.attr_name('" + attribute.name + "')) }"
+                    )
+            lines.append("| ${ i + 1 } | " + " | ".join(cells) + " |")
+            lines.append("% endfor")
+            lines.append("")
+
+    if shape_name == "motion" and profile.body.get("motion_prayer"):
+        lines.append(_substitute(profile.body["motion_prayer"], context))
+        lines.append("")
+    if shape_name == "affidavit":
+        closing = profile.body.get("affidavit_closing")
+        if closing:
+            lines.append(_substitute(closing, context))
+            lines.append("")
+        block_lines("jurat")
+    elif shape_name == "letter":
+        lines.append("Sincerely,")
+        lines.append("")
+        lines.append("{{ users[0].signature }}")
+        lines.append("")
+    else:
+        block_lines("signature")
+        if shape_name == "motion":
+            block_lines("certificate_of_service")
+
+    return "\n".join(lines)

--- a/docassemble/ALDashboard/court_form_profiles.py
+++ b/docassemble/ALDashboard/court_form_profiles.py
@@ -1,0 +1,624 @@
+"""Jurisdiction profiles that describe the shape of a court form.
+
+A court form is mostly boilerplate. The caption, the running footer with the
+form number and "Page 1 of 2", the signature block and the certificate of
+service are fixed by the court; only the middle of the document changes from
+form to form. Every jurisdiction writes that boilerplate differently -- compare
+Michigan's boxed SCAO caption against Vermont's two-column unit/docket line --
+so a drafting tool that hard-codes one court's layout is only useful in that
+court (SuffolkLITLab/docassemble-ALDashboard#272,
+SuffolkLITLab/docassemble-ALWeaver#498).
+
+This module keeps that boilerplate out of the code. A profile is a YAML file
+naming the styles the court wants and the blocks that make up each fixed
+section, and a section can instead be a Word-authored ``.docx`` fragment when a
+layout is easier to draw than to describe. Both are editable without touching
+Python:
+
+* ``data/sources/court_form_profiles/<id>.yml`` -- the declarative default.
+* ``data/templates/court_forms/<id>/<section>.docx`` -- an optional override,
+  spliced in verbatim, for people who would rather edit a caption in Word.
+
+Fonts, sizes and spacing live in the profile's ``styles:`` map and are written
+into the generated document as real Word paragraph styles. A court that wants
+Arial instead of Times gets a one-line edit rather than a search for every
+``Pt(12)`` in the generator.
+"""
+
+import copy
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
+
+try:
+    import docx
+    from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_LINE_SPACING
+    from docx.enum.style import WD_STYLE_TYPE
+    from docx.oxml.ns import qn
+    from docx.shared import Inches, Pt
+except ImportError:  # pragma: no cover - python-docx is a hard dependency at runtime
+    docx = None  # type: ignore[assignment]
+
+__all__ = [
+    "CourtFormProfile",
+    "PageSpec",
+    "StyleSpec",
+    "DEFAULT_PROFILE_ID",
+    "SECTION_NAMES",
+    "apply_profile_styles",
+    "find_docx_fragment",
+    "list_court_form_profiles",
+    "load_court_form_profile",
+    "packaged_profile_directory",
+    "packaged_fragment_directory",
+    "splice_docx_fragment",
+]
+
+DEFAULT_PROFILE_ID = "generic"
+
+# Sections a profile may define. Each may come from YAML blocks or from a
+# same-named .docx fragment.
+SECTION_NAMES: Sequence[str] = (
+    "caption",
+    "header",
+    "footer",
+    "letterhead",
+    "signature",
+    "certificate_of_service",
+    "jurat",
+)
+
+_ALIGNMENTS = {
+    "left": "LEFT",
+    "center": "CENTER",
+    "centre": "CENTER",
+    "right": "RIGHT",
+    "justify": "JUSTIFY",
+    "both": "JUSTIFY",
+}
+
+
+def _alignment(value: Any):
+    """Translate a profile's ``align:`` string into a python-docx constant."""
+    if value is None or docx is None:
+        return None
+    key = str(value).strip().lower()
+    name = _ALIGNMENTS.get(key)
+    if not name:
+        return None
+    return getattr(WD_ALIGN_PARAGRAPH, name)
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass
+class StyleSpec:
+    """One Word style the profile wants defined in the generated document."""
+
+    name: str
+    style_type: str = "paragraph"
+    based_on: Optional[str] = None
+    font: Optional[str] = None
+    size: Optional[float] = None
+    bold: Optional[bool] = None
+    italic: Optional[bool] = None
+    underline: Optional[bool] = None
+    all_caps: Optional[bool] = None
+    color: Optional[str] = None
+    align: Optional[str] = None
+    line_spacing: Optional[float] = None
+    space_before: Optional[float] = None
+    space_after: Optional[float] = None
+    left_indent: Optional[float] = None
+    first_line_indent: Optional[float] = None
+    keep_with_next: Optional[bool] = None
+
+    @classmethod
+    def from_mapping(cls, name: str, raw: Mapping[str, Any]) -> "StyleSpec":
+        def flag(key: str) -> Optional[bool]:
+            if key not in raw or raw.get(key) is None:
+                return None
+            return bool(raw.get(key))
+
+        return cls(
+            name=name,
+            style_type=str(raw.get("type") or "paragraph").strip().lower(),
+            based_on=(str(raw["based_on"]).strip() if raw.get("based_on") else None),
+            font=(str(raw["font"]).strip() if raw.get("font") else None),
+            size=_as_float(raw.get("size")),
+            bold=flag("bold"),
+            italic=flag("italic"),
+            underline=flag("underline"),
+            all_caps=flag("all_caps"),
+            color=(str(raw["color"]).strip() if raw.get("color") else None),
+            align=(str(raw["align"]).strip() if raw.get("align") else None),
+            line_spacing=_as_float(raw.get("line_spacing")),
+            space_before=_as_float(raw.get("space_before")),
+            space_after=_as_float(raw.get("space_after")),
+            left_indent=_as_float(raw.get("left_indent")),
+            first_line_indent=_as_float(raw.get("first_line_indent")),
+            keep_with_next=flag("keep_with_next"),
+        )
+
+
+@dataclass
+class PageSpec:
+    """Page setup the court expects."""
+
+    top_margin: float = 1.0
+    bottom_margin: float = 1.0
+    left_margin: float = 1.0
+    right_margin: float = 1.0
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "PageSpec":
+        raw_margins = raw.get("margins")
+        margins: Mapping[str, Any] = (
+            raw_margins if isinstance(raw_margins, Mapping) else {}
+        )
+        defaults = cls()
+
+        def margin(key: str, fallback: float) -> float:
+            value = _as_float(margins.get(key))
+            return value if value is not None else fallback
+
+        return cls(
+            top_margin=margin("top", defaults.top_margin),
+            bottom_margin=margin("bottom", defaults.bottom_margin),
+            left_margin=margin("left", defaults.left_margin),
+            right_margin=margin("right", defaults.right_margin),
+        )
+
+
+@dataclass
+class CourtFormProfile:
+    """Everything the generator needs to draw one court's boilerplate."""
+
+    id: str
+    name: str = ""
+    jurisdiction: str = ""
+    description: str = ""
+    page: PageSpec = field(default_factory=PageSpec)
+    styles: Dict[str, StyleSpec] = field(default_factory=dict)
+    sections: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
+    labels: Dict[str, str] = field(default_factory=dict)
+    body: Dict[str, Any] = field(default_factory=dict)
+    source_path: str = ""
+    # Directories searched, ahead of the packaged one, for .docx section
+    # overrides. Carried on the profile so a caller that named its own
+    # directory once does not have to name it again for every section.
+    fragment_dirs: List[str] = field(default_factory=list)
+
+    def style_name(self, role: str, fallback: str = "Normal") -> str:
+        """The style to use for a role, falling back when a profile omits it.
+
+        A role may be named either way round -- ``"text"`` or ``"text_style"``
+        -- because the profile writes ``body: {text_style: ...}`` while callers
+        think in roles.
+        """
+        key = role if role.endswith("_style") else f"{role}_style"
+        candidate = self.body.get(key) if self.body else None
+        if candidate and str(candidate) in self.styles:
+            return str(candidate)
+        if role in self.styles:
+            return role
+        return fallback
+
+    def label(self, key: str, fallback: str = "") -> str:
+        return str(self.labels.get(key, fallback) or fallback)
+
+    def section_blocks(self, section: str) -> List[Dict[str, Any]]:
+        blocks = self.sections.get(section)
+        return list(blocks) if isinstance(blocks, list) else []
+
+
+def packaged_profile_directory() -> str:
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "data",
+        "sources",
+        "court_form_profiles",
+    )
+
+
+def packaged_fragment_directory() -> str:
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "data",
+        "templates",
+        "court_forms",
+    )
+
+
+def _configured_profile_directories() -> List[str]:
+    """Extra profile directories named in the docassemble configuration.
+
+    Servers that keep their own court's profile outside this package can set
+    ``court form profiles`` in the configuration rather than forking the
+    package. Missing configuration is normal outside docassemble.
+    """
+    try:
+        from .pdf_field_labeler import get_config  # type: ignore
+
+        configured = get_config("court form profiles")
+    except Exception:
+        return []
+    if not configured:
+        return []
+    if isinstance(configured, str):
+        configured = [configured]
+    if not isinstance(configured, (list, tuple)):
+        return []
+    return [str(item) for item in configured if str(item or "").strip()]
+
+
+def _profile_search_directories(
+    extra_dirs: Optional[Iterable[str]] = None,
+) -> List[str]:
+    """Where to look for profiles, most specific first."""
+    directories: List[str] = []
+    for candidate in list(extra_dirs or []) + _configured_profile_directories():
+        text = str(candidate or "").strip()
+        if text and text not in directories:
+            directories.append(text)
+    packaged = packaged_profile_directory()
+    if packaged not in directories:
+        directories.append(packaged)
+    return [d for d in directories if os.path.isdir(d)]
+
+
+def _read_yaml_mapping(path: str) -> Dict[str, Any]:
+    yaml = YAML(typ="safe", pure=True)
+    with open(path, "r", encoding="utf-8") as handle:
+        loaded = yaml.load(StringIO(handle.read()))
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _merge_profile_mappings(
+    parent: Mapping[str, Any], child: Mapping[str, Any]
+) -> Dict[str, Any]:
+    """Overlay a child profile on the one it extends.
+
+    ``styles``, ``labels`` and ``body`` merge key by key, so a jurisdiction can
+    change one font without restating the whole style sheet. A section such as
+    ``caption`` is replaced outright: captions are ordered layouts, and merging
+    them entry by entry would silently interleave two courts' rows.
+    """
+    merged: Dict[str, Any] = dict(parent)
+    for key, value in child.items():
+        if (
+            key in ("styles", "labels", "body", "page")
+            and isinstance(value, Mapping)
+            and isinstance(merged.get(key), Mapping)
+        ):
+            combined: Dict[str, Any] = dict(merged[key])
+            for sub_key, sub_value in value.items():
+                if (
+                    key == "styles"
+                    and isinstance(sub_value, Mapping)
+                    and isinstance(combined.get(sub_key), Mapping)
+                ):
+                    style_merged = dict(combined[sub_key])
+                    style_merged.update(dict(sub_value))
+                    combined[sub_key] = style_merged
+                else:
+                    combined[sub_key] = sub_value
+            merged[key] = combined
+        else:
+            merged[key] = value
+    return merged
+
+
+def _resolve_extends(
+    raw: Mapping[str, Any],
+    directories: Sequence[str],
+    seen: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Fold in the profile named by ``extends:``, following the chain."""
+    parent_id = str(raw.get("extends") or "").strip()
+    if not parent_id:
+        return dict(raw)
+    chain = list(seen or [])
+    if parent_id in chain:
+        # A cycle means somebody mis-edited a profile; use what we have rather
+        # than recursing forever.
+        return dict(raw)
+    chain.append(parent_id)
+    for directory in directories:
+        for extension in (".yml", ".yaml"):
+            path = os.path.join(directory, f"{parent_id}{extension}")
+            if os.path.isfile(path):
+                try:
+                    parent_raw = _read_yaml_mapping(path)
+                except Exception:
+                    return dict(raw)
+                parent_resolved = _resolve_extends(parent_raw, directories, chain)
+                return _merge_profile_mappings(parent_resolved, raw)
+    return dict(raw)
+
+
+def _profile_from_mapping(
+    profile_id: str, raw: Mapping[str, Any], source_path: str = ""
+) -> CourtFormProfile:
+    styles: Dict[str, StyleSpec] = {}
+    raw_styles = raw.get("styles")
+    if isinstance(raw_styles, Mapping):
+        for style_name, style_raw in raw_styles.items():
+            if isinstance(style_raw, Mapping):
+                name = str(style_name)
+                styles[name] = StyleSpec.from_mapping(name, style_raw)
+
+    sections: Dict[str, List[Dict[str, Any]]] = {}
+    for section in SECTION_NAMES:
+        blocks = raw.get(section)
+        if isinstance(blocks, list):
+            sections[section] = [
+                dict(block) for block in blocks if isinstance(block, Mapping)
+            ]
+
+    labels: Dict[str, str] = {}
+    raw_labels = raw.get("labels")
+    if isinstance(raw_labels, Mapping):
+        labels = {str(k): str(v) for k, v in raw_labels.items() if v is not None}
+
+    body: Dict[str, Any] = {}
+    raw_body = raw.get("body")
+    if isinstance(raw_body, Mapping):
+        body = dict(raw_body)
+
+    raw_page = raw.get("page")
+    page_raw: Mapping[str, Any] = raw_page if isinstance(raw_page, Mapping) else {}
+
+    return CourtFormProfile(
+        id=str(raw.get("id") or profile_id),
+        name=str(raw.get("name") or profile_id),
+        jurisdiction=str(raw.get("jurisdiction") or ""),
+        description=str(raw.get("description") or ""),
+        page=PageSpec.from_mapping(page_raw),
+        styles=styles,
+        sections=sections,
+        labels=labels,
+        body=body,
+        source_path=source_path,
+    )
+
+
+def list_court_form_profiles(
+    extra_dirs: Optional[Iterable[str]] = None,
+) -> List[Dict[str, str]]:
+    """Every profile that can be loaded, for a dropdown or an API listing.
+
+    A profile found in an earlier directory wins, so a server's own copy of
+    ``ma_trial_court.yml`` overrides the packaged one.
+    """
+    found: Dict[str, Dict[str, str]] = {}
+    for directory in _profile_search_directories(extra_dirs):
+        try:
+            filenames = sorted(os.listdir(directory))
+        except OSError:
+            continue
+        for filename in filenames:
+            if not filename.lower().endswith((".yml", ".yaml")):
+                continue
+            profile_id = os.path.splitext(filename)[0]
+            if profile_id in found:
+                continue
+            path = os.path.join(directory, filename)
+            try:
+                raw = _read_yaml_mapping(path)
+            except Exception:
+                continue
+            found[profile_id] = {
+                "id": str(raw.get("id") or profile_id),
+                "name": str(raw.get("name") or profile_id),
+                "jurisdiction": str(raw.get("jurisdiction") or ""),
+                "description": str(raw.get("description") or ""),
+                "path": path,
+            }
+    return sorted(found.values(), key=lambda item: item["name"].lower())
+
+
+def load_court_form_profile(
+    profile_id: Optional[str] = None,
+    extra_dirs: Optional[Iterable[str]] = None,
+    fragment_dirs: Optional[Iterable[str]] = None,
+) -> CourtFormProfile:
+    """Load one profile by id, falling back to the generic profile.
+
+    An unknown id is not an error: drafting a usable generic court form beats
+    refusing to draft anything because a caller named a court we do not ship.
+    """
+    wanted = str(profile_id or DEFAULT_PROFILE_ID).strip() or DEFAULT_PROFILE_ID
+    directories = _profile_search_directories(extra_dirs)
+    overrides = [str(d) for d in (fragment_dirs or []) if str(d or "").strip()]
+
+    for candidate_id in (wanted, DEFAULT_PROFILE_ID):
+        for directory in directories:
+            for extension in (".yml", ".yaml"):
+                path = os.path.join(directory, f"{candidate_id}{extension}")
+                if os.path.isfile(path):
+                    resolved = _resolve_extends(
+                        _read_yaml_mapping(path), directories, [candidate_id]
+                    )
+                    profile = _profile_from_mapping(
+                        candidate_id, resolved, source_path=path
+                    )
+                    profile.fragment_dirs = overrides
+                    return profile
+
+    # Nothing on disk at all: an empty profile still produces a plain document.
+    return CourtFormProfile(id=wanted, name=wanted, fragment_dirs=overrides)
+
+
+def find_docx_fragment(
+    profile_id: str,
+    section: str,
+    extra_dirs: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """Path to a Word-authored override for one section, when one exists.
+
+    Looked up as ``<dir>/<profile_id>/<section>.docx``. The first hit wins, so a
+    caller-supplied directory beats the packaged fragment.
+    """
+    section_name = str(section or "").strip()
+    if not section_name:
+        return None
+    directories: List[str] = [
+        str(d) for d in (extra_dirs or []) if str(d or "").strip()
+    ]
+    directories.append(packaged_fragment_directory())
+    for directory in directories:
+        path = os.path.join(directory, str(profile_id or ""), f"{section_name}.docx")
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def apply_profile_styles(document, profile: CourtFormProfile) -> List[str]:
+    """Define the profile's styles in ``document``; return the names applied.
+
+    Styles are created rather than inlined so that changing a court's font is an
+    edit to the profile -- or to the generated document's style definition in
+    Word -- instead of a sweep through every paragraph.
+    """
+    if docx is None:  # pragma: no cover - guarded by callers
+        raise RuntimeError("python-docx is not installed in the python environment.")
+
+    applied: List[str] = []
+    for name, spec in profile.styles.items():
+        style_type = (
+            WD_STYLE_TYPE.CHARACTER
+            if spec.style_type.startswith("char")
+            else WD_STYLE_TYPE.PARAGRAPH
+        )
+        try:
+            style = document.styles[name]
+        except KeyError:
+            try:
+                style = document.styles.add_style(name, style_type)
+            except Exception:
+                continue
+
+        if spec.based_on:
+            try:
+                style.base_style = document.styles[spec.based_on]
+            except Exception:
+                pass
+
+        font = style.font
+        if spec.font:
+            font.name = spec.font
+            # Word consults the east-asian font for many runs; without this the
+            # requested face silently reverts for some characters.
+            try:
+                rpr = style.element.get_or_add_rPr()
+                rfonts = rpr.get_or_add_rFonts()
+                rfonts.set(qn("w:eastAsia"), spec.font)
+                rfonts.set(qn("w:cs"), spec.font)
+            except Exception:
+                pass
+        if spec.size is not None:
+            font.size = Pt(spec.size)
+        if spec.bold is not None:
+            font.bold = spec.bold
+        if spec.italic is not None:
+            font.italic = spec.italic
+        if spec.underline is not None:
+            font.underline = spec.underline
+        if spec.all_caps is not None:
+            font.all_caps = spec.all_caps
+        if spec.color:
+            try:
+                from docx.shared import RGBColor
+
+                font.color.rgb = RGBColor.from_string(spec.color.lstrip("#").upper())
+            except Exception:
+                pass
+
+        if style_type == WD_STYLE_TYPE.PARAGRAPH:
+            paragraph_format = style.paragraph_format
+            alignment = _alignment(spec.align)
+            if alignment is not None:
+                paragraph_format.alignment = alignment
+            if spec.line_spacing is not None:
+                paragraph_format.line_spacing = spec.line_spacing
+                if abs(spec.line_spacing - 2.0) < 0.001:
+                    paragraph_format.line_spacing_rule = WD_LINE_SPACING.DOUBLE
+            if spec.space_before is not None:
+                paragraph_format.space_before = Pt(spec.space_before)
+            if spec.space_after is not None:
+                paragraph_format.space_after = Pt(spec.space_after)
+            if spec.left_indent is not None:
+                paragraph_format.left_indent = Inches(spec.left_indent)
+            if spec.first_line_indent is not None:
+                paragraph_format.first_line_indent = Inches(spec.first_line_indent)
+            if spec.keep_with_next is not None:
+                paragraph_format.keep_with_next = spec.keep_with_next
+
+        applied.append(name)
+
+    return applied
+
+
+def splice_docx_fragment(document, fragment_path: str, container=None) -> int:
+    """Copy a Word-authored fragment into ``document``; return blocks copied.
+
+    Used for the ``.docx`` override of a section. Everything in the fragment's
+    body is copied except its ``sectPr``, which belongs to the fragment's own
+    page setup and would otherwise start a new section in the assembled form.
+    Styles the fragment defines are carried over when the target lacks them, so
+    a caption authored in Word keeps its fonts.
+    """
+    if docx is None:  # pragma: no cover - guarded by callers
+        raise RuntimeError("python-docx is not installed in the python environment.")
+
+    fragment = docx.Document(fragment_path)
+    _merge_missing_styles(document, fragment)
+
+    target = container if container is not None else document.element.body
+    anchor = None
+    if container is None:
+        # Keep the document's final sectPr last so page setup survives.
+        for child in document.element.body.iterchildren():
+            if child.tag == qn("w:sectPr"):
+                anchor = child
+                break
+
+    copied = 0
+    for child in fragment.element.body.iterchildren():
+        if child.tag == qn("w:sectPr"):
+            continue
+        new_child = copy.deepcopy(child)
+        if anchor is not None:
+            anchor.addprevious(new_child)
+        else:
+            target.append(new_child)
+        copied += 1
+    return copied
+
+
+def _merge_missing_styles(document, fragment) -> None:
+    """Bring over style definitions the target document does not already have."""
+    try:
+        target_styles = document.styles.element
+        existing = {
+            style.get(qn("w:styleId")) for style in target_styles.findall(qn("w:style"))
+        }
+        for style in fragment.styles.element.findall(qn("w:style")):
+            style_id = style.get(qn("w:styleId"))
+            if style_id and style_id not in existing:
+                target_styles.append(copy.deepcopy(style))
+                existing.add(style_id)
+    except Exception:
+        # A fragment without a styles part is fine; it just inherits the target's.
+        pass

--- a/docassemble/ALDashboard/data/questions/variable_report_generator.yml
+++ b/docassemble/ALDashboard/data/questions/variable_report_generator.yml
@@ -135,9 +135,8 @@ fields:
       interview's screens become the middle of the document.
   - Court / jurisdiction profile: court_profile
     datatype: dropdown
-    show if:
-      variable: report_shape
-      is not: intake
+    js show if: |
+      val("report_shape") != "intake"
     code: |
       [
         {"label": item["label"], "value": item["value"]}
@@ -153,9 +152,8 @@ fields:
   - Include a certificate of service: include_certificate_of_service
     datatype: yesno
     default: False
-    show if:
-      variable: report_shape
-      is not: intake
+    js show if: |
+      val("report_shape") != "intake"
   - Show internal variable names in labels: show_variable_names
     datatype: yesno
     default: False

--- a/docassemble/ALDashboard/data/questions/variable_report_generator.yml
+++ b/docassemble/ALDashboard/data/questions/variable_report_generator.yml
@@ -120,6 +120,42 @@ question: |
 fields:
   - Document Title: report_title
     default: ${ meta_info["display_title"] }
+  - Template shape: report_shape
+    datatype: radio
+    default: intake
+    code: |
+      [
+        {"label": item["label"], "value": item["value"]}
+        for item in list_court_form_shapes()
+      ]
+    help: |
+      The intake shape lists every variable the interview gathers. The court
+      shapes arrange the same variables into a filing: the jurisdiction profile
+      supplies the caption, running footer and signature block, and the
+      interview's screens become the middle of the document.
+  - Court / jurisdiction profile: court_profile
+    datatype: dropdown
+    show if:
+      variable: report_shape
+      is not: intake
+    code: |
+      [
+        {"label": item["label"], "value": item["value"]}
+        for item in list_court_form_profile_choices()
+      ]
+    default: generic
+    help: |
+      Profiles are editable YAML in
+      `data/sources/court_form_profiles/`, and any section can be replaced
+      with a Word-authored `.docx` in `data/templates/court_forms/<profile>/`.
+      Fonts and spacing are Word styles, so a court that wants a different
+      face is a one-line change.
+  - Include a certificate of service: include_certificate_of_service
+    datatype: yesno
+    default: False
+    show if:
+      variable: report_shape
+      is not: intake
   - Show internal variable names in labels: show_variable_names
     datatype: yesno
     default: False
@@ -167,6 +203,14 @@ code: |
   _md_name = md_filename if _save_to_pg and defined('md_filename') else meta_info["md_filename"]
   _docx_name = docx_filename if _save_to_pg and defined('docx_filename') else meta_info["docx_filename"]
 
+  _shape = report_shape if defined('report_shape') else "intake"
+  _profile = court_profile if _shape != "intake" and defined('court_profile') else None
+  _certificate = (
+    include_certificate_of_service
+    if _shape != "intake" and defined('include_certificate_of_service')
+    else None
+  )
+
   report_result = generate_variable_report(
     report_yaml_texts,
     report_title=report_title,
@@ -174,6 +218,9 @@ code: |
     show_variable_names=show_variable_names,
     show_variable_types=show_variable_types,
     max_list_cols=max_list_cols,
+    shape=_shape,
+    court_profile=_profile,
+    include_certificate_of_service=_certificate,
   )
 
   if _save_to_pg:
@@ -206,6 +253,16 @@ question: |
   ${ report_title }
 subquestion: |
   Files combined: **${ len(source_filenames) }** | Interview screens & objects processed: **${ len(report_result["groups"]) }** | Total variables: **${ report_result["variables_count"] }**
+
+  % if report_result.get("profile_name"):
+  Shape: **${ report_result.get("shape") }** | Court profile: **${ report_result.get("profile_name") }**
+
+  Fixed sections drawn: ${ ", ".join(f"{name} ({origin})" for name, origin in sorted(report_result.get("sections", {}).items())) }
+  <br/>
+  <small>`yaml` means the section came from the profile; `docx` means a Word-authored fragment replaced it.</small>
+
+  Word styles defined in the DOCX: ${ ", ".join(report_result.get("styles", [])) }
+  % endif
 
   ### Download Output Files
   * **[Download Mako + Markdown Draft (${ _md_name })](${ markdown_download.url_for(attachment=True) })**

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/README.md
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/README.md
@@ -1,0 +1,79 @@
+# Court form profiles
+
+One YAML file per court. Each describes the boilerplate that court fixes —
+the caption, the running footer, the signature block — and the Word styles the
+document should use. The middle of the form is generated from the interview's
+own questions, so only the parts the court dictates live here.
+
+Add a court by copying the closest existing file and editing it. Profiles are
+found by filename, so `data/sources/court_form_profiles/nh_circuit.yml` becomes
+the profile id `nh_circuit` and appears in the generator's dropdown with no code
+change. Servers that would rather not fork this package can point the
+`court form profiles` key in the docassemble configuration at their own
+directory; profiles found there win over the packaged ones of the same name.
+
+## What a profile contains
+
+| Key | What it does |
+| --- | --- |
+| `extends` | Inherit from another profile. `styles`, `labels`, `body` and `page` merge key by key; a section such as `caption` is replaced outright. |
+| `page` | Margins, in inches. |
+| `styles` | The Word styles to define. Font, size, bold, alignment, line spacing, space before and after, indents. |
+| `labels` | What this court calls things: `docket`, `plaintiff`, `defendant`. |
+| `caption`, `header`, `footer`, `letterhead`, `signature`, `certificate_of_service`, `jurat` | Ordered blocks that make up each fixed section. |
+| `body` | Which style fills which role, plus the shape-specific sentences (`motion_intro`, `motion_prayer`, `affidavit_intro`, `affidavit_closing`). |
+
+## Blocks
+
+A section is a list of blocks:
+
+```yaml
+caption:
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "COMMONWEALTH OF MASSACHUSETTS"
+  - type: table
+    widths: [3.4, 3.1]        # inches
+    borders: none             # none | box | grid | bottom
+    rows:
+      - cells: ["{{ users }}", "{{ docket_label }} {{ docket_number }}"]
+      - cells: ["v.", "{{ document_title }}"]
+        style: CourtCaptionText
+  - type: rule                # a horizontal line
+  - type: spacer              # an empty paragraph
+```
+
+`page_break` is also available. A `paragraph` may set `page_numbers: true` to
+append a live "Page X of Y" field, with `page_numbers_align` to place it.
+
+## Placeholders
+
+Two kinds of `{{ ... }}` appear in a profile, and they are treated differently.
+
+**Filled in while drafting**, because the drafter already knows them:
+`document_title`, `docket_label`, `court_name`, `jurisdiction`, `form_code`,
+`form_revision`, `court_rule_citation`, and `labels.<name>` for anything in the
+`labels:` map. These do not survive into the generated template.
+
+**Left alone**, because they are the interview's job to answer: everything
+else, including `{{ trial_court }}`, `{{ docket_number }}`, `{{ county }}`,
+`{{ users }}` and `{{ users[0].signature }}`. Write these the way you would in
+any docassemble DOCX template. They are the profile's contract with the
+interview: an interview drafted against this profile should define them.
+
+Fields discovered in the interview are handled separately and are always
+wrapped in `showifdef()`, because whether any one of them is defined at assembly
+time is exactly what the generator cannot know.
+
+## Changing a font
+
+Edit the `styles:` map. Everything the generator writes is tagged with one of
+these styles, so a court that prefers Arial needs one line changed, not a sweep
+through the layout:
+
+```yaml
+styles:
+  CourtBodyText:
+    font: Arial
+    size: 11
+```

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/dmass_federal.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/dmass_federal.yml
@@ -1,0 +1,69 @@
+id: dmass_federal
+name: U.S. District Court, District of Massachusetts
+jurisdiction: Federal (D. Mass.)
+extends: generic
+description: >-
+  The federal pleading caption under Fed. R. Civ. P. 10(a) as used in the
+  District of Massachusetts: the court name over the "for the" line and the
+  district, then the party block separated by the traditional column of close
+  parentheses with the civil action number beside it. Body text is double
+  spaced to match D. Mass. Local Rule 5.1.
+
+styles:
+  CourtBodyText:
+    font: Times New Roman
+    size: 12
+    line_spacing: 2.0
+    space_after: 0
+  CourtCaptionText:
+    font: Times New Roman
+    size: 12
+
+labels:
+  docket: "Civil Action No."
+  plaintiff: "Plaintiff(s)"
+  defendant: "Defendant(s)"
+
+caption:
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "UNITED STATES DISTRICT COURT"
+  - type: paragraph
+    style: CourtCaptionText
+    text: "for the"
+    align: center
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "District of Massachusetts"
+  - type: spacer
+  - type: table
+    widths: [3.0, 0.3, 3.2]
+    borders: none
+    rows:
+      - cells: ["{{ users }},", ")", ""]
+      - cells: ["", ")", "{{ docket_label }} {{ docket_number }}"]
+      - cells: ["                Plaintiff(s),", ")", ""]
+      - cells: ["", ")", ""]
+      - cells: ["        v.", ")", "Jury Trial: {{ jury_trial }}"]
+      - cells: ["", ")", ""]
+      - cells: ["{{ other_parties }},", ")", ""]
+      - cells: ["                Defendant(s).", ")", ""]
+  - type: rule
+
+certificate_of_service:
+  - type: paragraph
+    style: CourtDocumentTitle
+    text: "CERTIFICATE OF SERVICE"
+  - type: paragraph
+    style: CourtBodyText
+    text: >-
+      I hereby certify that this document filed through the CM/ECF system will
+      be sent electronically to the registered participants as identified on
+      the Notice of Electronic Filing (NEF) and paper copies will be sent to
+      those indicated as non-registered participants on {{ service_date }}.
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["Date: {{ service_date }}", "{{ users[0].signature }}"]
+      - cells: ["", "{{ users[0] }}"]

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/generic.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/generic.yml
@@ -1,0 +1,165 @@
+id: generic
+name: Generic court form
+jurisdiction: ""
+description: >-
+  A neutral caption that reads correctly in most trial courts. Used when no
+  jurisdiction profile is chosen, and a reasonable starting point for a court
+  this package does not ship a profile for.
+
+page:
+  margins:
+    top: 1.0
+    bottom: 1.0
+    left: 1.0
+    right: 1.0
+
+# Fonts, sizes and spacing live here, and are written into the generated
+# document as real Word styles. Change a font for a whole court in one line.
+styles:
+  CourtCaptionHeading:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    bold: true
+    align: center
+    space_after: 0
+    keep_with_next: true
+  CourtCaptionText:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    align: left
+    space_after: 0
+  CourtDocumentTitle:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    bold: true
+    all_caps: true
+    align: center
+    space_before: 12
+    space_after: 12
+    keep_with_next: true
+  CourtSectionHeading:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    bold: true
+    align: left
+    space_before: 12
+    space_after: 6
+    keep_with_next: true
+  CourtBodyText:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    align: left
+    line_spacing: 1.5
+    space_after: 10
+  CourtFieldLabel:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    bold: true
+    space_after: 0
+  CourtSignatureText:
+    based_on: Normal
+    font: Times New Roman
+    size: 12
+    align: left
+    space_after: 0
+  CourtFooterText:
+    based_on: Normal
+    font: Times New Roman
+    size: 9
+    align: left
+    space_after: 0
+  CourtSmallPrint:
+    based_on: Normal
+    font: Times New Roman
+    size: 9
+    italic: true
+    space_after: 0
+
+labels:
+  docket: "Case No."
+  plaintiff: "Plaintiff"
+  defendant: "Defendant"
+  versus: "v."
+
+caption:
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "IN THE {{ trial_court }}"
+  - type: spacer
+  - type: table
+    widths: [3.4, 3.1]
+    borders: none
+    rows:
+      - cells: ["{{ users }},", "{{ docket_label }} {{ docket_number }}"]
+      - cells: ["        Plaintiff,", ""]
+      - cells: ["v.", "{{ document_title }}"]
+      - cells: ["{{ other_parties }},", ""]
+      - cells: ["        Defendant.", ""]
+  - type: rule
+
+footer:
+  - type: paragraph
+    style: CourtFooterText
+    text: "{{ document_title }}"
+    page_numbers: true
+
+signature:
+  - type: spacer
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["Date: {{ signature_date }}", "{{ users[0].signature }}"]
+      - cells: ["", "{{ users[0] }}"]
+      - cells: ["", "{{ users[0].address.block() }}"]
+      - cells: ["", "{{ users[0].phone_number }}"]
+      - cells: ["", "{{ users[0].email }}"]
+
+certificate_of_service:
+  - type: paragraph
+    style: CourtDocumentTitle
+    text: "CERTIFICATE OF SERVICE"
+  - type: paragraph
+    style: CourtBodyText
+    text: >-
+      I certify that on {{ service_date }} I served a copy of this
+      {{ document_title }} on all parties of record, by
+      {{ service_method }}.
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["Date: {{ service_date }}", "{{ users[0].signature }}"]
+      - cells: ["", "{{ users[0] }}"]
+
+jurat:
+  - type: spacer
+  - type: paragraph
+    style: CourtBodyText
+    text: "Signed under the penalties of perjury."
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["Date: {{ signature_date }}", "{{ users[0].signature }}"]
+      - cells: ["", "{{ users[0] }}"]
+
+body:
+  title_style: CourtDocumentTitle
+  heading_style: CourtSectionHeading
+  text_style: CourtBodyText
+  label_style: CourtFieldLabel
+  numbered_paragraphs: true
+  motion_intro: >-
+    NOW COMES {{ users[0] }}, who respectfully moves this Court as follows:
+  motion_prayer: >-
+    WHEREFORE, {{ users[0] }} respectfully requests that this Court grant the
+    relief requested above, together with any further relief the Court deems
+    just and proper.
+  affidavit_intro: "I, {{ users[0] }}, state as follows:"

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/il_circuit.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/il_circuit.yml
@@ -1,0 +1,94 @@
+id: il_circuit
+name: Illinois Circuit Court (standardized form)
+jurisdiction: Illinois
+extends: generic
+description: >-
+  The Illinois Supreme Court standardized statewide form layout: the approval
+  notice above the caption, a boxed caption with the "For Court Use Only" panel
+  and the case number beside the parties, the "Enter the Case Number" running
+  header, and the form-code / page / revision footer.
+
+styles:
+  CourtCaptionHeading:
+    font: Arial
+    size: 12
+    bold: true
+    align: left
+  CourtCaptionText:
+    font: Arial
+    size: 11
+  CourtDocumentTitle:
+    font: Arial
+    size: 12
+  CourtSectionHeading:
+    font: Arial
+    size: 11
+  CourtBodyText:
+    font: Arial
+    size: 11
+    line_spacing: 1.15
+  CourtFieldLabel:
+    font: Arial
+    size: 11
+  CourtSignatureText:
+    font: Arial
+    size: 11
+  CourtFooterText:
+    font: Arial
+    size: 8
+  CourtSmallPrint:
+    font: Arial
+    size: 8
+
+labels:
+  docket: "Case Number"
+  plaintiff: "Plaintiff / Petitioner"
+  defendant: "Defendant / Respondent"
+
+caption:
+  - type: paragraph
+    style: CourtSmallPrint
+    text: >-
+      This form is approved by the Illinois Supreme Court and is required to be
+      used in all Illinois Circuit Courts.
+  - type: table
+    widths: [2.3, 2.3, 1.9]
+    borders: box
+    rows:
+      - cells:
+          - "STATE OF ILLINOIS,\nCIRCUIT COURT\n\n{{ county }} COUNTY"
+          - "{{ document_title }}"
+          - "For Court Use Only"
+        style: CourtCaptionText
+      - cells:
+          - "{{ users }}\nPlaintiff / Petitioner (First, middle, last name)"
+          - ""
+          - ""
+      - cells:
+          - "v."
+          - ""
+          - "{{ docket_label }}\n{{ docket_number }}"
+      - cells:
+          - "{{ other_parties }}\nDefendant / Respondent (First, middle, last name)"
+          - ""
+          - ""
+  - type: spacer
+
+header:
+  - type: paragraph
+    style: CourtSmallPrint
+    text: >-
+      Enter the Case Number given by the Circuit Clerk: {{ docket_number }}
+
+footer:
+  - type: table
+    widths: [2.2, 2.2, 2.1]
+    borders: none
+    rows:
+      - cells: ["{{ form_code }}", "", "{{ form_revision }}"]
+        style: CourtFooterText
+  - type: paragraph
+    style: CourtFooterText
+    text: ""
+    page_numbers: true
+    page_numbers_align: center

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/ma_trial_court.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/ma_trial_court.yml
@@ -1,0 +1,54 @@
+id: ma_trial_court
+name: Massachusetts Trial Court
+jurisdiction: Massachusetts
+extends: generic
+description: >-
+  Caption used across the Massachusetts Trial Court departments: the
+  Commonwealth line, the department and division, and the county "ss" line
+  beside the docket number. Modeled on the captions in the AssemblyLine
+  Massachusetts packages and on Trial Court forms.
+
+labels:
+  docket: "DOCKET NO."
+  plaintiff: "Plaintiff"
+  defendant: "Defendant"
+
+caption:
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "COMMONWEALTH OF MASSACHUSETTS"
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "THE TRIAL COURT"
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "{{ trial_court.department }}"
+  - type: spacer
+  - type: table
+    widths: [3.4, 3.1]
+    borders: none
+    rows:
+      - cells: ["{{ trial_court.address.county }}, ss", "{{ trial_court }}"]
+      - cells: ["", "{{ docket_label }} {{ docket_number }}"]
+      - cells: ["", ""]
+      - cells: ["{{ users }}", ""]
+      - cells: ["        Plaintiff", ""]
+      - cells: ["v.", "{{ document_title }}"]
+      - cells: ["{{ other_parties }}", ""]
+      - cells: ["        Defendant", ""]
+  - type: rule
+
+jurat:
+  - type: spacer
+  - type: paragraph
+    style: CourtBodyText
+    text: "Signed under the pains and penalties of perjury."
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["Date: {{ signature_date }}", "{{ users[0].signature }}"]
+      - cells: ["", "{{ users[0] }}"]
+
+body:
+  affidavit_closing: "Signed under the pains and penalties of perjury."

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/mi_scao.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/mi_scao.yml
@@ -1,0 +1,96 @@
+id: mi_scao
+name: Michigan SCAO-approved form
+jurisdiction: Michigan
+extends: generic
+description: >-
+  The Michigan State Court Administrative Office form layout: a boxed caption
+  naming the district, circuit or probate court beside the case number and
+  judge, court address and telephone boxes, a boxed party block with the
+  centered "v", and the "Approved, SCAO" / form number / court rule footer.
+  Modeled on SCAO form MC 02.
+
+styles:
+  CourtCaptionHeading:
+    font: Arial
+    size: 10
+    bold: true
+    align: left
+  CourtCaptionText:
+    font: Arial
+    size: 9
+  CourtDocumentTitle:
+    font: Arial
+    size: 11
+  CourtSectionHeading:
+    font: Arial
+    size: 10
+  CourtBodyText:
+    font: Arial
+    size: 10
+    line_spacing: 1.15
+  CourtFieldLabel:
+    font: Arial
+    size: 8
+  CourtSignatureText:
+    font: Arial
+    size: 10
+  CourtFooterText:
+    font: Arial
+    size: 7
+  CourtSmallPrint:
+    font: Arial
+    size: 7
+
+page:
+  margins:
+    top: 0.5
+    bottom: 0.5
+    left: 0.75
+    right: 0.75
+
+labels:
+  docket: "CASE NO."
+  plaintiff: "Plaintiff(s)/Petitioner(s)"
+  defendant: "Defendant(s)/Respondent(s)"
+
+caption:
+  - type: table
+    widths: [2.4, 2.4, 2.2]
+    borders: grid
+    rows:
+      - cells:
+          - "STATE OF MICHIGAN\n        JUDICIAL DISTRICT\n        JUDICIAL CIRCUIT\n{{ county }} COUNTY PROBATE"
+          - "{{ document_title }}"
+          - "{{ docket_label }} and JUDGE\n\n{{ docket_number }}"
+        style: CourtCaptionText
+      - cells:
+          - "Court address\n{{ trial_court.address.block() }}"
+          - ""
+          - "Court telephone no.\n{{ trial_court.phone_number }}"
+        style: CourtCaptionText
+  - type: table
+    widths: [3.0, 0.6, 3.4]
+    borders: grid
+    rows:
+      - cells:
+          - "{{ labels.plaintiff }}\n\n{{ users }}"
+          - "v"
+          - "{{ labels.defendant }}\n\n{{ other_parties }}"
+        style: CourtCaptionText
+  - type: spacer
+
+footer:
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["Approved, SCAO", ""]
+        style: CourtFooterText
+      - cells: ["{{ form_code }}, Rev. {{ form_revision }}", ""]
+        style: CourtFooterText
+      - cells: ["{{ court_rule_citation }}", ""]
+        style: CourtFooterText
+  - type: paragraph
+    style: CourtFooterText
+    text: ""
+    page_numbers: true

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/mn_district.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/mn_district.yml
@@ -1,0 +1,40 @@
+id: mn_district
+name: Minnesota District Court
+jurisdiction: Minnesota
+extends: generic
+description: >-
+  The Minnesota District Court caption: state and county on the left against
+  the court and judicial district on the right, followed by the court file
+  number and case type, then the party block. Modeled on Minnesota Judicial
+  Branch statewide forms such as CIV602.
+
+labels:
+  docket: "Court File Number:"
+  plaintiff: "Plaintiff / Petitioner"
+  defendant: "Defendant / Respondent"
+
+caption:
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["STATE OF MINNESOTA", "DISTRICT COURT"]
+        style: CourtCaptionHeading
+      - cells:
+          - "COUNTY OF {{ county }}"
+          - "{{ judicial_district }} JUDICIAL DISTRICT"
+        style: CourtCaptionHeading
+      - cells: ["", ""]
+      - cells: ["", "{{ docket_label }} {{ docket_number }}"]
+      - cells: ["", "Case Type: {{ case_type }}"]
+  - type: spacer
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["{{ users }},", ""]
+      - cells: ["        Plaintiff / Petitioner,", "{{ document_title }}"]
+      - cells: ["v.", ""]
+      - cells: ["{{ other_parties }},", ""]
+      - cells: ["        Defendant / Respondent.", ""]
+  - type: rule

--- a/docassemble/ALDashboard/data/sources/court_form_profiles/vt_superior.yml
+++ b/docassemble/ALDashboard/data/sources/court_form_profiles/vt_superior.yml
@@ -1,0 +1,56 @@
+id: vt_superior
+name: Vermont Superior Court
+jurisdiction: Vermont
+extends: generic
+description: >-
+  The Vermont Superior Court caption: the centered "STATE OF VERMONT" line over
+  a two-column block pairing the court and unit on the left with the division
+  and docket number on the right, then a two-column party block with name and
+  date of birth. Modeled on Vermont Judiciary Form 823.
+
+labels:
+  docket: "Docket No."
+  plaintiff: "Plaintiff"
+  defendant: "Defendant"
+
+caption:
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "STATE OF VERMONT"
+  - type: spacer
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["SUPERIOR COURT", "{{ division }} DIVISION"]
+        style: CourtCaptionHeading
+      - cells: ["{{ unit }} Unit", "{{ docket_label }} {{ docket_number }}"]
+  - type: spacer
+  - type: table
+    widths: [3.25, 3.25]
+    borders: bottom
+    rows:
+      - cells: ["Plaintiff", "Defendant"]
+        style: CourtFieldLabel
+      - cells:
+          - "{{ users }}"
+          - "{{ other_parties }}"
+      - cells: ["Name                              DOB", "Name                              DOB"]
+        style: CourtSmallPrint
+  - type: paragraph
+    style: CourtCaptionHeading
+    text: "v."
+  - type: spacer
+
+footer:
+  - type: table
+    widths: [3.25, 3.25]
+    borders: none
+    rows:
+      - cells: ["{{ form_code }}", "{{ document_title }}"]
+        style: CourtFooterText
+  - type: paragraph
+    style: CourtFooterText
+    text: ""
+    page_numbers: true
+    page_numbers_align: center

--- a/docassemble/ALDashboard/data/templates/court_forms/README.md
+++ b/docassemble/ALDashboard/data/templates/court_forms/README.md
@@ -1,0 +1,54 @@
+# Word-authored overrides for court form sections
+
+A court form drafted by the Interview Intake Document Generator gets its fixed
+sections — caption, running header and footer, signature block, certificate of
+service, jurat — from the jurisdiction profile in
+`data/sources/court_form_profiles/`. Those profiles are YAML, which is easy to
+diff and easy to edit in the Playground.
+
+Some layouts are easier to draw than to describe. When that is the case, put a
+Word document here instead and it will be used verbatim in place of the
+profile's version of that section:
+
+```
+data/templates/court_forms/
+  <profile id>/
+    caption.docx
+    header.docx
+    footer.docx
+    letterhead.docx
+    signature.docx
+    certificate_of_service.docx
+    jurat.docx
+```
+
+`<profile id>` is the profile's filename without its extension — for example
+`ma_trial_court`, `mi_scao`, `dmass_federal`.
+
+## How the override behaves
+
+* **One section at a time.** Dropping in `caption.docx` replaces only the
+  caption. Every other section still comes from the profile, so a court that
+  just wants its own caption does not have to redraw its footer.
+* **Copied as written.** Everything in the fragment's body is copied in,
+  including its tables, tabs and images. Its own page setup is not: page size
+  and margins stay with the profile, so a fragment cannot accidentally start a
+  new section in the middle of the form.
+* **Styles come along.** Any style the fragment defines that the generated
+  document does not already have is copied over, so a caption you formatted in
+  Word keeps its fonts.
+* **Jinja passes through.** Write `{{ docket_number }}`, `{{ trial_court }}` or
+  `{{ users[0].signature }}` in the fragment exactly as you would in any
+  docassemble DOCX template. The generator does not rewrite them.
+
+The generator reports where each section came from — `yaml` for the profile,
+`docx` for an override — on the results screen and in the `sections` field of
+the API response, which is the fastest way to confirm your fragment was picked
+up.
+
+## Fonts
+
+Prefer changing a font in the profile's `styles:` map over formatting runs
+directly in a fragment. The profile's styles are written into the generated
+document as real Word styles, so one edit repoints the whole document; direct
+formatting has to be redone every time the layout changes.

--- a/docassemble/ALDashboard/test/test_court_form_generator.py
+++ b/docassemble/ALDashboard/test/test_court_form_generator.py
@@ -1,0 +1,483 @@
+# do not pre-load
+import os
+import tempfile
+import unittest
+
+import docx
+
+from docassemble.ALDashboard.court_form_generator import (
+    COURT_FORM_SHAPES,
+    build_court_form_context,
+    generate_court_form_docx,
+    generate_court_form_markdown,
+)
+from docassemble.ALDashboard.court_form_profiles import (
+    apply_profile_styles,
+    find_docx_fragment,
+    list_court_form_profiles,
+    load_court_form_profile,
+    splice_docx_fragment,
+)
+from docassemble.ALDashboard.variable_report_generator import (
+    extract_interview_questions_and_variables,
+    generate_variable_report,
+    list_court_form_profile_choices,
+    list_court_form_shapes,
+)
+
+SAMPLE_YAML = """
+---
+objects:
+  - users: ALPeopleList
+  - other_parties: ALPeopleList
+---
+id: case information
+question: |
+  Tell us about your case
+fields:
+  - Docket number: docket_number
+  - Were you served?: was_served
+    datatype: yesno
+---
+id: grounds
+question: |
+  Why are you filing?
+fields:
+  - Reason: motion_reason
+  - Date of the order: order_date
+    datatype: date
+"""
+
+# Every jurisdiction profile this package ships.
+SHIPPED_PROFILES = (
+    "generic",
+    "ma_trial_court",
+    "il_circuit",
+    "vt_superior",
+    "mi_scao",
+    "mn_district",
+    "dmass_federal",
+)
+
+
+def _document_text(document) -> str:
+    """All the text in a document, body and tables and header and footer."""
+    parts = [paragraph.text for paragraph in document.paragraphs]
+    for table in document.tables:
+        for row in table.rows:
+            parts.extend(cell.text for cell in row.cells)
+    for section in document.sections:
+        for container in (section.header, section.footer):
+            parts.extend(paragraph.text for paragraph in container.paragraphs)
+            for table in container.tables:
+                for row in table.rows:
+                    parts.extend(cell.text for cell in row.cells)
+    return "\n".join(parts)
+
+
+class TestCourtFormProfiles(unittest.TestCase):
+    def test_every_shipped_profile_loads(self):
+        listed = {profile["id"] for profile in list_court_form_profiles()}
+        for profile_id in SHIPPED_PROFILES:
+            self.assertIn(profile_id, listed)
+            profile = load_court_form_profile(profile_id)
+            self.assertEqual(profile.id, profile_id)
+            self.assertTrue(profile.name)
+            self.assertTrue(profile.styles, f"{profile_id} defines no Word styles")
+
+    def test_unknown_profile_falls_back_to_generic(self):
+        profile = load_court_form_profile("no_such_court")
+        self.assertEqual(profile.id, "generic")
+
+    def test_extends_merges_styles_and_keeps_own_caption(self):
+        profile = load_court_form_profile("dmass_federal")
+        # Inherited from generic...
+        self.assertIn("CourtDocumentTitle", profile.styles)
+        self.assertTrue(profile.body.get("motion_intro"))
+        # ...while its own overrides win.
+        self.assertEqual(profile.styles["CourtBodyText"].line_spacing, 2.0)
+        self.assertEqual(profile.label("docket"), "Civil Action No.")
+
+    def test_style_name_accepts_either_spelling_of_a_role(self):
+        profile = load_court_form_profile("generic")
+        self.assertEqual(profile.style_name("text_style"), "CourtBodyText")
+        self.assertEqual(profile.style_name("text"), "CourtBodyText")
+        self.assertEqual(profile.style_name("nonexistent", "Normal"), "Normal")
+
+    def test_apply_profile_styles_writes_font_and_spacing(self):
+        profile = load_court_form_profile("mi_scao")
+        document = docx.Document()
+        applied = apply_profile_styles(document, profile)
+        self.assertIn("CourtBodyText", applied)
+        style = document.styles["CourtBodyText"]
+        self.assertEqual(style.font.name, "Arial")
+        self.assertEqual(style.font.size.pt, 10.0)
+
+    def test_changing_the_font_in_a_profile_changes_the_document(self):
+        """The point of using Word styles: one edit repoints a whole court."""
+        profile = load_court_form_profile("ma_trial_court")
+        profile.styles["CourtBodyText"].font = "Comic Sans MS"
+        document = docx.Document()
+        apply_profile_styles(document, profile)
+        self.assertEqual(document.styles["CourtBodyText"].font.name, "Comic Sans MS")
+
+
+class TestCourtFormGeneration(unittest.TestCase):
+    def setUp(self):
+        self.groups, self.variables = extract_interview_questions_and_variables(
+            [SAMPLE_YAML]
+        )
+        self.tempdir = tempfile.mkdtemp(prefix="court_form_test_")
+
+    def _generate(self, **kwargs):
+        kwargs.setdefault("document_title", "Motion to Vacate Default Judgment")
+        shape = kwargs.get("shape", "court_form")
+        profile_id = kwargs.get("profile_id", "generic")
+        kwargs["output_path"] = os.path.join(self.tempdir, f"{profile_id}_{shape}.docx")
+        return generate_court_form_docx(self.groups, self.variables, **kwargs)
+
+    def test_every_shape_and_profile_produces_a_document(self):
+        for profile_id in SHIPPED_PROFILES:
+            for shape in COURT_FORM_SHAPES:
+                with self.subTest(profile=profile_id, shape=shape):
+                    result = self._generate(shape=shape, profile_id=profile_id)
+                    self.assertTrue(os.path.getsize(result["docx_path"]) > 0)
+                    self.assertEqual(result["shape"], shape)
+                    self.assertEqual(result["profile_id"], profile_id)
+
+    def test_unknown_shape_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self._generate(shape="subpoena")
+
+    def test_caption_carries_the_jurisdiction_boilerplate(self):
+        expectations = {
+            "ma_trial_court": "COMMONWEALTH OF MASSACHUSETTS",
+            "vt_superior": "STATE OF VERMONT",
+            "mi_scao": "STATE OF MICHIGAN",
+            "mn_district": "STATE OF MINNESOTA",
+            "dmass_federal": "UNITED STATES DISTRICT COURT",
+            "il_circuit": "STATE OF ILLINOIS",
+        }
+        for profile_id, expected in expectations.items():
+            with self.subTest(profile=profile_id):
+                result = self._generate(profile_id=profile_id)
+                text = _document_text(docx.Document(result["docx_path"]))
+                self.assertIn(expected, text)
+
+    def test_docket_label_follows_the_jurisdiction(self):
+        for profile_id, expected in (
+            ("dmass_federal", "Civil Action No."),
+            ("mn_district", "Court File Number:"),
+            ("ma_trial_court", "DOCKET NO."),
+        ):
+            with self.subTest(profile=profile_id):
+                result = self._generate(profile_id=profile_id)
+                text = _document_text(docx.Document(result["docx_path"]))
+                self.assertIn(expected, text)
+
+    def test_body_uses_the_profiles_word_styles(self):
+        result = self._generate(profile_id="ma_trial_court")
+        document = docx.Document(result["docx_path"])
+        styles_used = {paragraph.style.name for paragraph in document.paragraphs}
+        self.assertIn("CourtBodyText", styles_used)
+        self.assertIn("CourtDocumentTitle", styles_used)
+        self.assertIn("CourtCaptionHeading", styles_used)
+
+    def test_interview_fields_become_guarded_body_paragraphs(self):
+        result = self._generate()
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("{{ showifdef('motion_reason') }}", text)
+        # A yes/no field renders as a conditional, not a bare value.
+        self.assertIn("showifdef('was_served')", text)
+        self.assertIn("1. Docket number:", text)
+
+    def test_caption_boilerplate_is_left_as_plain_jinja(self):
+        """Profile-named variables are the profile's contract; do not wrap them."""
+        result = self._generate(profile_id="ma_trial_court")
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("{{ trial_court }}", text)
+        self.assertIn("{{ docket_number }}", text)
+
+    def test_draft_time_placeholders_are_resolved(self):
+        result = self._generate(profile_id="ma_trial_court")
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("Motion to Vacate Default Judgment", text)
+        self.assertNotIn("{{ document_title }}", text)
+        self.assertNotIn("{{ docket_label }}", text)
+
+    def test_motion_adds_intro_prayer_and_certificate_of_service(self):
+        result = self._generate(shape="motion", profile_id="generic")
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("NOW COMES", text)
+        self.assertIn("WHEREFORE", text)
+        self.assertIn("CERTIFICATE OF SERVICE", text)
+        self.assertEqual(result["sections"].get("certificate_of_service"), "yaml")
+
+    def test_affidavit_closes_with_the_jurisdictions_perjury_language(self):
+        result = self._generate(shape="affidavit", profile_id="ma_trial_court")
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("pains and penalties of perjury", text)
+        self.assertEqual(result["sections"].get("jurat"), "yaml")
+        self.assertNotIn("signature", result["sections"])
+
+    def test_court_form_has_no_certificate_of_service_by_default(self):
+        result = self._generate(shape="court_form")
+        self.assertNotIn("certificate_of_service", result["sections"])
+
+    def test_certificate_of_service_can_be_forced_on(self):
+        result = self._generate(shape="court_form", include_certificate_of_service=True)
+        self.assertEqual(result["sections"].get("certificate_of_service"), "yaml")
+
+    def test_letter_has_no_caption_header_or_footer(self):
+        result = self._generate(shape="letter", profile_id="il_circuit")
+        self.assertNotIn("caption", result["sections"])
+        self.assertNotIn("header", result["sections"])
+        self.assertNotIn("footer", result["sections"])
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("Dear {{ recipient }}", text)
+        self.assertIn("Sincerely,", text)
+        self.assertNotIn("STATE OF ILLINOIS", text)
+
+    def test_illinois_running_header_names_the_case_number(self):
+        result = self._generate(profile_id="il_circuit")
+        document = docx.Document(result["docx_path"])
+        header_text = "\n".join(
+            paragraph.text for paragraph in document.sections[0].header.paragraphs
+        )
+        self.assertIn("Enter the Case Number", header_text)
+        self.assertEqual(result["sections"].get("header"), "yaml")
+
+    def test_page_setup_follows_the_profile(self):
+        result = self._generate(profile_id="mi_scao")
+        section = docx.Document(result["docx_path"]).sections[0]
+        self.assertAlmostEqual(section.top_margin.inches, 0.5, places=2)
+        self.assertAlmostEqual(section.left_margin.inches, 0.75, places=2)
+
+    def test_list_variables_become_repeating_tables(self):
+        result = self._generate()
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("{%tr for item in showifdef('users') %}", text)
+        self.assertIn("{%tr endfor %}", text)
+
+    def test_numbering_can_be_turned_off(self):
+        result = self._generate(numbered_paragraphs=False)
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("Docket number:", text)
+        self.assertNotIn("1. Docket number:", text)
+
+    def test_unsupplied_form_metadata_shows_as_a_fill_in(self):
+        result = self._generate(profile_id="mi_scao")
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("Approved, SCAO", text)
+        self.assertIn("[form number]", text)
+
+    def test_form_metadata_can_be_supplied(self):
+        result = self._generate(
+            profile_id="mi_scao",
+            context_extra={"form_code": "Form MC 02", "form_revision": "12/21"},
+        )
+        text = _document_text(docx.Document(result["docx_path"]))
+        self.assertIn("Form MC 02, Rev. 12/21", text)
+        self.assertNotIn("[form number]", text)
+
+    def test_build_context_exposes_profile_labels(self):
+        profile = load_court_form_profile("mi_scao")
+        context = build_court_form_context(profile, "Appearance")
+        self.assertEqual(context["document_title"], "Appearance")
+        self.assertEqual(context["docket_label"], "CASE NO.")
+        self.assertEqual(context["labels.defendant"], "Defendant(s)/Respondent(s)")
+
+
+class TestDocxFragmentOverride(unittest.TestCase):
+    """A section may be replaced by a caption somebody drew in Word."""
+
+    def setUp(self):
+        self.groups, self.variables = extract_interview_questions_and_variables(
+            [SAMPLE_YAML]
+        )
+        self.tempdir = tempfile.mkdtemp(prefix="court_form_fragment_")
+        self.fragment_root = os.path.join(self.tempdir, "overrides")
+        profile_dir = os.path.join(self.fragment_root, "ma_trial_court")
+        os.makedirs(profile_dir)
+        fragment = docx.Document()
+        fragment.add_paragraph("CAPTION AUTHORED IN WORD")
+        table = fragment.add_table(rows=1, cols=2)
+        table.rows[0].cells[0].text = "Suffolk, ss"
+        table.rows[0].cells[1].text = "DOCKET NO. {{ docket_number }}"
+        fragment.save(os.path.join(profile_dir, "caption.docx"))
+
+    def test_fragment_is_found(self):
+        path = find_docx_fragment("ma_trial_court", "caption", [self.fragment_root])
+        self.assertTrue(path and os.path.isfile(path))
+        self.assertIsNone(
+            find_docx_fragment("ma_trial_court", "signature", [self.fragment_root])
+        )
+
+    def test_fragment_replaces_only_that_section(self):
+        result = generate_court_form_docx(
+            self.groups,
+            self.variables,
+            shape="court_form",
+            profile_id="ma_trial_court",
+            document_title="Motion to Vacate",
+            output_path=os.path.join(self.tempdir, "out.docx"),
+            fragment_dirs=[self.fragment_root],
+        )
+        self.assertEqual(result["sections"]["caption"], "docx")
+        # The sections the override does not cover still come from the profile.
+        self.assertEqual(result["sections"]["signature"], "yaml")
+        self.assertEqual(result["sections"]["footer"], "yaml")
+
+        document = docx.Document(result["docx_path"])
+        text = _document_text(document)
+        self.assertIn("CAPTION AUTHORED IN WORD", text)
+        self.assertNotIn("COMMONWEALTH OF MASSACHUSETTS", text)
+        # The profile's styles are still defined for the rest of the document.
+        self.assertIn("CourtBodyText", [style.name for style in document.styles])
+
+    def test_splice_keeps_the_documents_own_section_properties(self):
+        target = docx.Document()
+        target.sections[0].left_margin = docx.shared.Inches(2.0)
+        fragment_path = os.path.join(
+            self.fragment_root, "ma_trial_court", "caption.docx"
+        )
+        copied = splice_docx_fragment(target, fragment_path)
+        self.assertGreater(copied, 0)
+        out = os.path.join(self.tempdir, "spliced.docx")
+        target.save(out)
+        self.assertAlmostEqual(
+            docx.Document(out).sections[0].left_margin.inches, 2.0, places=2
+        )
+
+
+class TestCourtFormMarkdown(unittest.TestCase):
+    def setUp(self):
+        self.groups, self.variables = extract_interview_questions_and_variables(
+            [SAMPLE_YAML]
+        )
+
+    def test_markdown_carries_caption_and_body(self):
+        text = generate_court_form_markdown(
+            self.groups,
+            self.variables,
+            shape="motion",
+            profile_id="vt_superior",
+            document_title="Motion to Enforce",
+        )
+        self.assertIn("STATE OF VERMONT", text)
+        self.assertIn("# Motion to Enforce", text)
+        self.assertIn("NOW COMES", text)
+        self.assertIn("${ showifdef('motion_reason') }", text)
+
+    def test_letter_markdown_has_no_caption(self):
+        text = generate_court_form_markdown(
+            self.groups,
+            self.variables,
+            shape="letter",
+            profile_id="ma_trial_court",
+            document_title="Request for Records",
+        )
+        self.assertNotIn("COMMONWEALTH OF MASSACHUSETTS", text)
+        self.assertIn("RE: Request for Records", text)
+        self.assertIn("Sincerely,", text)
+
+
+class TestVariableReportIntegration(unittest.TestCase):
+    """The court shapes reach callers through the variable report's own API."""
+
+    def test_intake_remains_the_default_and_is_unchanged(self):
+        result = generate_variable_report([SAMPLE_YAML], report_title="Intake")
+        self.assertEqual(result["shape"], "intake")
+        self.assertIn("| Field | Value |", result["mako_markdown"])
+        self.assertNotIn("profile_id", result)
+
+    def test_court_shape_reports_which_templates_it_used(self):
+        result = generate_variable_report(
+            [SAMPLE_YAML],
+            report_title="Motion to Vacate",
+            shape="motion",
+            court_profile="mn_district",
+        )
+        self.assertEqual(result["shape"], "motion")
+        self.assertEqual(result["profile_id"], "mn_district")
+        self.assertEqual(result["profile_name"], "Minnesota District Court")
+        self.assertEqual(result["sections"]["caption"], "yaml")
+        self.assertIn("CourtBodyText", result["styles"])
+        self.assertTrue(os.path.isfile(result["docx_path"]))
+
+    def test_output_path_is_honoured_for_court_shapes(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            target = os.path.join(tempdir, "drafted.docx")
+            result = generate_variable_report(
+                [SAMPLE_YAML],
+                report_title="Affidavit of Indigency",
+                shape="affidavit",
+                court_profile="ma_trial_court",
+                output_docx_path=target,
+            )
+            self.assertEqual(result["docx_path"], target)
+            self.assertTrue(os.path.isfile(target))
+
+    def test_choice_helpers_list_shapes_and_profiles(self):
+        shapes = {item["value"] for item in list_court_form_shapes()}
+        self.assertEqual(shapes, {"intake"} | set(COURT_FORM_SHAPES))
+        profiles = {item["value"] for item in list_court_form_profile_choices()}
+        for profile_id in SHIPPED_PROFILES:
+            self.assertIn(profile_id, profiles)
+
+
+class TestCourtFormAPI(unittest.TestCase):
+    """The same shapes over the HTTP API the Weaver and other clients use."""
+
+    def setUp(self):
+        from docassemble.ALDashboard.api_dashboard_utils import (
+            court_form_profiles_payload_from_options,
+            variable_report_payload_from_options,
+        )
+
+        self.report = variable_report_payload_from_options
+        self.profiles = court_form_profiles_payload_from_options
+
+    def test_court_shape_returns_the_docx_by_default(self):
+        payload = self.report(
+            {
+                "yaml_text": SAMPLE_YAML,
+                "report_title": "Motion to Dismiss",
+                "shape": "motion",
+                "court_profile": "il_circuit",
+            }
+        )
+        self.assertEqual(payload["shape"], "motion")
+        self.assertEqual(payload["profile_id"], "il_circuit")
+        self.assertIn("caption", payload["sections"])
+        self.assertTrue(payload["docx_base64"])
+
+    def test_intake_response_stays_lean(self):
+        payload = self.report({"yaml_text": SAMPLE_YAML})
+        self.assertEqual(payload["shape"], "intake")
+        self.assertNotIn("docx_base64", payload)
+        self.assertNotIn("profile_id", payload)
+
+    def test_docx_can_be_requested_for_intake_too(self):
+        payload = self.report({"yaml_text": SAMPLE_YAML, "include_docx_base64": True})
+        self.assertTrue(payload["docx_base64"])
+
+    def test_unknown_shape_is_a_validation_error(self):
+        from docassemble.ALDashboard.api_dashboard_utils import (
+            DashboardAPIValidationError,
+        )
+
+        with self.assertRaises(DashboardAPIValidationError):
+            self.report({"yaml_text": SAMPLE_YAML, "shape": "subpoena"})
+
+    def test_profiles_endpoint_lists_shapes_profiles_and_sections(self):
+        payload = self.profiles({})
+        listed = {profile["id"] for profile in payload["profiles"]}
+        for profile_id in SHIPPED_PROFILES:
+            self.assertIn(profile_id, listed)
+        self.assertIn("court_form", {item["value"] for item in payload["shapes"]})
+        self.assertIn("caption", payload["sections"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALDashboard/test/test_question_blocks_parse.py
+++ b/docassemble/ALDashboard/test/test_question_blocks_parse.py
@@ -1,0 +1,112 @@
+# do not pre-load
+"""Every packaged question block must survive docassemble's own parser.
+
+A block can be valid YAML, and pass dayamlchecker, and still be rejected by
+docassemble at runtime -- `show if:` accepts only `variable` plus `is`, or
+`code`, and anything else raises `DASourceError` the moment a user opens the
+screen. That failure mode is invisible to every other check in CI, so it is
+worth spending a test on: this walks the package's question files and builds
+each block the way the server would.
+"""
+
+import glob
+import os
+import unittest
+
+from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
+
+try:
+    from docassemble.base.parse import Interview, InterviewSourceString, Question
+except Exception:  # pragma: no cover - depends on the server's packages
+    Interview = None  # type: ignore[assignment]
+
+PACKAGE = "docassemble.ALDashboard"
+QUESTIONS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data",
+    "questions",
+)
+
+# Keys that mark a mapping as something docassemble would build a Question from.
+QUESTION_KEYS = ("question", "fields", "code", "event")
+
+
+def _question_files():
+    return sorted(glob.glob(os.path.join(QUESTIONS_DIR, "*.yml")))
+
+
+@unittest.skipIf(Interview is None, "docassemble.base is not installed")
+class TestPackagedQuestionBlocksParse(unittest.TestCase):
+    def test_every_question_block_builds(self):
+        yaml = YAML(typ="safe", pure=True)
+        files = _question_files()
+        self.assertTrue(files, "no packaged question files were found")
+
+        parsed = 0
+        for path in files:
+            with self.subTest(interview=os.path.basename(path)):
+                with open(path, "r", encoding="utf-8") as handle:
+                    text = handle.read()
+                source = InterviewSourceString(
+                    content="", directory=None, path=path, package=PACKAGE
+                )
+                interview = Interview(source=source)
+                documents = list(yaml.load_all(StringIO(text)))
+                for index, document in enumerate(documents):
+                    if not isinstance(document, dict):
+                        continue
+                    if not any(key in document for key in QUESTION_KEYS):
+                        continue
+                    label = document.get("id") or f"document {index}"
+                    try:
+                        Question(document, interview, source=source, package=PACKAGE)
+                    except Exception as err:
+                        self.fail(
+                            f"{os.path.basename(path)} [{label}] is not a valid "
+                            f"docassemble block: {err}"
+                        )
+                    parsed += 1
+
+        self.assertGreater(parsed, 0, "no question blocks were checked")
+
+    def test_the_court_form_options_screen_is_valid(self):
+        """The screen that gained the shape and jurisdiction fields.
+
+        `show if:` with `is not:` parsed as YAML and passed dayamlchecker but
+        was rejected by the server; the same-screen condition has to be written
+        as `js show if:`.
+        """
+        path = os.path.join(QUESTIONS_DIR, "variable_report_generator.yml")
+        self.assertTrue(os.path.isfile(path))
+        with open(path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+
+        yaml = YAML(typ="safe", pure=True)
+        source = InterviewSourceString(
+            content="", directory=None, path=path, package=PACKAGE
+        )
+        interview = Interview(source=source)
+
+        options_screen = None
+        for document in yaml.load_all(StringIO(text)):
+            if isinstance(document, dict) and document.get("id") == (
+                "variable report options"
+            ):
+                options_screen = document
+                break
+
+        self.assertIsNotNone(options_screen, "the options screen went missing")
+        assert options_screen is not None  # for mypy
+        Question(options_screen, interview, source=source, package=PACKAGE)
+
+        field_names = set()
+        for field in options_screen.get("fields") or []:
+            if isinstance(field, dict):
+                field_names.update(str(key) for key in field.values())
+        self.assertIn("report_shape", field_names)
+        self.assertIn("court_profile", field_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALDashboard/test/test_question_blocks_parse.py
+++ b/docassemble/ALDashboard/test/test_question_blocks_parse.py
@@ -19,7 +19,20 @@ from ruamel.yaml.compat import StringIO
 try:
     from docassemble.base.parse import Interview, InterviewSourceString, Question
 except Exception:  # pragma: no cover - depends on the server's packages
-    Interview = None  # type: ignore[assignment]
+    Interview = None  # type: ignore[assignment, misc]
+
+
+def _parser_runtime_available():
+    """The parser needs the request-local state that the webapp initializes."""
+    if Interview is None:
+        return False
+    try:
+        from docassemble.base.thread_context import this_thread
+
+        return this_thread._get_current_object() is not None
+    except (ImportError, RuntimeError):
+        return False
+
 
 PACKAGE = "docassemble.ALDashboard"
 QUESTIONS_DIR = os.path.join(
@@ -36,7 +49,10 @@ def _question_files():
     return sorted(glob.glob(os.path.join(QUESTIONS_DIR, "*.yml")))
 
 
-@unittest.skipIf(Interview is None, "docassemble.base is not installed")
+@unittest.skipUnless(
+    _parser_runtime_available(),
+    "docassemble parser requires an active webapp request context",
+)
 class TestPackagedQuestionBlocksParse(unittest.TestCase):
     def test_every_question_block_builds(self):
         yaml = YAML(typ="safe", pure=True)

--- a/docassemble/ALDashboard/variable_report_generator.py
+++ b/docassemble/ALDashboard/variable_report_generator.py
@@ -130,6 +130,33 @@ class QuestionGroupSpec:
     lists: List[VariableSpec] = field(default_factory=list)
 
 
+def list_court_form_shapes() -> List[Dict[str, str]]:
+    """The template shapes a report can be drafted in, for a dropdown."""
+    from .court_form_generator import COURT_FORM_SHAPES, SHAPE_LABELS
+
+    shapes = ["intake"] + list(COURT_FORM_SHAPES)
+    return [
+        {"value": shape, "label": SHAPE_LABELS.get(shape, shape)} for shape in shapes
+    ]
+
+
+def list_court_form_profile_choices() -> List[Dict[str, str]]:
+    """Jurisdiction profiles available on this server, for a dropdown."""
+    from .court_form_profiles import list_court_form_profiles
+
+    return [
+        {
+            "value": profile["id"],
+            "label": (
+                f"{profile['name']} ({profile['jurisdiction']})"
+                if profile.get("jurisdiction")
+                else profile["name"]
+            ),
+        }
+        for profile in list_court_form_profiles()
+    ]
+
+
 def list_variable_report_playground_projects() -> List[str]:
     from .interview_linter import list_playground_projects
 
@@ -842,32 +869,82 @@ def generate_variable_report(
     show_variable_types: bool = False,
     max_list_cols: int = 4,
     output_docx_path: Optional[str] = None,
+    shape: str = "intake",
+    court_profile: Optional[str] = None,
+    fragment_dirs: Optional[List[str]] = None,
+    include_certificate_of_service: Optional[bool] = None,
+    numbered_paragraphs: Optional[bool] = None,
 ) -> Dict[str, Any]:
+    """Draft a document from an interview's variables.
+
+    ``shape`` selects the template shape. ``"intake"`` is the original field and
+    value summary and stays the default, so existing callers -- the Weaver's
+    ``variable_report.py`` among them -- are unaffected. The other shapes draft
+    a court document using the jurisdiction profile named by ``court_profile``
+    (see ``court_form_profiles``).
+    """
     groups, variables = extract_interview_questions_and_variables(
         yaml_texts, infer_assemblyline=infer_assemblyline
     )
-    mako_markdown = generate_mako_markdown_report(
-        groups,
-        variables,
-        report_title=report_title,
-        show_variable_names=show_variable_names,
-        show_variable_types=show_variable_types,
-        max_list_cols=max_list_cols,
-    )
-    docx_file_path = generate_docx_report(
-        groups,
-        variables,
-        report_title=report_title,
-        output_path=output_docx_path,
-        show_variable_names=show_variable_names,
-        show_variable_types=show_variable_types,
-        max_list_cols=max_list_cols,
-    )
+
+    shape_name = str(shape or "intake").strip().lower()
+
+    if shape_name == "intake":
+        mako_markdown = generate_mako_markdown_report(
+            groups,
+            variables,
+            report_title=report_title,
+            show_variable_names=show_variable_names,
+            show_variable_types=show_variable_types,
+            max_list_cols=max_list_cols,
+        )
+        docx_file_path = generate_docx_report(
+            groups,
+            variables,
+            report_title=report_title,
+            output_path=output_docx_path,
+            show_variable_names=show_variable_names,
+            show_variable_types=show_variable_types,
+            max_list_cols=max_list_cols,
+        )
+        court_details: Dict[str, Any] = {}
+    else:
+        from .court_form_generator import (
+            generate_court_form_docx,
+            generate_court_form_markdown,
+        )
+        from .court_form_profiles import load_court_form_profile
+
+        profile = load_court_form_profile(court_profile, fragment_dirs=fragment_dirs)
+        mako_markdown = generate_court_form_markdown(
+            groups,
+            variables,
+            shape=shape_name,
+            profile=profile,
+            document_title=report_title,
+        )
+        court_result = generate_court_form_docx(
+            groups,
+            variables,
+            shape=shape_name,
+            profile=profile,
+            document_title=report_title,
+            output_path=output_docx_path,
+            include_certificate_of_service=include_certificate_of_service,
+            numbered_paragraphs=numbered_paragraphs,
+        )
+        docx_file_path = court_result["docx_path"]
+        court_details = {
+            "profile_id": court_result["profile_id"],
+            "profile_name": court_result["profile_name"],
+            "sections": court_result["sections"],
+            "styles": court_result["styles"],
+        }
 
     list_count = sum(1 for v in variables.values() if v.is_list)
     scalar_count = sum(1 for v in variables.values() if not v.is_list)
 
-    return {
+    result: Dict[str, Any] = {
         "variables": variables,
         "groups": groups,
         "mako_markdown": mako_markdown,
@@ -875,7 +952,10 @@ def generate_variable_report(
         "variables_count": len(variables),
         "list_count": list_count,
         "scalar_count": scalar_count,
+        "shape": shape_name,
     }
+    result.update(court_details)
+    return result
 
 
 def save_variable_report_to_playground(
@@ -1034,6 +1114,9 @@ def generate_and_save_playground_variable_report(
     show_variable_types: bool = False,
     max_list_cols: int = 4,
     report_title: Optional[str] = None,
+    shape: str = "intake",
+    court_profile: Optional[str] = None,
+    include_certificate_of_service: Optional[bool] = None,
 ) -> Dict[str, Any]:
     project = str(selected_playground_project or "default")
     filenames = [str(f) for f in selected_filenames]
@@ -1050,6 +1133,9 @@ def generate_and_save_playground_variable_report(
         show_variable_names=show_variable_names,
         show_variable_types=show_variable_types,
         max_list_cols=max_list_cols,
+        shape=shape,
+        court_profile=court_profile,
+        include_certificate_of_service=include_certificate_of_service,
     )
 
     if save_to_playground:


### PR DESCRIPTION
## Summary
- add declarative court form profiles and four document shapes to the variable report generator
- expose court profiles and DOCX generation through the dashboard API and intake interview
- fix the variable-report Flask route to pass the expected endpoint arguments
- make parser coverage skip clearly outside an active docassemble request context

## Verification
- `433 passed, 2 skipped, 37 subtests passed`
- `.venv/bin/mypy docassemble/ALDashboard --exclude '^build/' --explicit-package-bases`\n- `git diff --check` and Python syntax checks\n- installed twice with `~/venv/bin/dainstall . --server localhost --debug`\n- localhost API: profiles returned 7 shipped profiles; all four shapes returned HTTP 200 with DOCX payloads\n