### PR TITLE
Enhance user account management workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: local
+    hooks:
+      - id: da-build
+        name: docassemble build checks
+        entry: scripts/run_da_build_checks.sh
+        language: python
+        additional_dependencies:
+          - dayamlchecker>=1.5.0
+        pass_filenames: false
+        always_run: true

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -24,7 +24,7 @@ from flask import current_app, flash, redirect
 
 # SQLAlchemy expressions are shared by both the legacy engine and Flask extension.
 from sqlalchemy.sql import text
-from sqlalchemy import func, or_, select
+from sqlalchemy import bindparam, func, or_, select
 from sqlalchemy.orm import joinedload
 from typing import Any, List, Tuple, Dict, Optional, Callable, Set
 import math
@@ -170,8 +170,11 @@ __all__ = [
     "get_session_file_for_download",
     "get_session_files_zip",
     "get_user_details",
+    "can_access_user_sessions",
     "disable_user_mfa",
     "get_password_reset_link",
+    "send_password_reset_email",
+    "recent_account_activity_report",
     "inactive_developer_login_summary",
     "inactive_developer_account_report",
     "delete_inactive_developer_accounts",
@@ -574,7 +577,11 @@ def get_users_and_name_by_ids(ids: List[int]) -> List[Tuple[int, str, str, str]]
         return results
 
 
-def search_users_by_email(wordstart: str, limit: int = 20) -> List[Tuple[int, str]]:
+def search_users_by_email(
+    wordstart: str,
+    limit: int = 20,
+    exclude_privileged: bool = False,
+) -> List[Tuple[int, str]]:
     """
     Search for users whose email starts with the given text. Used by the input type: ajax field on large servers,
     so we never load the full user table - just return a handful of matches as the admin types.
@@ -583,12 +590,14 @@ def search_users_by_email(wordstart: str, limit: int = 20) -> List[Tuple[int, st
     if not wordstart:
         return []
 
-    statement = (
-        select(UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name)
-        .where(UserModel.email.istartswith(wordstart))
-        .limit(limit)
-    )
-
+    statement = select(
+        UserModel.id, UserModel.email, UserModel.first_name, UserModel.last_name
+    ).where(UserModel.email.istartswith(wordstart))
+    if exclude_privileged:
+        statement = statement.where(
+            ~UserModel.roles.any(Role.name.in_(["admin", "developer", "cron"]))
+        )
+    statement = statement.limit(limit)
     with _get_db_session() as session:
         users = session.execute(statement).all()
 
@@ -644,7 +653,9 @@ def get_user_details(user_id: int) -> Optional[Dict]:
     Returns:
         A dictionary with user details, or None if the user is not found. Keys include:
         id, email, first_name, last_name, active, account_type, privileges (list of str),
-        mfa_enabled (bool), and mfa_type (str or None: "app", "sms", or None).
+        mfa_enabled (bool), mfa_type (str or None: "app", "sms", or None),
+        last_login (datetime or None), session_count (int), and
+        last_session_activity (datetime or None).
     """
     with _get_db_session() as session:
         user = (
@@ -671,6 +682,8 @@ def get_user_details(user_id: int) -> Optional[Dict]:
 
     account_type = re.sub(r"\$.*", "", user.social_id) if user.social_id else "unknown"
 
+    session_summary = _user_session_summary(user.id)
+
     return {
         "id": user.id,
         "email": user.email,
@@ -681,7 +694,47 @@ def get_user_details(user_id: int) -> Optional[Dict]:
         "privileges": privileges,
         "mfa_enabled": mfa_enabled,
         "mfa_type": mfa_type,
+        "last_login": getattr(user, "last_login", None),
+        "session_count": session_summary["session_count"],
+        "last_session_activity": session_summary["last_session_activity"],
     }
+
+
+def _current_user_permissions() -> Set[str]:
+    """Return the current user's configured docassemble permissions."""
+    if not user_logged_in():
+        return set()
+    try:
+        return set(getattr(user_info(), "permissions", []) or [])
+    except (AttributeError, TypeError, RuntimeError):
+        return set()
+
+
+def can_access_user_sessions(user_id: Optional[int] = None) -> bool:
+    """Whether the current user may inspect another account's sessions.
+
+    Docassemble's ``access_sessions`` permission grants access to other users'
+    sessions. The user-centered entry point also requires ``access_user_info``.
+    Non-admin support users may not use it to inspect protected accounts.
+    """
+    if not user_logged_in():
+        return False
+    if user_id is not None:
+        try:
+            target_user_id = int(user_id)
+        except (TypeError, ValueError):
+            return False
+        if target_user_id == _resolve_current_user_id():
+            return True
+    if user_has_privilege(["admin", "developer"]):
+        return True
+    permissions = _current_user_permissions()
+    if not {"access_sessions", "access_user_info"}.issubset(permissions):
+        return False
+    if user_id is None:
+        return True
+    privileged = is_user_privileged(target_user_id)
+    return privileged is False
 
 
 def disable_user_mfa(user_id: int) -> bool:
@@ -774,6 +827,197 @@ def get_password_reset_link(user_id: int) -> Optional[str]:
     reset_link = url_for("user.reset_password", token=token, _external=True)
 
     return reset_link
+
+
+def send_password_reset_email(user_id: int) -> Dict[str, Any]:
+    """Ask docassemble's user manager to send its standard reset email.
+
+    This deliberately uses the same authorization and protected-account rules
+    as :func:`get_password_reset_link`, and delegates token generation, message
+    templates, and delivery to docassemble's built-in forgot-password flow.
+    """
+    if not user_logged_in() or (
+        not user_has_privilege("admin")
+        and "edit_user_password" not in _current_user_permissions()
+    ):
+        log("send_password_reset_email: current user lacks permission")
+        return {
+            "sent": False,
+            "message": "You do not have permission to send a reset email.",
+        }
+
+    if is_user_privileged(user_id) and not user_has_privilege(["admin", "developer"]):
+        log(
+            "send_password_reset_email: refusing protected target "
+            f"user {user_id} for a non-admin support user"
+        )
+        return {
+            "sent": False,
+            "message": "Only an administrator can reset this account.",
+        }
+
+    with _get_db_session() as session:
+        user = session.execute(
+            select(UserModel).where(UserModel.id == user_id)
+        ).scalar_one_or_none()
+
+    if user is None or not user.email:
+        log(f"send_password_reset_email: no email address for user {user_id}")
+        return {
+            "sent": False,
+            "message": "This account does not have an email address.",
+        }
+
+    user_manager = current_app.user_manager  # type: ignore[attr-defined]
+    if not getattr(user_manager, "enable_forgot_password", False):
+        return {
+            "sent": False,
+            "message": "Password reset email is disabled on this server.",
+        }
+    if not current_app.config.get("ALLOW_CHANGING_PASSWORD", True):
+        return {
+            "sent": False,
+            "message": "Password changes are disabled on this server.",
+        }
+
+    try:
+        user_manager.send_reset_password_email(user.email)
+    except Exception as error:
+        log(
+            "send_password_reset_email: delivery failed for "
+            f"user {user_id}: {error.__class__.__name__}: {error}"
+        )
+        return {
+            "sent": False,
+            "message": "The server could not send the reset email.",
+        }
+    return {"sent": True, "message": "The password reset email was sent."}
+
+
+def recent_account_activity_report(
+    days: int = 30,
+    user_limit: int = 200,
+    anonymous_limit: int = 100,
+) -> Dict[str, Any]:
+    """Return recent login activity and grouped anonymous session activity.
+
+    Anonymous activity is grouped by docassemble's temporary user identifier.
+    The interview/session tables do not contain a reliable historical source IP.
+    """
+    if not can_access_user_sessions():
+        return {"authorized": False, "users": [], "anonymous": []}
+    try:
+        days = min(365, max(1, int(days)))
+    except (TypeError, ValueError):
+        days = 30
+    user_limit = min(500, max(1, int(user_limit)))
+    anonymous_limit = min(500, max(1, int(anonymous_limit)))
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
+
+    user_statement = (
+        select(
+            UserModel.id,
+            UserModel.email,
+            UserModel.first_name,
+            UserModel.last_name,
+            UserModel.last_login,
+        )
+        .where(
+            UserModel.last_login.isnot(None),
+            UserModel.last_login >= cutoff,
+            ~UserModel.social_id.startswith("disabled$"),
+        )
+        .order_by(UserModel.last_login.desc())
+        .limit(user_limit)
+    )
+    if not user_has_privilege(["admin", "developer"]):
+        user_statement = user_statement.where(
+            ~UserModel.roles.any(Role.name.in_(["admin", "developer", "cron"]))
+        )
+
+    recent_user_sessions_statement = text("""
+        SELECT
+            userdictkeys.user_id AS user_id,
+            COUNT(DISTINCT userdictkeys.key) AS recent_session_count,
+            MAX(userdict.modtime) AS last_session_activity
+        FROM userdictkeys
+        JOIN userdict
+          ON userdict.key = userdictkeys.key
+         AND userdict.filename = userdictkeys.filename
+        WHERE userdictkeys.user_id IN :user_ids
+          AND userdict.modtime >= :cutoff
+        GROUP BY userdictkeys.user_id
+    """).bindparams(bindparam("user_ids", expanding=True))
+
+    anonymous_statement = text("""
+        SELECT
+            userdictkeys.temp_user_id AS temp_user_id,
+            COUNT(DISTINCT userdictkeys.key) AS session_count,
+            MAX(userdict.modtime) AS last_activity
+        FROM userdictkeys
+        JOIN userdict
+          ON userdict.key = userdictkeys.key
+         AND userdict.filename = userdictkeys.filename
+        WHERE userdictkeys.user_id IS NULL
+          AND userdictkeys.temp_user_id IS NOT NULL
+          AND userdict.modtime >= :cutoff
+        GROUP BY userdictkeys.temp_user_id
+        ORDER BY last_activity DESC
+        LIMIT :anonymous_limit
+    """)
+
+    with _get_db_session() as session:
+        user_rows = session.execute(user_statement).all()
+        if user_rows:
+            recent_user_session_rows = session.execute(
+                recent_user_sessions_statement,
+                {"user_ids": [row.id for row in user_rows], "cutoff": cutoff},
+            ).all()
+        else:
+            recent_user_session_rows = []
+        anonymous_rows = session.execute(
+            anonymous_statement,
+            {"cutoff": cutoff, "anonymous_limit": anonymous_limit},
+        ).all()
+
+    recent_sessions_by_user = {
+        row.user_id: {
+            "recent_session_count": int(row.recent_session_count or 0),
+            "last_session_activity": row.last_session_activity,
+        }
+        for row in recent_user_session_rows
+    }
+
+    return {
+        "authorized": True,
+        "days": days,
+        "cutoff": cutoff,
+        "users": [
+            {
+                "id": row.id,
+                "email": row.email or "",
+                "name": " ".join(
+                    part for part in (row.first_name or "", row.last_name or "") if part
+                ),
+                "last_login": row.last_login,
+                "recent_session_count": recent_sessions_by_user.get(row.id, {}).get(
+                    "recent_session_count", 0
+                ),
+                "last_session_activity": recent_sessions_by_user.get(row.id, {}).get(
+                    "last_session_activity"
+                ),
+            }
+            for row in user_rows
+        ],
+        "anonymous": [
+            {
+                "temp_user_id": row.temp_user_id,
+                "session_count": int(row.session_count or 0),
+                "last_activity": row.last_activity,
+            }
+            for row in anonymous_rows
+        ],
+    }
 
 
 PLAYGROUND_SECTIONS = (
@@ -1324,6 +1568,7 @@ def format_session_users(session: Any, users_by_id: Dict[int, str]) -> str:
 
 def speedy_get_sessions(
     user_id: Optional[int] = None,
+    temp_user_id: Optional[int] = None,
     filename: Optional[str] = None,
     filter_step1: bool = True,
     metadata_key_name: str = "metadata",
@@ -1332,7 +1577,8 @@ def speedy_get_sessions(
     search_criteria_text: Optional[str] = None,
 ) -> List[Tuple]:
     """
-    Return a list of the most recent 500 sessions, optionally tied to a specific user ID.
+    Return the 500 most recently active sessions, optionally tied to a registered
+    user ID or an anonymous temporary-user ID.
 
     Each session is a tuple with named columns:
     filename,
@@ -1341,9 +1587,45 @@ def speedy_get_sessions(
     key
     """
     get_sessions_query = text("""
+WITH mostrecent AS (
+    SELECT
+        key,
+        MAX(modtime) AS modtime,
+        COUNT(key) AS num_keys
+    FROM userdict
+    WHERE
+        (user_id = :user_id OR :user_id IS NULL)
+        AND (
+            :temp_user_id IS NULL
+            OR EXISTS (
+                SELECT 1
+                FROM userdictkeys AS target_user
+                WHERE target_user.key = userdict.key
+                  AND target_user.filename = userdict.filename
+                  AND target_user.temp_user_id = :temp_user_id
+            )
+        )
+        AND (filename = :filename OR :filename IS NULL)
+    GROUP BY key
+    HAVING
+        (COUNT(key) > 1 OR :filter_step1 = FALSE)
+        AND (:start_date IS NULL OR DATE(MAX(modtime)) >= CAST(:start_date AS DATE))
+        AND (:end_date IS NULL OR DATE(MAX(modtime)) <= CAST(:end_date AS DATE))
+    ORDER BY modtime DESC
+    LIMIT 500
+),
+joined_users AS (
+    SELECT
+        userdictkeys.key,
+        MIN(userdictkeys.user_id) AS user_id,
+        STRING_AGG(DISTINCT CAST(userdictkeys.user_id AS TEXT), ',') AS user_ids
+    FROM userdictkeys
+    JOIN mostrecent ON mostrecent.key = userdictkeys.key
+    GROUP BY userdictkeys.key
+)
 SELECT 
     userdict.filename as filename,
-    num_keys,
+    mostrecent.num_keys,
     joined_users.user_id as user_id,
     joined_users.user_ids as user_ids,
     mostrecent.modtime as modtime,  -- This retrieves the most recent modification time for each key
@@ -1353,45 +1635,46 @@ SELECT
     jsonstorage.data->>'description' as description,
     jsonstorage.data->>'steps' as steps,
     jsonstorage.data->>'progress' as progress
-FROM 
-    userdict 
-NATURAL JOIN 
-    (
-        SELECT 
-            key,
-            MAX(modtime) AS modtime,  -- Calculate the most recent modification time for each key
-            COUNT(key) AS num_keys
-        FROM 
-            userdict
-        GROUP BY 
-            key
-        HAVING 
-            COUNT(key) > 1 OR :filter_step1 = False
-    ) mostrecent
-LEFT JOIN 
-    (
-        SELECT
-            key,
-            MIN(user_id) AS user_id,
-            STRING_AGG(DISTINCT CAST(user_id AS TEXT), ',') AS user_ids
-        FROM userdictkeys
-        GROUP BY key
-    ) joined_users ON joined_users.key = userdict.key
+FROM mostrecent
+JOIN userdict
+    ON userdict.key = mostrecent.key AND userdict.modtime = mostrecent.modtime
+LEFT JOIN joined_users ON joined_users.key = userdict.key
 LEFT JOIN 
     jsonstorage ON jsonstorage.key = userdict.key AND jsonstorage.tags = :metadata
-WHERE 
-    (userdict.user_id = :user_id OR :user_id is null)
-    AND (userdict.filename = :filename OR :filename is null)
-    AND (:start_date is null OR DATE(mostrecent.modtime) >= CAST(:start_date AS DATE))
-    AND (:end_date is null OR DATE(mostrecent.modtime) <= CAST(:end_date AS DATE))
+WHERE
+    (userdict.user_id = :user_id OR :user_id IS NULL)
+    AND (
+        :temp_user_id IS NULL
+        OR EXISTS (
+            SELECT 1
+            FROM userdictkeys AS target_user
+            WHERE target_user.key = userdict.key
+              AND target_user.filename = userdict.filename
+              AND target_user.temp_user_id = :temp_user_id
+        )
+    )
+    AND (userdict.filename = :filename OR :filename IS NULL)
 ORDER BY 
     modtime DESC 
 LIMIT 500;
         """)
-    if not filename:
-        if not user_has_privilege(["admin", "developer"]):
+    if user_id is not None and temp_user_id is not None:
+        raise ValueError("Filter by either user_id or temp_user_id, not both.")
+    if user_id and not can_access_user_sessions(user_id):
+        raise Exception("You do not have permission to view this user's sessions.")
+    if temp_user_id is not None:
+        if not can_access_user_sessions():
             raise Exception(
-                "You must provide a filename to filter sessions unless you are a developer or administrator."
+                "You do not have permission to view this anonymous user's sessions."
+            )
+        try:
+            temp_user_id = int(temp_user_id)
+        except (TypeError, ValueError) as error:
+            raise ValueError("Invalid temporary user ID.") from error
+    if not filename:
+        if not can_access_user_sessions():
+            raise Exception(
+                "You must provide a filename to filter sessions unless you have access to other users' sessions."
             )
         filename = None  # Explicitly treat empty string as equivalent to None
     if not user_id:
@@ -1413,6 +1696,7 @@ LIMIT 500;
                 get_sessions_query,
                 {
                     "user_id": user_id,
+                    "temp_user_id": temp_user_id,
                     "filename": filename,
                     "filter_step1": filter_step1,
                     "metadata": metadata_key_name,
@@ -1728,13 +2012,14 @@ def build_session_files_zip(
 def get_allowed_interview_filenames() -> Optional[Set[str]]:
     """
     Return the set of interview filenames the current user may look at sessions
-    for, or None if the user is unrestricted (admins and developers).
+    for, or None if the user is unrestricted (admins, developers, and users
+    granted both ``access_user_info`` and ``access_sessions``).
 
     Non-privileged users are limited to the interviews listed under
     `assembly line: interview viewers:` in the configuration for one of the
     privileges they hold.
     """
-    if user_has_privilege(["admin", "developer"]):
+    if can_access_user_sessions():
         return None
     allowed_filenames: Set[str] = set()
     interview_viewers = get_config("assembly line", {}).get("interview viewers", {})

--- a/docassemble/ALDashboard/aldashboard.py
+++ b/docassemble/ALDashboard/aldashboard.py
@@ -910,8 +910,14 @@ def recent_account_activity_report(
         days = min(365, max(1, int(days)))
     except (TypeError, ValueError):
         days = 30
-    user_limit = min(500, max(1, int(user_limit)))
-    anonymous_limit = min(500, max(1, int(anonymous_limit)))
+    try:
+        user_limit = min(500, max(1, int(user_limit)))
+    except (TypeError, ValueError):
+        user_limit = 200
+    try:
+        anonymous_limit = min(500, max(1, int(anonymous_limit)))
+    except (TypeError, ValueError):
+        anonymous_limit = 100
     cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
 
     user_statement = (

--- a/docassemble/ALDashboard/data/questions/list_sessions.yml
+++ b/docassemble/ALDashboard/data/questions/list_sessions.yml
@@ -32,9 +32,10 @@ question: |
   Splash screen
 ---
 code: |
-  # get_allowed_interview_filenames() returns None for admins and developers,
-  # who can see every interview, and otherwise the set of interviews listed
-  # under `assembly line: interview viewers:` for the user's privileges.
+  # get_allowed_interview_filenames() returns None for admins, developers, and
+  # support users with both account and session access. Otherwise it returns the
+  # interviews listed under `assembly line: interview viewers:` for the user's
+  # privileges.
   allowed_interview_filenames = get_allowed_interview_filenames()
   interviews = {
     interview["filename"]: interview
@@ -57,7 +58,7 @@ code: |
 code: |
   # Used to decide whether it's safe to load every user into the dropdown below, 
   # or whether the server has too many users for that
-  if user_has_privilege(["admin", "developer"]):
+  if can_access_user_sessions():
     total_user_count = get_user_count()
   else:
     total_user_count = 0
@@ -149,7 +150,7 @@ fields:
       ["browse", "search"].includes(val("session_list_mode"))
     show if:
       code: |
-        user_has_privilege(['admin', 'developer'])
+        can_access_user_sessions()
   - Filename: filename
     code: |
       sorted(
@@ -171,7 +172,7 @@ fields:
       ["browse", "search"].includes(val("session_list_mode"))
     show if:
       code: |
-        not user_has_privilege(['admin', 'developer'])
+        not can_access_user_sessions()
   - User (leave blank to view all sessions): chosen_user
     required: False
     datatype: integer
@@ -184,7 +185,7 @@ fields:
     code: |
       (
         speedy_get_users()
-        if user_has_privilege(["admin", "developer"])
+        if can_access_user_sessions()
         else [{user_info().id: user_info().email}]
       )
   - User (leave blank to view all sessions): chosen_user

--- a/docassemble/ALDashboard/data/questions/manage_users.yml
+++ b/docassemble/ALDashboard/data/questions/manage_users.yml
@@ -18,31 +18,45 @@ modules:
 mandatory: True
 id: interview order
 code: |
-  chosen_user
-  if not user_has_privilege("admin"):
-    if is_user_privileged(chosen_user) and user_task in (
-      "reset_password",
-      "get_reset_link",
-      "elevate_permissions",
-      "disable_mfa",
-      "edit_profile",
-    ):
-      exit_cant_manage_privileged_user
-  if user_task == "reset_password":
-    do_update_password
-  elif user_task == "get_reset_link":
-    display_reset_link_screen
-  elif user_task == "elevate_permissions":
-    do_update_privileges
-  elif user_task == "download_playground":
-    do_download_playground
-  elif user_task == "view_user_info":
-    view_user_info_screen
-  elif user_task == "disable_mfa":
-    confirm_disable_mfa
-    do_disable_mfa
-  elif user_task == "edit_profile":
-    edit_profile_screen
+  user_task
+  if user_task == "recent_activity":
+    recent_activity_days
+    recent_activity_data
+    recent_activity_report_screen
+  else:
+    chosen_user
+    if not user_has_privilege("admin"):
+      if is_user_privileged(chosen_user) and user_task in (
+        "reset_password",
+        "get_reset_link",
+        "send_reset_email",
+        "view_sessions",
+        "elevate_permissions",
+        "disable_mfa",
+        "edit_profile",
+      ):
+        exit_cant_manage_privileged_user
+    if user_task == "reset_password":
+      do_update_password
+    elif user_task == "get_reset_link":
+      display_reset_link_screen
+    elif user_task == "send_reset_email":
+      confirm_reset_email_delivery
+      send_reset_email_result
+      send_reset_email_complete_screen
+    elif user_task == "elevate_permissions":
+      do_update_privileges
+    elif user_task == "download_playground":
+      do_download_playground
+    elif user_task == "view_user_info":
+      view_user_info_screen
+    elif user_task == "view_sessions":
+      view_user_sessions_screen
+    elif user_task == "disable_mfa":
+      confirm_disable_mfa
+      do_disable_mfa
+    elif user_task == "edit_profile":
+      edit_profile_screen
   ending_screen
 ---
 id: exit_cant_manage_privileged_user
@@ -53,14 +67,26 @@ subquestion: |
   Only users with the `admin` privilege are allowed to edit privileged accounts.
 ---
 code: |
-  user_lookup = {}
-  for user in get_users_and_name():
-    user_lookup[user[0]] = f"{user[2]} {user[3]} ({user[1]})".strip()
+  user_details = get_user_details(chosen_user)
+  if user_details:
+    user_label = f"{user_details['first_name'] or ''} {user_details['last_name'] or ''} ({user_details['email'] or 'no email'})".strip()
+  else:
+    user_label = f"User ID {chosen_user}"
 ---
 code: |
-  user_details = get_user_details(chosen_user)
+  manage_user_count = get_user_count()
 ---
-id: select user
+id: select recent activity period
+question: |
+  Recently active users
+fields:
+  - Days of activity to include: recent_activity_days
+    datatype: integer
+    min: 1
+    max: 365
+    default: 5
+---
+id: select user and management task
 question: |
   Manage users
 subquestion: |
@@ -85,6 +111,7 @@ subquestion: |
   % endif
 fields:
   - User: chosen_user
+    required: False
     datatype: integer
     input type: combobox
     code: |
@@ -96,28 +123,44 @@ fields:
       ]
     exclude:
       - "2"
-    # User ID 2 is the "cron" user and should not be managed here
+    show if:
+      code: |
+        manage_user_count <= 200
+    js show if: |
+      val("user_task") != "recent_activity"
+  - User: chosen_user
+    required: False
+    datatype: integer
+    input type: ajax
+    action: manage_user_search_ajax
+    show if:
+      code: |
+        manage_user_count > 200
+    js show if: |
+      val("user_task") != "recent_activity"
   - What do you want to do?: user_task
     datatype: radio
+    default: view_user_info
     choices:
       - View user information: view_user_info
+      - View saved interviews and answers: view_sessions
+      - Visit recent user report: recent_activity
       - Reset password: reset_password
       - Get password reset link: get_reset_link
+      - Send password reset email: send_reset_email
       - Download playground files: download_playground
       - Change user permissions: elevate_permissions
       - Disable two-factor authentication: disable_mfa
       - Edit profile in docassemble: edit_profile
   - New password: new_user_password
     datatype: password
-    show if:
-      variable: user_task
-      is: reset_password
+    js show if: |
+      val("user_task") == "reset_password"
     validate: valid_password      
   - Verify new password: new_user_password_2
     datatype: password
-    show if:
-      variable: user_task
-      is: reset_password
+    js show if: |
+      val("user_task") == "reset_password"
     validate: valid_password      
   - New permissions: new_permission_level
     datatype: multiselect
@@ -126,10 +169,10 @@ fields:
     exclude: |
       'cron'
     show if:
-      variable: user_task
-      is: elevate_permissions
       code: |
         "access_privileges" in user_info().permissions
+    js show if: |
+      val("user_task") == "elevate_permissions"
     help: |
       The user's permissions will be completely reset to match the new
       list of permissions. Use "ctrl" to select multiple.
@@ -139,8 +182,32 @@ fields:
       code: |
         not "access_privileges" in user_info().permissions
 validation code: |
+  if user_task != "recent_activity" and not chosen_user:
+    validation_error("Select a user", field="chosen_user")
   if user_task == "reset_password" and new_user_password != new_user_password_2:
     validation_error("The passwords do not match", field="new_user_password_2")
+---
+event: manage_user_search_ajax
+code: |
+  set_save_status("ignore")
+  original = action_argument("wordstart")
+  try:
+    original_id = int(original)
+    existing_match = get_users_and_name_by_ids([original_id])
+    if existing_match:
+      user_id, email, name, last = existing_match[0]
+      if user_has_privilege(["admin", "developer"]) or not is_user_privileged(user_id):
+        json_response([[str(user_id), f"{name} {last} ({email})".strip()]])
+  except (TypeError, ValueError):
+    pass
+  results = [
+    [str(user_id), label]
+    for user_id, label in search_users_by_email(
+      original,
+      exclude_privileged=not user_has_privilege(["admin", "developer"]),
+    )
+  ]
+  json_response(results)
 ---
 code: |
   set_user_info(user_id=chosen_user, password=new_user_password)
@@ -154,10 +221,10 @@ code: |
 ---
 id: download playground
 question: |
-  Playground download for ${ user_lookup[chosen_user] }
+  Playground download for ${ user_label }
 subquestion: |
   % for project in get_list_of_projects(chosen_user) + ['default']:
-  [${project}]( ${ create_user_playground_zip(chosen_user, space_to_underscore(user_lookup[chosen_user]), project).url_for() })
+  [${project}]( ${ create_user_playground_zip(chosen_user, space_to_underscore(user_label), project).url_for() })
   % endfor
 event: do_download_playground
 ---
@@ -191,12 +258,25 @@ subquestion: |
   **Active** | ${ "Yes" if user_details["active"] else "No" }
   **Account type** | ${ user_details["account_type"] }
   **Privileges** | ${ ", ".join(user_details["privileges"]) if user_details["privileges"] else "user" }
+  **Last login** | ${ user_details["last_login"].strftime("%b %d, %Y at %H:%M UTC") if user_details["last_login"] else "Never" }
+  **Saved interview sessions** | ${ user_details["session_count"] }
+  **Last interview activity** | ${ user_details["last_session_activity"].strftime("%b %d, %Y at %H:%M UTC") if user_details["last_session_activity"] else "Never" }
   **2FA enabled** | ${ "Yes" if user_details["mfa_enabled"] else "No" }
   % if user_details["mfa_enabled"]:
   **2FA type** | ${ "Authenticator app" if user_details["mfa_type"] == "app" else "SMS" }
   % endif
   % else:
   The selected user could not be found in the database.
+  % endif
+under: |
+  % if user_details:
+  % if can_access_user_sessions(user_details["id"]):
+  ${ action_button_html(url_action("view_user_sessions_screen"), label="View saved interviews and answers", icon="folder-open", color="primary") }
+  % endif
+  % if user_has_privilege("admin") or "edit_user_password" in getattr(user_info(), "permissions", []):
+  ${ action_button_html(url_action("start_send_reset_email"), label="Send password reset email", icon="envelope", color="secondary") }
+  ${ action_button_html(url_action("display_reset_link_screen"), label="Copy password reset link", icon="link", color="secondary") }
+  % endif
   % endif
 buttons:
   - Restart: restart
@@ -260,10 +340,176 @@ code: |
   # This does not send an email, it only generates the URL for the admin to send manually
   password_reset_link = get_password_reset_link(chosen_user)
 ---
+id: confirm send reset email
+question: |
+  Send a password reset email?
+subquestion: |
+  Docassemble will send its standard password reset message to
+  **${ user_details["email"] if user_details else user_label }**.
+
+  The message will contain a private, expiring reset link. Sending it may cause
+  the user to lose access to encrypted saved answers after they reset their password.
+field: confirm_reset_email_delivery
+buttons:
+  - Send reset email: True
+  - Cancel: False
+---
+event: start_send_reset_email
+code: |
+  undefine("confirm_reset_email_delivery")
+  confirm_reset_email_delivery
+  send_reset_email_result
+  send_reset_email_complete_screen
+---
+code: |
+  if confirm_reset_email_delivery:
+    send_reset_email_result = send_password_reset_email(chosen_user)
+  else:
+    send_reset_email_result = {"sent": False, "message": "No email was sent."}
+---
+event: send_reset_email_complete_screen
+question: |
+  ${ "Password reset email sent" if send_reset_email_result["sent"] else "Password reset email not sent" }
+subquestion: |
+  ${ send_reset_email_result["message"] }
+buttons:
+  - Restart: restart
+---
+code: |
+  if can_access_user_sessions(chosen_user):
+    managed_user_sessions = speedy_get_sessions(
+      user_id=chosen_user,
+      filename=None,
+      filter_step1=False,
+    )
+  else:
+    managed_user_sessions = []
+---
+event: view_user_sessions_screen
+code: |
+  if not can_access_user_sessions(chosen_user):
+    response(response="You do not have permission to view this user's sessions.", response_code=403)
+  managed_session_subject = user_label
+  managed_sessions = managed_user_sessions
+  view_managed_sessions_screen
+---
+event: view_anonymous_sessions_screen
+code: |
+  if not can_access_user_sessions():
+    response(response="You do not have permission to view anonymous sessions.", response_code=403)
+  try:
+    managed_temp_user_id = int(action_argument("temp_user_id"))
+  except (TypeError, ValueError):
+    response(response="Invalid anonymous user identifier.", response_code=400)
+  managed_session_subject = f"anonymous user {managed_temp_user_id}"
+  managed_sessions = speedy_get_sessions(
+    temp_user_id=managed_temp_user_id,
+    filename=None,
+    filter_step1=False,
+  )
+  view_managed_sessions_screen
+---
+event: view_managed_sessions_screen
+question: |
+  Saved interviews and answers for ${ managed_session_subject }
+subquestion: |
+  % if managed_sessions:
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Interview</th>
+        <th>Modified</th>
+        <th>Step / progress</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+  % for interview in managed_sessions:
+      <tr>
+        <td class="text-wrap text-break">
+          <strong>${ interview.title or interview.auto_title or nicer_interview_filename(interview.filename) }</strong>
+          <br><small>${ nicer_interview_filename(interview.filename) }</small>
+          <br><code>${ interview.key }</code>
+        </td>
+        <td>${ format_date(interview.modtime, "MMM d YYYY") }</td>
+        <td>${ f"Step {interview.num_keys}" if not interview.progress else f"{interview.progress}%" }</td>
+        <td>
+          <a target="_blank" rel="noopener" href="${ interview_url(i=interview.filename, session=interview.key) }"><i class="fa-solid fa-folder-open"></i>&nbsp;Join live interview</a><br>
+          <a target="_blank" rel="noopener" href="${ interview_url_action('view_single_session', i=user_info().package + ':list_sessions.yml', new_session=1, session_id=interview.key) }"><i class="fa-solid fa-magnifying-glass"></i>&nbsp;Details and files</a><br>
+          <a target="_blank" rel="noopener" href="${ interview_url_action('view_session_variables', i=user_info().package + ':list_sessions.yml', new_session=1, session_id=interview.key) }"><i class="fa-solid fa-eye"></i>&nbsp;View answers</a>
+        </td>
+      </tr>
+  % endfor
+    </tbody>
+  </table>
+  % else:
+  <div class="alert alert-secondary">No saved interview sessions were found for this user.</div>
+  % endif
+back button: True
+---
+code: |
+  recent_activity_data = recent_account_activity_report(recent_activity_days)
+---
+event: recent_activity_report_screen
+question: |
+  Recently active users
+subquestion: |
+  % if not recent_activity_data["authorized"]:
+  <div class="alert alert-danger">You do not have permission to view account activity.</div>
+  % else:
+  <h2 class="h4">Registered users who logged in during the last ${ recent_activity_data["days"] } days</h2>
+  % if recent_activity_data["users"]:
+  <table class="table table-striped">
+    <thead><tr><th>User</th><th>Last login</th><th>Recent sessions</th><th>Last session activity</th><th>Action</th></tr></thead>
+    <tbody>
+  % for row in recent_activity_data["users"]:
+      <tr>
+        <td>${ row["name"] or row["email"] or f'User ID {row["id"]}' }<br><small>${ row["email"] }</small></td>
+        <td>${ row["last_login"].strftime("%b %d, %Y at %H:%M UTC") }</td>
+        <td>${ row["recent_session_count"] }</td>
+        <td>${ row["last_session_activity"].strftime("%b %d, %Y at %H:%M UTC") if row["last_session_activity"] else "None" }</td>
+        <td><a href="${ url_action('view_activity_user', user_id=row['id']) }">View user information</a></td>
+      </tr>
+  % endfor
+    </tbody>
+  </table>
+  % else:
+  <p>No registered users logged in during this period.</p>
+  % endif
+
+  <h2 class="h4 mt-4">Recently active anonymous users</h2>
+  % if recent_activity_data["anonymous"]:
+  <table class="table table-striped">
+    <thead><tr><th>Anonymous identifier</th><th>Recent sessions</th><th>Last activity</th><th>Action</th></tr></thead>
+    <tbody>
+  % for row in recent_activity_data["anonymous"]:
+      <tr>
+        <td><code>temp-user-${ row["temp_user_id"] }</code></td>
+        <td>${ row["session_count"] }</td>
+        <td>${ row["last_activity"].strftime("%b %d, %Y at %H:%M UTC") }</td>
+        <td><a href="${ url_action('view_anonymous_sessions_screen', temp_user_id=row['temp_user_id']) }">View sessions</a></td>
+      </tr>
+  % endfor
+    </tbody>
+  </table>
+  % else:
+  <p>No anonymous activity was found during this period.</p>
+  % endif
+  % endif
+back button: True
+---
+event: view_activity_user
+code: |
+  chosen_user = int(action_argument("user_id"))
+  if not user_has_privilege("admin") and is_user_privileged(chosen_user):
+    response(response="You do not have permission to view this user's information.", response_code=403)
+  undefine("user_details", "user_label", "managed_user_sessions", "managed_sessions", "managed_session_subject")
+  view_user_info_screen
+---
 id: display reset link
 event: display_reset_link_screen
 question: |
-  Password reset link for ${ user_lookup.get(chosen_user, "this user") }
+  Password reset link for ${ user_label }
 subquestion: |
   % if password_reset_link:
   Copy the link below and send it to the user directly.
@@ -275,8 +521,8 @@ subquestion: |
   <div class="alert alert-danger" role="alert">
   Could not generate a reset link. Check logs for more information.
   % if not user_has_privilege(["admin", "developer"]):
-  Note: only admin or developer accounts with the `access_user_info` permission can generate password reset links for
-  users with the admin, developer, or cron privileges.
+  A user with the `edit_user_password` permission can generate links for regular
+  accounts. Protected admin, developer, and cron accounts require an administrator.
   </div>
   % endif
   % endif

--- a/docassemble/ALDashboard/data/questions/manage_users.yml
+++ b/docassemble/ALDashboard/data/questions/manage_users.yml
@@ -345,7 +345,7 @@ question: |
   Send a password reset email?
 subquestion: |
   Docassemble will send its standard password reset message to
-  **${ user_details["email"] if user_details else user_label }**.
+  **${ (user_details["email"] or "no email address") if user_details else user_label }**.
 
   The message will contain a private, expiring reset link. Sending it may cause
   the user to lose access to encrypted saved answers after they reset their password.
@@ -368,6 +368,7 @@ code: |
     send_reset_email_result = {"sent": False, "message": "No email was sent."}
 ---
 event: send_reset_email_complete_screen
+id: password reset email result
 question: |
   ${ "Password reset email sent" if send_reset_email_result["sent"] else "Password reset email not sent" }
 subquestion: |
@@ -410,6 +411,7 @@ code: |
   view_managed_sessions_screen
 ---
 event: view_managed_sessions_screen
+id: managed user sessions
 question: |
   Saved interviews and answers for ${ managed_session_subject }
 subquestion: |
@@ -451,6 +453,7 @@ code: |
   recent_activity_data = recent_account_activity_report(recent_activity_days)
 ---
 event: recent_activity_report_screen
+id: recent account activity report
 question: |
   Recently active users
 subquestion: |
@@ -500,7 +503,10 @@ back button: True
 ---
 event: view_activity_user
 code: |
-  chosen_user = int(action_argument("user_id"))
+  try:
+    chosen_user = int(action_argument("user_id"))
+  except (TypeError, ValueError):
+    response(response="Invalid user identifier.", response_code=400)
   if not user_has_privilege("admin") and is_user_privileged(chosen_user):
     response(response="You do not have permission to view this user's information.", response_code=403)
   undefine("user_details", "user_label", "managed_user_sessions", "managed_sessions", "managed_session_subject")

--- a/docassemble/ALDashboard/test/test_session_details_and_files.py
+++ b/docassemble/ALDashboard/test/test_session_details_and_files.py
@@ -28,6 +28,8 @@ def _load_session_detail_helpers():
     tree = ast.parse(source)
     lines = source.splitlines(keepends=True)
     names = {
+        "_current_user_permissions",
+        "can_access_user_sessions",
         "get_session_details",
         "get_upload_details",
         "get_permitted_upload_details",
@@ -588,6 +590,7 @@ def test_format_session_users_with_dict():
 
 def test_get_allowed_interview_filenames_is_none_for_privileged_users(monkeypatch):
     monkeypatch.setattr(aldashboard, "user_has_privilege", lambda privileges: True)
+    monkeypatch.setattr(aldashboard, "user_logged_in", lambda: True)
 
     assert get_allowed_interview_filenames() is None
 

--- a/docassemble/ALDashboard/test/test_session_search.py
+++ b/docassemble/ALDashboard/test/test_session_search.py
@@ -6,6 +6,8 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+import pytest
+
 
 @contextmanager
 def _unavailable_database_session():
@@ -59,6 +61,7 @@ def _load_session_search_helpers():
         "log": lambda *args, **kwargs: None,
         "text": lambda value: value,
         "user_has_privilege": lambda privileges: False,
+        "can_access_user_sessions": lambda user_id=None: False,
     }
     found = set()
     for node in tree.body:
@@ -218,16 +221,63 @@ def test_speedy_get_sessions_groups_user_rows_in_sql(monkeypatch):
     )
 
     assert [session.key for session in sessions] == ["abc", "def"]
-    assert "MIN(user_id) AS user_id" in executed["query"]
+    assert "MIN(userdictkeys.user_id) AS user_id" in executed["query"]
     assert (
-        "STRING_AGG(DISTINCT CAST(user_id AS TEXT), ',') AS user_ids"
+        "STRING_AGG(DISTINCT CAST(userdictkeys.user_id AS TEXT), ',') AS user_ids"
         in executed["query"]
     )
-    assert ") joined_users ON joined_users.key = userdict.key" in executed["query"]
-    assert "DATE(mostrecent.modtime) >= CAST(:start_date AS DATE)" in executed["query"]
-    assert "DATE(mostrecent.modtime) <= CAST(:end_date AS DATE)" in executed["query"]
+    assert "JOIN mostrecent ON mostrecent.key = userdictkeys.key" in executed["query"]
+    assert "DATE(MAX(modtime)) >= CAST(:start_date AS DATE)" in executed["query"]
+    assert "DATE(MAX(modtime)) <= CAST(:end_date AS DATE)" in executed["query"]
+    assert executed["query"].index("LIMIT 500") < executed["query"].index(
+        "SELECT \n    userdict.filename"
+    )
     assert executed["params"]["start_date"] == "2026-01-01"
     assert executed["params"]["end_date"] == "2026-01-31"
+
+
+def test_speedy_get_sessions_rechecks_access_to_selected_user(monkeypatch):
+    monkeypatch.setattr(
+        aldashboard, "can_access_user_sessions", lambda user_id=None: False
+    )
+
+    with pytest.raises(Exception, match="permission"):
+        speedy_get_sessions(
+            user_id=42,
+            filename="pkg:data/questions/a.yml",
+        )
+
+
+def test_speedy_get_sessions_filters_anonymous_sessions_by_temporary_user(
+    monkeypatch,
+):
+    executed = {}
+
+    class Connection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, *args, **kwargs):
+            executed["query"] = args[0]
+            executed["params"] = args[1]
+            return []
+
+    monkeypatch.setattr(aldashboard, "_get_db_session", Connection)
+    monkeypatch.setattr(
+        aldashboard, "can_access_user_sessions", lambda user_id=None: True
+    )
+
+    assert speedy_get_sessions(temp_user_id=73, filename=None) == []
+    assert "target_user.temp_user_id = :temp_user_id" in executed["query"]
+    assert executed["params"]["temp_user_id"] == 73
+
+
+def test_speedy_get_sessions_rejects_registered_and_anonymous_filters_together():
+    with pytest.raises(ValueError, match="either user_id or temp_user_id"):
+        speedy_get_sessions(user_id=42, temp_user_id=73)
 
 
 def test_speedy_get_sessions_can_filter_by_answer_criteria(monkeypatch):

--- a/docassemble/ALDashboard/test/test_user_account_manager.py
+++ b/docassemble/ALDashboard/test/test_user_account_manager.py
@@ -302,3 +302,31 @@ def test_recent_activity_report_is_permission_gated_and_groups_anonymous_users()
     assert "LIMIT :anonymous_limit" in source
     assert "COUNT(DISTINCT userdictkeys.key) AS recent_session_count" in source
     assert ".order_by(UserModel.last_login.desc())" in source
+    assert "except (TypeError, ValueError):\n        user_limit = 200" in source
+    assert "except (TypeError, ValueError):\n        anonymous_limit = 100" in source
+
+
+def test_recent_activity_user_action_rejects_invalid_user_ids():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    user_action = next(
+        document
+        for document in documents
+        if isinstance(document, dict) and document.get("event") == "view_activity_user"
+    )
+
+    assert "except (TypeError, ValueError)" in user_action["code"]
+    assert "response_code=400" in user_action["code"]
+
+
+def test_reset_email_confirmation_labels_an_account_without_email():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    confirmation = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("id") == "confirm send reset email"
+    )
+
+    assert "no email address" in confirmation["subquestion"]

--- a/docassemble/ALDashboard/test/test_user_account_manager.py
+++ b/docassemble/ALDashboard/test/test_user_account_manager.py
@@ -1,0 +1,304 @@
+# do not pre-load
+import ast
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Optional, Set
+
+from ruamel.yaml import YAML
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _function_sources(names):
+    source = (PACKAGE_ROOT / "aldashboard.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    lines = source.splitlines(keepends=True)
+    return {
+        node.name: "".join(lines[node.lineno - 1 : node.end_lineno])
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    }
+
+
+def _load_permission_helpers():
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "Optional": Optional,
+        "Set": Set,
+        "user_logged_in": lambda: True,
+        "user_has_privilege": lambda roles: False,
+        "user_info": lambda: SimpleNamespace(permissions=[]),
+        "is_user_privileged": lambda user_id: False,
+        "_resolve_current_user_id": lambda: 7,
+    }
+    sources = _function_sources(
+        {"_current_user_permissions", "can_access_user_sessions"}
+    )
+    for name in ("_current_user_permissions", "can_access_user_sessions"):
+        exec(sources[name], namespace)
+    return namespace
+
+
+def test_support_user_session_access_requires_both_permissions():
+    namespace = _load_permission_helpers()
+    namespace["user_info"] = lambda: SimpleNamespace(
+        permissions=["access_user_info", "access_sessions"]
+    )
+
+    assert namespace["can_access_user_sessions"](42) is True
+
+    namespace["user_info"] = lambda: SimpleNamespace(permissions=["access_user_info"])
+    assert namespace["can_access_user_sessions"](42) is False
+
+
+def test_user_can_still_inspect_their_own_allowed_interview_session():
+    namespace = _load_permission_helpers()
+
+    assert namespace["can_access_user_sessions"](7) is True
+
+
+def test_support_user_cannot_inspect_a_protected_account():
+    namespace = _load_permission_helpers()
+    namespace["user_info"] = lambda: SimpleNamespace(
+        permissions=["access_user_info", "access_sessions"]
+    )
+    namespace["is_user_privileged"] = lambda user_id: True
+
+    assert namespace["can_access_user_sessions"](42) is False
+
+
+def test_admin_can_inspect_a_protected_account():
+    namespace = _load_permission_helpers()
+    namespace["user_has_privilege"] = lambda roles: "admin" in roles
+    namespace["is_user_privileged"] = lambda user_id: True
+
+    assert namespace["can_access_user_sessions"](42) is True
+
+
+def test_send_reset_email_uses_docassemble_user_manager():
+    sent_to = []
+    user = SimpleNamespace(email="client@example.com")
+
+    class Statement:
+        def where(self, *args):
+            return self
+
+    class UserColumn:
+        def __eq__(self, other):
+            return ("id", other)
+
+    class UserModel:
+        id = UserColumn()
+
+    class Result:
+        def scalar_one_or_none(self):
+            return user
+
+    @contextmanager
+    def database_session():
+        yield SimpleNamespace(execute=lambda statement: Result())
+
+    manager = SimpleNamespace(
+        enable_forgot_password=True,
+        send_reset_password_email=sent_to.append,
+    )
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "UserModel": UserModel,
+        "current_app": SimpleNamespace(
+            user_manager=manager,
+            config={"ALLOW_CHANGING_PASSWORD": True},
+        ),
+        "_current_user_permissions": lambda: {"edit_user_password"},
+        "_get_db_session": database_session,
+        "is_user_privileged": lambda user_id: False,
+        "log": lambda *args: None,
+        "select": lambda model: Statement(),
+        "user_has_privilege": lambda roles: False,
+        "user_logged_in": lambda: True,
+    }
+    source = _function_sources({"send_password_reset_email"})[
+        "send_password_reset_email"
+    ]
+    exec(source, namespace)
+
+    result = namespace["send_password_reset_email"](42)
+
+    assert result == {
+        "sent": True,
+        "message": "The password reset email was sent.",
+    }
+    assert sent_to == ["client@example.com"]
+
+
+def test_manage_user_page_links_to_prefiltered_session_viewer():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    view_screen = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("event") == "view_user_info_screen"
+    )
+
+    assert "Last login" in view_screen["subquestion"]
+    assert "Last interview activity" in view_screen["subquestion"]
+    assert 'url_action("view_user_sessions_screen")' in view_screen["under"]
+    assert "can_access_user_sessions" in view_screen["under"]
+
+
+def test_manage_user_picker_adapts_to_server_size():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    picker = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("id") == "select user and management task"
+    )
+    search_event = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("event") == "manage_user_search_ajax"
+    )
+
+    user_fields = [
+        field for field in picker["fields"] if field.get("User") == "chosen_user"
+    ]
+    assert len(user_fields) == 2
+    assert user_fields[0]["input type"] == "combobox"
+    assert user_fields[0]["show if"]["code"].strip() == "manage_user_count <= 200"
+    assert user_fields[1]["input type"] == "ajax"
+    assert user_fields[1]["action"] == "manage_user_search_ajax"
+    assert user_fields[1]["show if"]["code"].strip() == "manage_user_count > 200"
+    assert "search_users_by_email" in search_event["code"]
+    assert "exclude_privileged=" in search_event["code"]
+
+
+def test_user_and_task_are_gathered_together_without_server_side_cycle():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    user_screen = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("id") == "select user and management task"
+    )
+    period_screen = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("id") == "select recent activity period"
+    )
+
+    assert any(
+        field.get("What do you want to do?") == "user_task"
+        for field in user_screen["fields"]
+    )
+    assert "recent_activity" in str(user_screen["fields"])
+    assert not any(
+        isinstance(field.get("show if"), dict)
+        and field["show if"].get("variable") == "user_task"
+        for field in user_screen["fields"]
+    )
+    assert (
+        period_screen["fields"][0]["Days of activity to include"]
+        == "recent_activity_days"
+    )
+
+
+def test_reset_email_confirmation_is_a_data_gathering_screen_not_an_event():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    confirmation = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("id") == "confirm send reset email"
+    )
+    start_event = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("event") == "start_send_reset_email"
+    )
+
+    assert confirmation["field"] == "confirm_reset_email_delivery"
+    assert "event" not in confirmation
+    assert "confirm_reset_email_delivery" in start_event["code"]
+
+
+def test_user_centered_session_view_reuses_answer_viewer_actions():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    user_session_action = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("event") == "view_user_sessions_screen"
+    )
+    session_screen = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("event") == "view_managed_sessions_screen"
+    )
+
+    assert "managed_user_sessions" in user_session_action["code"]
+    assert "managed_sessions" in session_screen["subquestion"]
+    assert "list_sessions.yml" in session_screen["subquestion"]
+    assert "view_single_session" in session_screen["subquestion"]
+    assert "view_session_variables" in session_screen["subquestion"]
+    assert 'target="_blank"' in session_screen["subquestion"]
+    assert "redirect(" not in path.read_text(encoding="utf-8")
+
+
+def test_recent_activity_report_links_registered_users_to_user_info():
+    path = PACKAGE_ROOT / "data" / "questions" / "manage_users.yml"
+    documents = list(YAML(typ="safe").load_all(path.read_text(encoding="utf-8")))
+    report_screen = next(
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("event") == "recent_activity_report_screen"
+    )
+    user_action = next(
+        document
+        for document in documents
+        if isinstance(document, dict) and document.get("event") == "view_activity_user"
+    )
+
+    assert "Registered users who logged in" in report_screen["subquestion"]
+    assert "temp_user_id" in report_screen["subquestion"]
+    assert "view_activity_user" in report_screen["subquestion"]
+    assert "recent_session_count" in report_screen["subquestion"]
+    assert "last_session_activity" in report_screen["subquestion"]
+    assert "view_anonymous_sessions_screen" in report_screen["subquestion"]
+    assert "is_user_privileged(chosen_user)" in user_action["code"]
+
+
+def test_recent_activity_report_is_permission_gated_and_groups_anonymous_users():
+    source = _function_sources({"recent_account_activity_report"})[
+        "recent_account_activity_report"
+    ]
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "can_access_user_sessions": lambda: False,
+    }
+    exec(source, namespace)
+
+    assert namespace["recent_account_activity_report"]() == {
+        "authorized": False,
+        "users": [],
+        "anonymous": [],
+    }
+    assert "GROUP BY userdictkeys.temp_user_id" in source
+    assert "userdict.modtime >= :cutoff" in source
+    assert "LIMIT :anonymous_limit" in source
+    assert "COUNT(DISTINCT userdictkeys.key) AS recent_session_count" in source
+    assert ".order_by(UserModel.last_login.desc())" in source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'xmlschema>=4.3.1',
     'pyaml',
     'formfyxer>=1.1.0',
-    'dayamlchecker>=1.4.0',
+    'dayamlchecker>=1.5.0',
     'Mako>=1.1.4',
     'pyspellchecker>=0.6.3',
     'ruamel.yaml>=0.17.4',
@@ -212,6 +212,7 @@ dev = [
     "openai",
     "tiktoken",
     "dayamlchecker",
+    "pre-commit",
     "types-lxml",
     "xmlschema>=4.3.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'xmlschema>=4.3.1',
     'pyaml',
     'formfyxer>=1.1.0',
-    'dayamlchecker>=1.5.0',
+    'dayamlchecker>=1.4.0',
     'Mako>=1.1.4',
     'pyspellchecker>=0.6.3',
     'ruamel.yaml>=0.17.4',

--- a/scripts/run_da_build_checks.sh
+++ b/scripts/run_da_build_checks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+python -m compileall . -q
+uv build --sdist --wheel --out-dir dist/
+
+mapfile -d '' da_files < <(
+  find . \
+    \( \
+      \( -name "*.yml" -path "./docassemble/*/questions/*" \) -o \
+      \( -name "*.docx" -path "./docassemble/*/data/templates/*" \) \
+    \) -print0
+)
+
+if ((${#da_files[@]})); then
+  python -m dayamlchecker \
+    --docx-accessibility-severity warning \
+    "${da_files[@]}"
+fi
+
+python -m dayamlchecker.check_questions_urls


### PR DESCRIPTION
Closes #283.

## Summary

- Add last login, saved-session count, and latest interview activity to the user-information page.
- Add server-sent password-reset email alongside the existing reset and copy-link options.
- Add a user-filtered saved-interview view with Join, Details/files, and View answers actions. Detail and answer actions reuse the existing list-sessions interview and open in a new tab.
- Add a recent-account-activity report for registered and anonymous temporary users.
- Show recent-session counts and latest session activity in the report, sorted newest first.
- Let support users drill into an anonymous temporary user's sessions with the same reusable session view and actions.
- Use the full account combobox through 200 users and bounded AJAX lookup on larger servers.
- Add a pre-commit gate that mirrors the DA build workflow: Python compilation, source/wheel packaging, DAYamlChecker interview and template validation, DOCX accessibility reporting, and URL validation.

## Permissions and performance

Cross-user interview access requires the existing access-sessions and access-user-info permissions. Non-admin support users cannot inspect or modify protected admin, developer, or cron accounts.

Session queries limit recent candidates before joining user and metadata records. Recent registered-session aggregation is restricted to the users displayed in the report, and account lookup does not load the complete user table on servers above the threshold.

## Development and review history

This implementation went through several rounds of local testing and revision:

1. Reused the existing account search, password tools, and session-detail actions instead of introducing a parallel implementation.
2. Added adaptive account lookup after considering servers with thousands of users. The more aggressive lookup is used only above 200 accounts.
3. Replaced an invalid confirmation block that combined an event designator with a gathering field with a separate event and confirmation screen.
4. Replaced a saved-interview link that lost its user filter with an account-centered session list, and removed the undefined redirect reference from the main session viewer.
5. Added a recent-activity report centered on accounts. Anonymous activity uses docassemble's temporary-user identifier because the session tables do not preserve reliable historical IP addresses.
6. Fixed an infinite user-task variable-resolution loop. An initial two-page correction proved less usable and caused a Continue-button regression, so user and task selection were restored to the first page while same-screen task conditions were moved to browser-side visibility rules.
7. Removed implementation commentary from the end-user interface.
8. Replaced the initial dead-end anonymous summary with session drill-down and added recent-session totals and latest activity to registered-user rows.

## Testing

- Manually tested locally by Quinten.
- 430 tests passed, 2 skipped, and 37 subtests passed.
- Mypy passed with no issues, and Bandit found no high-severity issues.
- The complete docassemble pre-commit build gate passed locally.
- git diff --check passed.
